### PR TITLE
P0-05: Define verification, source, and license policies

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -27,8 +27,8 @@ This document tracks public, repository-level implementation work. It is not the
 | P0-01 | Development control | Completed | Repository bootstrap | [#1](https://github.com/badjoke-lab/cryptopaymap/pull/1) |
 | P0-02 | Product constitution | Completed | P0-01 | [#3](https://github.com/badjoke-lab/cryptopaymap/pull/3) |
 | P0-03 | Information architecture | Completed | P0-02 | [#4](https://github.com/badjoke-lab/cryptopaymap/pull/4) |
-| P0-04 | Data architecture | In progress | P0-02 | [#5](https://github.com/badjoke-lab/cryptopaymap/pull/5) |
-| P0-05 | Verification, sources, and licenses | Planned | P0-04 | — |
+| P0-04 | Data architecture | Completed | P0-02 | [#5](https://github.com/badjoke-lab/cryptopaymap/pull/5) |
+| P0-05 | Verification, sources, and licenses | In progress | P0-04 | [#6](https://github.com/badjoke-lab/cryptopaymap/pull/6) |
 | P0-06 | Submission and media policies | Planned | P0-04, P0-05 | — |
 | P0-07 | Technical, UX, security, and privacy architecture | Planned | P0-03, P0-04 | — |
 | P0-08 | Operations, migration, launch, and public roadmap | Planned | P0-03 through P0-07 | — |

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -9,11 +9,11 @@ Phase 0 — Public specifications and development control
 
 ## Current implementation item
 
-`P0-04 — Data architecture`
+`P0-05 — Verification, sources, and licenses`
 
 ## Active pull request
 
-[#5 — P0-04: Define canonical data architecture](https://github.com/badjoke-lab/cryptopaymap/pull/5)
+[#6 — P0-05: Define verification, source, and license policies](https://github.com/badjoke-lab/cryptopaymap/pull/6)
 
 ## Latest completed work
 
@@ -22,16 +22,18 @@ Phase 0 — Public specifications and development control
 - `P0-01 — Development control` completed through [pull request #1](https://github.com/badjoke-lab/cryptopaymap/pull/1).
 - `P0-02 — Product constitution` completed through [pull request #3](https://github.com/badjoke-lab/cryptopaymap/pull/3), merged as `d09849c`.
 - `P0-03 — Information architecture` completed through [pull request #4](https://github.com/badjoke-lab/cryptopaymap/pull/4), merged as `09b9807`.
+- `P0-04 — Data architecture` completed through [pull request #5](https://github.com/badjoke-lab/cryptopaymap/pull/5), merged as `6e7392d`.
 
-## Current deliverable
+## Current deliverables
 
-- `docs/DATA_MODEL.md`
+- `docs/VERIFICATION_POLICY.md`
+- `docs/SOURCE_AND_LICENSE_POLICY.md`
 
 ## Next
 
-1. Review and merge pull request #5 when its completion criteria are satisfied.
-2. Mark P0-04 completed in `docs/IMPLEMENTATION_PLAN.md`.
-3. Start `P0-05 — Verification, sources, and licenses`.
+1. Review and merge pull request #6 when its completion criteria are satisfied.
+2. Mark P0-05 completed in `docs/IMPLEMENTATION_PLAN.md`.
+3. Start `P0-06 — Submission and media policies`.
 
 ## Blocked
 

--- a/docs/SOURCE_AND_LICENSE_POLICY.md
+++ b/docs/SOURCE_AND_LICENSE_POLICY.md
@@ -1,0 +1,586 @@
+# CryptoPayMap source and license policy
+
+## Purpose
+
+This document defines how CryptoPayMap records source provenance, uses external material, attributes OpenStreetMap, licenses project-originated public data and explanatory text, handles contributed media, and labels combined public exports.
+
+This policy is an operational publication rule, not legal advice. The full license texts control if this summary conflicts with them.
+
+---
+
+## 1. Core principles
+
+1. **A source is not automatically proof.** Source usefulness and verification strength are separate decisions.
+2. **Provenance remains traceable.** Public and private records retain source, observation date, license, and attribution metadata where applicable.
+3. **External content is not republished by default.** CryptoPayMap stores factual metadata, reviewed summaries, links, and limited evidence needed for verification rather than copying whole third-party pages.
+4. **OpenStreetMap-derived location data remains identifiable.** OSM-origin fields are not relabeled as solely CryptoPayMap data.
+5. **Project-originated acceptance data has its own license layer.** CryptoPayMap verification claims do not change the license of OSM location data.
+6. **Combined exports preserve component licenses.** A convenience file does not erase or replace the license applying to each component.
+7. **Images are separate.** Public data and text licenses do not automatically apply to images, logos, screenshots, or trademarks.
+8. **Private evidence stays private.** Submission or review access does not imply public republication rights.
+9. **Attribution is a product requirement.** Attribution is included in pages, data manifests, files, and interfaces where the applicable license requires it.
+10. **The system fails closed.** Unclear rights or provenance prevent public reuse until resolved.
+
+---
+
+## 2. Source categories
+
+### 2.1 Official merchant or service pages
+
+Examples:
+
+- payment pages;
+- help centers;
+- checkout documentation;
+- terms;
+- official FAQs;
+- branch pages;
+- service-plan pages.
+
+Permitted recordkeeping normally includes:
+
+- source URL;
+- page title;
+- observation and publication dates where known;
+- a short factual summary;
+- content hash or change indicator;
+- an archive URL where lawful and appropriate.
+
+CryptoPayMap does not assume a right to republish the full page, page design, photographs, logos, or long quotations.
+
+### 2.2 Official social accounts
+
+Official social posts may support verification when the account and applicable scope are identifiable.
+
+CryptoPayMap records the URL, date, account identity, and reviewed factual summary. Embedded media or full post copies are not republished unless the platform terms and rights basis permit it.
+
+### 2.3 Payment-processor sources
+
+Processor merchant directories, case studies, documentation, and checkout observations may identify a route or integration.
+
+Processor capability does not prove that every merchant enabled the feature. Processor material is attributed to the processor and reviewed for merchant, location, product, region, and date applicability.
+
+### 2.4 OpenStreetMap
+
+OpenStreetMap may provide location identity, names, addresses, coordinates, categories, websites, and payment tags.
+
+OSM data is a source layer, not automatic acceptance confirmation.
+
+- a recent dated payment observation may be medium verification evidence;
+- an undated payment tag is weak candidate-discovery evidence;
+- OSM alone does not satisfy the full confirmation threshold;
+- OSM-derived fields retain OSM provenance and license metadata.
+
+### 2.5 Directories and maps
+
+Third-party directories, community maps, and aggregators may identify candidates.
+
+They normally remain weak evidence unless their underlying source and date independently meet a stronger evidence class.
+
+A copied directory chain counts as one origin, not multiple independent sources.
+
+### 2.6 News and articles
+
+Articles may provide historical context, but current acceptance normally requires a more direct and recent source.
+
+CryptoPayMap stores links and short factual summaries rather than republishing article text.
+
+### 2.7 Search-result snippets
+
+Search snippets are discovery aids only. They are not treated as reliable standalone evidence or republished as source content.
+
+### 2.8 Public user submissions
+
+A user may submit:
+
+- factual listing details;
+- payment observations;
+- correction reports;
+- source URLs;
+- evidence media;
+- public-gallery media;
+- business-claim information.
+
+Submission intake terms must explain the applicable use permission for each purpose. Evidence-only permission and public-republication permission are separate.
+
+### 2.9 Verified business representatives
+
+Business representatives may provide official details and media after identity or control verification.
+
+Verification of the representative does not transfer ownership of third-party content and does not bypass public verification policy.
+
+### 2.10 Archives
+
+Public web archives may improve durability when use is appropriate and the archive contains no private or restricted material.
+
+CryptoPayMap does not submit private correspondence, receipts, ownership proof, personal data, or secret status pages to public archive services.
+
+---
+
+## 3. Source capture requirements
+
+Every retained source record should store, where applicable:
+
+- source type;
+- source name;
+- source URL;
+- source-native identifier;
+- observed date;
+- published date;
+- fetched date;
+- reviewed summary;
+- content hash;
+- archive URL;
+- license identifier;
+- attribution text;
+- visibility;
+- relationship to candidate, claim, evidence, or field.
+
+### 3.1 Observation date is not ingestion date
+
+The date CryptoPayMap imports a page does not prove the claim became true on that date.
+
+`observed_at`, `published_at`, and `fetched_at` remain separate.
+
+### 3.2 Minimal necessary copying
+
+Operational source capture should prefer:
+
+- URLs;
+- metadata;
+- hashes;
+- structured factual values;
+- reviewer-authored summaries;
+- limited excerpts only where legally appropriate and necessary.
+
+Whole-page copies, large excerpts, full social posts, and third-party image downloads are not default source records.
+
+### 3.3 Terms and access controls
+
+Collection must respect applicable law, access controls, robots instructions where relevant, and source terms.
+
+CryptoPayMap must not bypass authentication, technical restrictions, or paid access to obtain public evidence.
+
+### 3.4 Sensitive source data
+
+Private source material receives restricted visibility and appropriate retention. It is never added to public archives or public data files merely because it supports a public conclusion.
+
+---
+
+## 4. License layers
+
+CryptoPayMap separates database, content, software, and media licensing.
+
+### 4.1 OpenStreetMap-derived location data — ODbL 1.0
+
+OpenStreetMap data is made available by the OpenStreetMap Foundation under the Open Data Commons Open Database License 1.0.
+
+Official references:
+
+- [OpenStreetMap copyright and license](https://www.openstreetmap.org/copyright)
+- [Open Data Commons ODbL 1.0](https://opendatacommons.org/licenses/odbl/1-0/)
+
+CryptoPayMap uses OSM-derived location data subject to ODbL requirements, including attribution and applicable share-alike obligations.
+
+Required attribution uses the standard form:
+
+> © OpenStreetMap contributors
+
+The attribution links to the OpenStreetMap copyright page or otherwise makes the ODbL status clear.
+
+### 4.2 CryptoPayMap acceptance database — ODC-By 1.0
+
+CryptoPayMap-originated structured acceptance claims are intended to be made available under the Open Data Commons Attribution License 1.0.
+
+Official reference:
+
+- [Open Data Commons Attribution License 1.0](https://opendatacommons.org/licenses/by/1-0/)
+
+This layer includes, to the extent CryptoPayMap owns or may license the applicable database rights:
+
+- reviewed acceptance claims;
+- asset and network combinations;
+- route and payment-method classifications;
+- confirmation dates;
+- public verification events;
+- public status;
+- public restrictions;
+- project-originated structured registry data;
+- project-originated aggregate statistics.
+
+Recommended attribution:
+
+> CryptoPayMap acceptance data — ODC-By 1.0
+
+The attribution should include the dataset or page name, CryptoPayMap, a version or retrieval date, and a link to the license or data page where practical.
+
+### 4.3 CryptoPayMap explanatory text — CC BY 4.0
+
+CryptoPayMap-authored explanatory text is intended to be licensed under Creative Commons Attribution 4.0 International, to the extent the text is protected and CryptoPayMap owns or may license the relevant rights.
+
+Official reference:
+
+- [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
+
+This layer may include:
+
+- reviewer-authored How to pay text;
+- public evidence summaries;
+- methodology explanations;
+- glossary and help text;
+- project-authored public documentation and data-field descriptions where marked.
+
+Recommended attribution:
+
+> CryptoPayMap explanatory content — CC BY 4.0
+
+Adaptations should identify that changes were made where the license requires it.
+
+### 4.4 Software code
+
+This source and data policy does not automatically license repository software code.
+
+A separate software license must be selected and added before code reuse rights are offered. Until then, the presence of code in a public repository does not by itself grant a general reuse license beyond rights provided by applicable law or platform terms.
+
+### 4.5 Images and media
+
+Images are excluded from the general public data and explanatory-text licenses unless an individual media record explicitly states otherwise.
+
+Media may use one of these rights bases:
+
+- owned by CryptoPayMap;
+- submitted by a rights holder under the public-display grant;
+- used with written permission;
+- published under a compatible open license;
+- public-domain material with documented basis.
+
+Each public media item stores its own:
+
+- rights basis;
+- license where applicable;
+- attribution;
+- source;
+- approved public use;
+- removal status.
+
+### 4.6 Logos, names, and trademarks
+
+Business names, logos, processor marks, and trademarks remain the property of their respective owners.
+
+Their appearance in factual records does not grant trademark rights or imply endorsement.
+
+---
+
+## 5. Public file license mapping
+
+### 5.1 Separated source layers
+
+| Public file | Primary content | License treatment |
+|---|---|---|
+| `/data/locations-osm.json` | Publishable OSM-derived location layer | ODbL 1.0 with OSM attribution |
+| `/data/acceptance-claims.json` | CryptoPayMap-reviewed acceptance claims | ODC-By 1.0 |
+| `/data/online-services.json` | CryptoPayMap-reviewed online acceptance records | ODC-By 1.0, with separate source notices where needed |
+| `/data/assets.json` | Project-maintained public asset registry | ODC-By 1.0 |
+| `/data/networks.json` | Project-maintained public network registry | ODC-By 1.0 |
+| `/data/stats.json` | Aggregates of the public dataset | ODC-By 1.0, subject to source-layer notices |
+| `/data/updates.json` | Structured public record changes | ODC-By 1.0; authored summaries may also carry CC BY 4.0 |
+
+### 5.2 Combined convenience exports
+
+| Public file | Treatment |
+|---|---|
+| `/data/places.json` | Combined convenience export retaining record-level or field-level source and license metadata |
+| `/data/places.geojson` | Geographic convenience export retaining OSM attribution and component-license notices |
+| `/data/place-pins.json` | Minimal combined map projection retaining required attribution through the map and data interface |
+
+A combined file is not presented as though ODC-By replaces ODbL for OSM-derived data.
+
+The manifest identifies:
+
+- which fields or components derive from OSM;
+- which components are CryptoPayMap-originated;
+- applicable licenses;
+- required attribution;
+- schema and dataset versions;
+- generation date.
+
+CryptoPayMap does not promise that every combined use is legally a Collective Database rather than a Derivative Database. Reusers remain responsible for complying with the licenses applicable to the components and their intended use.
+
+### 5.3 Manifest and notices
+
+`/data/manifest.json` includes:
+
+- file inventory;
+- schema version;
+- generated date;
+- record counts for public data;
+- source layers;
+- license identifiers;
+- attribution text;
+- links to full license terms;
+- data-safety statement.
+
+`/version.json` identifies the public dataset and schema version but does not replace license notices.
+
+---
+
+## 6. OpenStreetMap handling
+
+### 6.1 Attribution placement
+
+OSM attribution appears wherever OSM data is presented, including:
+
+- interactive maps;
+- map-derived screenshots published by CryptoPayMap;
+- OSM-derived public data files;
+- data and source documentation;
+- downloads where attribution is not otherwise visible.
+
+The map interface must keep attribution readable and must not cover or remove provider-required notices.
+
+### 6.2 OSM source separation
+
+OSM-derived location fields remain identifiable through provenance metadata.
+
+Examples:
+
+- OSM object type and ID;
+- source record;
+- field-level provenance;
+- ODbL identifier;
+- attribution notice.
+
+CryptoPayMap-authored acceptance instructions, evidence summaries, and verification state remain separate from the OSM location layer.
+
+### 6.3 OSM changes and corrections
+
+CryptoPayMap may correct its canonical display without claiming that the correction changed OpenStreetMap.
+
+Where appropriate, operators or users may separately contribute improvements to OSM under OSM's own contribution process and terms.
+
+### 6.4 OSM payment tags
+
+OSM payment tags retain OSM provenance. CryptoPayMap may review them as candidate or evidence data, but a CryptoPayMap confirmation is a separate project decision.
+
+---
+
+## 7. CryptoPayMap data reuse
+
+### 7.1 Attribution elements
+
+A reasonable CryptoPayMap data attribution includes:
+
+- `CryptoPayMap`;
+- the dataset or file name;
+- the applicable license;
+- a link to the data page or source repository;
+- version or retrieval date where practical.
+
+### 7.2 Modification notices
+
+Reusers should identify material modifications, especially where changed instructions, status, dates, or scope could be mistaken for current CryptoPayMap verification.
+
+### 7.3 Freshness
+
+A reused record should preserve:
+
+- `last_confirmed_at`;
+- public status;
+- source or evidence references;
+- dataset version or retrieval date.
+
+Removing freshness information may make the data misleading even when license attribution is present.
+
+### 7.4 No endorsement
+
+Reuse does not imply endorsement by CryptoPayMap, BadJoke-Lab, a listed business, a processor, OpenStreetMap, or any contributor.
+
+### 7.5 No verification inheritance after modification
+
+A materially modified record must not be described as currently confirmed by CryptoPayMap unless it remains identical to the applicable published verification data or clearly distinguishes the modification.
+
+---
+
+## 8. Contributor permissions
+
+### 8.1 Factual data submissions
+
+Submission terms must authorize CryptoPayMap to:
+
+- store and review submitted factual data;
+- normalize it;
+- compare it with other sources;
+- incorporate approved factual contributions into the public acceptance database;
+- distribute approved structured data under the applicable public data license.
+
+A contributor must not submit information they are not permitted to share.
+
+### 8.2 Evidence-only media and documents
+
+Evidence-only permission allows CryptoPayMap to:
+
+- receive;
+- store privately;
+- process for safety and privacy;
+- review;
+- create internal derivatives needed for review;
+- retain according to policy;
+- use the reviewed conclusion in a public record.
+
+It does not authorize public gallery display or open-data redistribution of the original.
+
+### 8.3 Public gallery media
+
+A public-gallery submission requires the contributor to confirm that they own the media or are authorized to license it.
+
+The contributor grants CryptoPayMap a non-exclusive, worldwide, royalty-free permission to:
+
+- host;
+- display;
+- resize;
+- crop;
+- re-encode;
+- create responsive derivatives;
+- include the media in the applicable public listing and project promotion;
+- remove the media when required.
+
+The contributor retains ownership. The media is not automatically licensed to third parties as ODC-By or CC BY.
+
+### 8.4 Business-provided media
+
+Business media requires confirmation that the submitter is authorized to grant the relevant use permission.
+
+Ownership verification of the business relationship and rights authorization for each media item remain separate checks.
+
+### 8.5 Text contributions
+
+Where a contributor supplies original public explanatory text, the submission terms must obtain permission for CryptoPayMap to edit, publish, and distribute approved text under the public text license.
+
+Private correspondence is not converted into public CC BY content by default.
+
+---
+
+## 9. Third-party content exclusions
+
+Unless explicitly licensed or permitted, public exports exclude:
+
+- copied website descriptions;
+- full articles;
+- social-media text beyond limited necessary reference;
+- third-party photographs;
+- map-service screenshots without compliant attribution and permission;
+- menus, logos, or product images copied from business websites;
+- processor marketing images;
+- private receipts or transaction screenshots;
+- personal correspondence.
+
+A URL and factual summary do not transfer ownership of the linked content.
+
+---
+
+## 10. Evidence citations and quotations
+
+### 10.1 Prefer summary over quotation
+
+Public evidence entries use reviewer-authored factual summaries and source links.
+
+### 10.2 Limited quotation
+
+A short quotation may be used only when:
+
+- necessary to explain the evidence;
+- legally appropriate;
+- attributed;
+- limited to what is needed;
+- not a substitute for the source.
+
+### 10.3 Translation
+
+A translation of source material is treated as an adaptation and is not published without an appropriate rights basis. CryptoPayMap may instead publish an original factual summary in another language.
+
+---
+
+## 11. Archive and preservation policy
+
+CryptoPayMap may store:
+
+- source URL;
+- archive URL;
+- metadata;
+- content hash;
+- observation date;
+- limited internal review notes.
+
+The existence of a public archive does not change the source's copyright or license.
+
+Archive links are removed or restricted when they expose private, harmful, or unlawfully retained material.
+
+---
+
+## 12. Attribution failure and remediation
+
+If required attribution is missing or incorrect:
+
+1. stop or limit the affected publication where necessary;
+2. identify the affected file, page, or image;
+3. restore attribution or remove the material;
+4. record the correction;
+5. review whether a public Changelog entry is required;
+6. verify generated files and cached copies.
+
+License or attribution errors are not corrected only in documentation while leaving affected public artifacts unchanged.
+
+---
+
+## 13. Rights, privacy, and takedown requests
+
+A rights holder or affected person may report:
+
+- unauthorized image use;
+- incorrect attribution;
+- personal information;
+- private evidence exposure;
+- trademark confusion;
+- inaccurate ownership claims;
+- license incompatibility.
+
+Urgent reports may cause temporary hiding while the underlying issue is reviewed.
+
+Removal of public media does not require deletion of all non-public audit metadata when lawful retention remains necessary. Private source material follows the applicable retention and privacy policy.
+
+---
+
+## 14. License changes
+
+A public license change requires:
+
+- confirmation that CryptoPayMap has authority to apply the new terms;
+- compatibility review for existing contributions;
+- separation of material that cannot be relicensed;
+- updates to manifests and notices;
+- public Changelog review after release;
+- a clear effective date.
+
+OpenStreetMap-derived data cannot be relicensed by CryptoPayMap in a way that removes ODbL obligations.
+
+Contributed images cannot be relicensed as open data without the contributor's applicable permission.
+
+---
+
+## 15. Publication checklist
+
+Before releasing a data or content artifact, verify:
+
+- [ ] The source is recorded.
+- [ ] The observation date is distinct from ingestion date.
+- [ ] The applicable license is identified.
+- [ ] Required attribution is visible.
+- [ ] OSM-derived fields remain identifiable.
+- [ ] ODC-By is not presented as replacing ODbL.
+- [ ] Combined exports preserve component notices.
+- [ ] Third-party text is summarized rather than copied without permission.
+- [ ] Images have item-level rights metadata.
+- [ ] Private evidence and contacts are excluded.
+- [ ] Public text and structured data use the correct license layer.
+- [ ] The manifest and version metadata are current.
+- [ ] Cached and downloadable copies carry the required notices.

--- a/docs/VERIFICATION_POLICY.md
+++ b/docs/VERIFICATION_POLICY.md
@@ -1,0 +1,710 @@
+# CryptoPayMap verification policy
+
+## Purpose
+
+CryptoPayMap publishes claims about where and how cryptocurrency can be used at checkout. This policy defines the evidence, scope, freshness, contradiction handling, and state transitions required before an acceptance claim may appear publicly.
+
+The policy is designed to answer a practical question:
+
+> Can a customer reasonably understand and attempt this payment route now?
+
+A listing is not confirmed merely because a business is described as crypto-friendly, appears in a directory, has an old payment tag, or uses a platform that supports cryptocurrency in general.
+
+---
+
+## 1. Verification principles
+
+1. **The payment route must be specific.** The accepted asset, network, route, payment method, and usable instructions must be known.
+2. **Evidence must apply to the listed scope.** A brand announcement does not automatically prove every branch accepts cryptocurrency.
+3. **Freshness matters.** Older evidence loses weight when checkout options, processors, branches, or service plans change.
+4. **Newer contradiction overrides older support.** A current removal notice or failed checkout can outweigh an older announcement.
+5. **Candidate data is private.** Unverified candidates never appear on public maps, public search, or public statistics.
+6. **Commercial relationships do not change verification.** Sponsorship, payment, ownership claims, and partnerships cannot purchase confirmed status.
+7. **Private proof may support a public conclusion without being published.** Receipts, transaction links, ownership proof, and personal information remain private unless separately approved for public display.
+8. **The policy fails closed.** Missing required information prevents confirmation rather than being filled by assumption.
+
+---
+
+## 2. Acceptance-claim states
+
+### 2.1 Candidate
+
+A candidate is an internal review record.
+
+Candidate records:
+
+- are not public;
+- do not appear in public counts;
+- may be incomplete;
+- may contain conflicting or weak evidence;
+- may be linked to source records or submissions;
+- require explicit review before promotion.
+
+### 2.2 Confirmed
+
+A claim is confirmed only when all required payment details are known and the evidence threshold is met.
+
+Confirmed does not mean guaranteed. It means the claim met the published verification policy at its last confirmation date.
+
+### 2.3 Stale
+
+A claim is stale when:
+
+- its reconfirmation window has expired;
+- recent contradictory evidence requires investigation;
+- previously confirmed information may no longer be reliable;
+- the payment route remains plausible but is not currently strong enough for default discovery.
+
+Stale claims are excluded from default search and map results.
+
+### 2.4 Ended
+
+A claim is ended when reliable evidence shows that:
+
+- cryptocurrency acceptance ended;
+- the relevant checkout option disappeared;
+- the business or location closed;
+- the service or applicable product ended;
+- the previously listed route is no longer available.
+
+Ended records may remain available as public history but are excluded from normal active discovery.
+
+### 2.5 Rejected
+
+A claim is rejected when it is:
+
+- outside product scope;
+- false or misleading;
+- unsupported after review;
+- not identifiable;
+- a duplicate;
+- spam or promotion without useful evidence;
+- affected by unresolved rights or privacy problems;
+- an indirect spending route presented as merchant acceptance.
+
+Rejected claims are not normally public.
+
+### 2.6 Visibility is separate from status
+
+A claim may be temporarily hidden without changing its verification state when urgent privacy, rights, legal, or safety review is required.
+
+```text
+claim_status = confirmed
+visibility = temporarily_hidden
+```
+
+Temporary hiding is not evidence that the payment route ended.
+
+---
+
+## 3. Required payment information
+
+A confirmed claim requires:
+
+- an identifiable merchant, place, or online service;
+- an applicable location or service scope;
+- at least one accepted asset;
+- an explicit network for each published asset combination;
+- a payment route;
+- a payment method;
+- usable How to pay instructions;
+- supporting evidence meeting this policy;
+- a last confirmation date.
+
+### 3.1 Payment route
+
+```text
+direct_wallet
+processor_checkout
+```
+
+### 3.2 Payment method
+
+Examples include:
+
+```text
+onchain
+lightning_invoice
+lightning_nfc
+wallet_qr
+processor_checkout
+pos_terminal
+invoice
+payment_link
+```
+
+Payment route and payment method are not interchangeable.
+
+### 3.3 Network requirement
+
+The network must be explicit for each published asset combination.
+
+Examples:
+
+- BTC on Bitcoin mainnet;
+- BTC over Lightning;
+- USDT on Tron;
+- USDC on Base;
+- XRP on XRPL.
+
+The network must not be inferred solely from the asset symbol.
+
+A direct-wallet claim with an unknown network cannot be confirmed.
+
+### 3.4 Processor requirement
+
+A processor-checkout claim requires:
+
+- an identified processor;
+- a verified checkout or invoice path;
+- at least one currently verified asset, network, and payment-method combination;
+- instructions explaining where the customer selects or receives the crypto payment option.
+
+If available assets may change at checkout, the public record may say so, but only verified combinations may be listed as current accepted options.
+
+### 3.5 How to pay
+
+How to pay must be actionable, not merely promotional.
+
+A useful instruction explains one or more of the following:
+
+- what to ask staff;
+- where the checkout option appears;
+- which QR, invoice, terminal, or payment link is used;
+- which network is required;
+- which processor is involved;
+- which products, plans, regions, or customer types are eligible;
+- any minimum, reservation, renewal, or timing restriction.
+
+Example:
+
+> Ask staff to display a Lightning invoice, then scan the QR code with a Lightning-compatible wallet.
+
+### 3.6 Merchant-receipt information
+
+The merchant's settlement outcome is recorded only when publicly confirmed.
+
+```text
+crypto
+fiat
+crypto_or_fiat
+not_publicly_confirmed
+```
+
+Processor capability alone is not proof of the merchant's selected settlement setting.
+
+---
+
+## 4. Evidence classes
+
+Evidence is classified by strength and source relationship.
+
+### 4.1 Class A — strong evidence
+
+#### A1 — Live checkout observed
+
+CryptoPayMap or a reviewer confirms that the current checkout, invoice, terminal, or in-person flow actually presents the described cryptocurrency payment route.
+
+A live checkout observation records:
+
+- observation date;
+- applicable product or location;
+- asset and network where visible;
+- route and method;
+- any restrictions;
+- whether payment completion was observed or only option availability was observed.
+
+#### A2 — Current official merchant or service page
+
+A current official page explicitly describes the applicable cryptocurrency payment route.
+
+Examples:
+
+- payment help page;
+- checkout documentation;
+- official terms;
+- official FAQ;
+- branch-specific payment page.
+
+A generic corporate blockchain announcement is not automatically A2.
+
+#### A3 — Verified business representative
+
+A business or service representative completes an approved ownership-verification method and provides applicable payment details.
+
+Ownership verification proves the representative relationship. The supplied acceptance details still undergo consistency and scope review.
+
+#### A4 — Dated real-payment proof
+
+A dated payment report provides enough private or public evidence to verify the target, route, asset, network, and successful payment.
+
+Sensitive transaction details may remain private. The public record uses a reviewed summary rather than publishing the original proof by default.
+
+### 4.2 Class B — medium evidence
+
+#### B1 — Recent official social statement
+
+A recent post from an official business account explicitly describes the applicable payment route or current acceptance.
+
+#### B2 — Current processor case study or merchant listing
+
+A processor identifies the business or service as a current customer or acceptance example.
+
+A processor listing is medium evidence because integrations may be optional, partial, branch-specific, or outdated.
+
+#### B3 — Recent dated OpenStreetMap observation
+
+A recent OpenStreetMap payment tag has a useful survey or check date and applies to the specific physical location.
+
+An undated tag is not B3.
+
+#### B4 — Recent independent user report
+
+A recent report describes the target, date, route, asset, network, method, and observed result but does not include enough proof for A4.
+
+### 4.3 Class C — weak discovery evidence
+
+Examples:
+
+- BTC Map or another directory listing;
+- undated OpenStreetMap payment tags;
+- old articles;
+- generic social posts;
+- search-result snippets;
+- copied directory entries;
+- platform capability without merchant-specific activation;
+- vague “crypto accepted” claims without asset, network, route, or date.
+
+Class C is useful for candidate discovery. It is never sufficient by itself for confirmation.
+
+---
+
+## 5. Confirmation threshold
+
+A claim may be confirmed when all required payment information is present and one of these evidence conditions is met.
+
+### 5.1 One Class A item
+
+```text
+one accepted A item
+and
+no newer material contradiction
+```
+
+### 5.2 Two independent Class B items
+
+```text
+two accepted independent B items
+and
+one is merchant-side or processor-side
+and
+one is usage-side, on-the-ground, or dated OSM-side
+and
+no newer material contradiction
+```
+
+Examples of acceptable B pairs:
+
+- recent official merchant social statement + recent independent user report;
+- current processor case study + recent dated OSM survey;
+- recent official merchant statement + recent dated OSM survey.
+
+### 5.3 Evidence independence
+
+Two pages do not count as independent merely because they have different URLs.
+
+The following normally count as one origin:
+
+- directories copying the same announcement;
+- articles repeating one press release;
+- multiple processor pages generated from one integration record;
+- reposts of the same user report;
+- a search snippet and the page it summarizes.
+
+Evidence is independent when it comes from materially separate observation or responsibility paths.
+
+### 5.4 Class C cannot complete the threshold
+
+Class C may support context, duplicate resolution, or candidate discovery, but cannot replace A or B evidence.
+
+---
+
+## 6. Scope verification
+
+### 6.1 Location-specific claims
+
+A physical map pin normally requires a confirmed `location_specific` claim.
+
+Evidence must identify the actual branch or location.
+
+### 6.2 Brand-region or brand-global claims
+
+A brand-wide statement does not automatically create pins for every location.
+
+Expansion to location pins requires:
+
+- an explicit official statement that the relevant locations participate;
+- a current official locator or stable location list;
+- a defined region;
+- no unresolved franchise or branch exception;
+- a way to track exclusions and changes.
+
+If these conditions are not met, the claim remains brand-level and does not generate location-specific public pins.
+
+### 6.3 Franchise and independently operated locations
+
+Franchise or independently operated branches do not inherit acceptance from a parent brand without applicable evidence.
+
+### 6.4 Platform capability
+
+A commerce or point-of-sale platform supporting cryptocurrency does not prove that each merchant using the platform enabled it.
+
+`platform_capability` never creates a merchant pin by itself.
+
+### 6.5 Online-service scope
+
+Online acceptance records must describe applicable scope where relevant:
+
+```text
+all_checkout
+selected_products
+new_purchase_only
+renewal_only
+region_limited
+temporary
+```
+
+A marketplace is listed only when the platform's own checkout supports cryptocurrency. Individual seller arrangements do not prove platform-wide acceptance.
+
+---
+
+## 7. Freshness and reconfirmation
+
+Freshness windows are measured from the applicable observation or verification date, not merely the date a record was entered.
+
+Initial reconfirmation windows:
+
+| Evidence basis | Review window |
+|---|---:|
+| Current official payment page or live checkout observation | 180 days |
+| Dated real-payment proof | 180 days |
+| Verified business representative | 365 days |
+| Dated medium evidence pair | 180 days unless a shorter context applies |
+| Undated OSM only | Not publishable |
+| Directory only | Not publishable |
+
+The system stores `last_confirmed_at` and `next_review_at` separately.
+
+### 7.1 Reconfirmation
+
+Reconfirmation requires evidence that meets the current policy for the same applicable scope.
+
+A reconfirmation event records:
+
+- date;
+- evidence used;
+- whether payment details changed;
+- new next-review date;
+- public summary where appropriate.
+
+### 7.2 Expired review window
+
+When the review window expires without sufficient reconfirmation:
+
+```text
+confirmed → stale
+```
+
+Expiration alone does not prove acceptance ended.
+
+### 7.3 Policy changes
+
+Changes to freshness windows are documented and apply prospectively or through an explicit migration review. They are not silently backdated without updating affected next-review dates.
+
+---
+
+## 8. Contradictory and negative evidence
+
+### 8.1 One ordinary failure report
+
+One ordinary failure report normally causes:
+
+- private negative evidence;
+- a priority recheck;
+- no immediate ended status;
+- no automatic removal of the current claim.
+
+The report may cause temporary hiding only for a separate urgent privacy, rights, or safety reason.
+
+### 8.2 Two independent recent failure reports
+
+Two independent credible reports within 30 days normally cause:
+
+```text
+confirmed → stale
+```
+
+The route remains under review until official or stronger evidence resolves the contradiction.
+
+### 8.3 Strong official removal evidence
+
+Examples:
+
+- official payment page removes the option;
+- checkout no longer presents the option;
+- processor or merchant confirms termination;
+- official branch closure notice;
+- official service shutdown.
+
+Depending on clarity:
+
+```text
+confirmed → stale
+```
+
+or:
+
+```text
+confirmed → ended
+```
+
+### 8.4 Newer evidence priority
+
+When evidence conflicts, reviewers consider:
+
+1. applicability to the exact place, service, product, and region;
+2. observation date;
+3. source responsibility;
+4. independence;
+5. directness of observation;
+6. whether the payment route was merely offered or successfully completed.
+
+A newer, directly applicable official removal normally outweighs an older confirmation.
+
+### 8.5 No automatic crowd vote
+
+Report count alone does not determine truth. Duplicate, coordinated, copied, or unsupported reports are not treated as independent evidence.
+
+---
+
+## 9. Ended-state requirements
+
+Ended status requires strong evidence that the applicable route or target ended.
+
+Examples:
+
+- official end-of-support statement;
+- current checkout removal confirmed by direct observation;
+- official business closure;
+- current service shutdown;
+- processor termination confirmed for the applicable merchant;
+- multiple independent failures plus supporting current evidence.
+
+An ended event records:
+
+- effective or observed end date where known;
+- reason code;
+- evidence;
+- public summary;
+- previous state.
+
+Ended does not erase history.
+
+---
+
+## 10. Rejected-state requirements
+
+A rejected decision records a machine-readable reason such as:
+
+```text
+out_of_scope
+insufficient_evidence
+unverifiable
+false_or_misleading
+duplicate
+spam_or_promotion
+location_not_identifiable
+asset_or_network_not_identifiable
+rights_issue
+privacy_issue
+indirect_spending_route
+```
+
+A rejected source candidate is not a public allegation against a business. Rejection is normally internal.
+
+---
+
+## 11. Evidence handling and publication
+
+### 11.1 Public evidence
+
+Public evidence may include:
+
+- official URLs;
+- public archive URLs where permitted;
+- reviewed summaries;
+- observation dates;
+- source type;
+- evidence class;
+- public verification events.
+
+### 11.2 Private evidence
+
+Private evidence may include:
+
+- transaction URLs;
+- receipts;
+- screenshots containing personal information;
+- ownership proof;
+- private correspondence;
+- unredacted payment details;
+- private submitter contact information.
+
+Private evidence may support a public conclusion without being published.
+
+### 11.3 Screenshots and media
+
+A screenshot or photograph used as evidence is not automatically licensed for public gallery use.
+
+Evidence review, privacy review, and public-media rights review are separate decisions.
+
+### 11.4 Archive URLs
+
+Archive services may be used only when:
+
+- archiving is lawful and appropriate;
+- the archived page does not contain private or restricted material;
+- the archive adds durable verification value;
+- the source and observation dates remain clear.
+
+CryptoPayMap does not archive private submissions, ownership proof, receipts, or personal data through public archive services.
+
+### 11.5 Search snippets
+
+A search-result snippet is discovery evidence only. Reviewers must inspect the underlying source where possible.
+
+---
+
+## 12. Review decisions
+
+### 12.1 Reviewer output
+
+A verification review records:
+
+- claim scope;
+- route and method;
+- asset and network combinations;
+- How to pay;
+- restrictions;
+- evidence accepted or rejected;
+- status decision;
+- confirmation or effective date;
+- next review date;
+- public summary;
+- private notes where needed.
+
+### 12.2 Atomic canonical change
+
+A review decision updates canonical data and verification history in one controlled transaction.
+
+A public status is not reported as published until public-export validation succeeds.
+
+### 12.3 Partial evidence acceptance
+
+A submission may contain useful and unusable parts.
+
+Reviewers may accept one field or evidence item while rejecting or holding another. This does not lower the confirmation threshold.
+
+### 12.4 Ownership claims
+
+Verified ownership establishes the claimant's relationship to a business. It does not:
+
+- automatically confirm acceptance;
+- allow unreviewed public edits;
+- suppress contradictory evidence;
+- change ranking or visibility through payment.
+
+---
+
+## 13. Public language
+
+CryptoPayMap uses precise status language.
+
+Preferred:
+
+- Confirmed on 12 June 2026.
+- Last reconfirmed 90 days ago.
+- This payment route is stale and excluded from default results.
+- Acceptance ended according to the linked official notice.
+- Available assets are shown at checkout and may change.
+
+Avoid:
+
+- guaranteed;
+- certified safe;
+- always accepted;
+- officially endorsed by CryptoPayMap;
+- every branch accepts cryptocurrency;
+- the merchant receives crypto, unless confirmed.
+
+---
+
+## 14. Public statistics
+
+Public statistics count only eligible public canonical records.
+
+They exclude:
+
+- source candidates;
+- rejected records;
+- private submissions;
+- internal review queues;
+- duplicate source observations;
+- temporarily hidden records where public counting would reveal restricted information.
+
+Stats describe the CryptoPayMap dataset, not global cryptocurrency adoption.
+
+---
+
+## 15. Appeals, corrections, and emergency handling
+
+Businesses and users may submit corrections through the public contribution routes.
+
+Urgent privacy, rights, or dangerous misinformation reports may cause temporary hiding before the underlying verification review completes.
+
+A correction or removal request does not erase valid evidence history automatically. Retention and deletion follow the applicable privacy, media, and legal policies.
+
+---
+
+## 16. Policy versioning
+
+Material policy changes require:
+
+- a reviewed pull request;
+- public Changelog review after the product is released;
+- migration analysis for affected claims;
+- explicit effective date;
+- updated validators where applicable.
+
+Existing confirmations are re-evaluated when a policy change materially affects eligibility.
+
+---
+
+## 17. Verification checklist
+
+Before marking a claim confirmed, verify:
+
+- [ ] The target is identifiable.
+- [ ] The claim scope is correct.
+- [ ] The route is direct wallet or processor checkout.
+- [ ] The payment method is explicit.
+- [ ] Each listed asset has an explicit network.
+- [ ] How to pay is actionable.
+- [ ] Restrictions are recorded.
+- [ ] Evidence meets one-A or two-independent-B threshold.
+- [ ] Evidence applies to the listed location or service scope.
+- [ ] No newer material contradiction exists.
+- [ ] Last confirmation and next review dates are set.
+- [ ] Merchant settlement is not inferred.
+- [ ] Public evidence contains no private material.
+- [ ] The canonical and public-export validators pass.


### PR DESCRIPTION
## Implementation item

`P0-05`

## Purpose

Define the public verification threshold, evidence classes, freshness and contradiction rules, source-capture requirements, attribution, and the separate license layers for OpenStreetMap location data, CryptoPayMap acceptance data, explanatory text, software, and media.

## Changes

- add `docs/VERIFICATION_POLICY.md`
- add `docs/SOURCE_AND_LICENSE_POLICY.md`

## Out of scope

- final application validators
- submission and media workflow implementation
- database migrations
- final software-code license selection
- legal advice for third-party reusers

## Completion criteria

- [x] Evidence classes and confirmation requirements are explicit.
- [x] Direct payments without a known network cannot be confirmed.
- [x] Reconfirmation, stale, ended, negative-evidence, and contradiction behavior are defined.
- [x] OpenStreetMap and project-originated data remain attributable and separately licensed.
- [x] Combined exports preserve component-license notices rather than replacing ODbL with a blanket project license.
- [x] Evidence-only media and public-gallery media use separate permissions.

## Important policy decisions

- confirmation requires one accepted Class A item or two independent Class B items from complementary source sides
- Class C is discovery evidence only
- official or directly observed newer contradiction can outweigh older support
- OSM-derived location data remains under ODbL 1.0 with OpenStreetMap attribution
- CryptoPayMap-originated structured acceptance data is intended for ODC-By 1.0
- project-authored explanatory text is intended for CC BY 4.0
- images and trademarks are excluded unless individually licensed or permitted
- software code requires a separate license decision

## Publication, privacy, and integrity

- [x] Candidate counts and private queues remain excluded from public statistics.
- [x] Private proof may support a public conclusion without being published.
- [x] Full third-party pages and images are not republished by default.
- [x] Ownership verification and commercial relationships cannot bypass verification.

## Public impact

Documentation only. These policies become release-facing contracts when implemented and published with the product.

## Rollback

Revert the P0-05 documentation commits.