### PR TITLE
P0-06: Define submission and media policies

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -28,8 +28,8 @@ This document tracks public, repository-level implementation work. It is not the
 | P0-02 | Product constitution | Completed | P0-01 | [#3](https://github.com/badjoke-lab/cryptopaymap/pull/3) |
 | P0-03 | Information architecture | Completed | P0-02 | [#4](https://github.com/badjoke-lab/cryptopaymap/pull/4) |
 | P0-04 | Data architecture | Completed | P0-02 | [#5](https://github.com/badjoke-lab/cryptopaymap/pull/5) |
-| P0-05 | Verification, sources, and licenses | In progress | P0-04 | [#6](https://github.com/badjoke-lab/cryptopaymap/pull/6) |
-| P0-06 | Submission and media policies | Planned | P0-04, P0-05 | — |
+| P0-05 | Verification, sources, and licenses | Completed | P0-04 | [#6](https://github.com/badjoke-lab/cryptopaymap/pull/6) |
+| P0-06 | Submission and media policies | In progress | P0-04, P0-05 | [#7](https://github.com/badjoke-lab/cryptopaymap/pull/7) |
 | P0-07 | Technical, UX, security, and privacy architecture | Planned | P0-03, P0-04 | — |
 | P0-08 | Operations, migration, launch, and public roadmap | Planned | P0-03 through P0-07 | — |
 

--- a/docs/MEDIA_POLICY.md
+++ b/docs/MEDIA_POLICY.md
@@ -1,0 +1,786 @@
+# CryptoPayMap media policy
+
+## Purpose
+
+This document defines how CryptoPayMap receives, stores, validates, reviews, transforms, publishes, retains, and removes images and other supported media.
+
+Media serves three distinct purposes:
+
+```text
+evidence_image
+owner_verification_proof
+public_gallery_candidate
+```
+
+These purposes are never interchangeable by default.
+
+The central rules are:
+
+> Submission approval does not approve media for public display.
+
+> Evidence access does not grant public-gallery rights.
+
+---
+
+## 1. Media principles
+
+1. **Private by default.** New uploads enter private quarantine and are not public URLs.
+2. **Purpose is explicit.** Evidence, ownership proof, and public gallery media follow different review and retention paths.
+3. **Rights and privacy are separate checks.** A useful image may still be unpublishable.
+4. **Originals remain private.** Only reviewed, privacy-safe derivatives may become public.
+5. **Metadata is removed before publication.** Public derivatives do not retain EXIF or GPS metadata.
+6. **File extensions are not trusted.** The system validates file signatures and decodes or re-encodes accepted files.
+7. **No artificial storefront evidence.** AI-generated or unrelated stock imagery must not represent a real business or payment route.
+8. **No unauthorized scraping.** Images are not copied from map platforms, business sites, social media, or directories without a documented rights basis.
+9. **Public listings do not require images.** A category placeholder is preferable to misleading or unlicensed media.
+10. **Removal can be urgent.** Rights, privacy, or safety issues may temporarily hide media before final review.
+
+---
+
+## 2. Media purposes
+
+### 2.1 Evidence image
+
+Evidence images help review a factual claim.
+
+Examples:
+
+- payment sign;
+- current checkout screen;
+- terminal or invoice flow;
+- dated payment receipt with unnecessary information removed;
+- storefront context needed to identify a location;
+- screenshot showing an applicable payment option.
+
+Evidence images are private or restricted by default. A reviewed factual conclusion may be public even when the original image remains private.
+
+### 2.2 Owner-verification proof
+
+Ownership proof helps verify that a claimant controls or represents a business or service.
+
+Examples:
+
+- temporary website code;
+- DNS verification evidence;
+- official account confirmation;
+- private business correspondence;
+- official-domain email verification artifacts.
+
+Ownership proof is never public gallery material by default and has a shorter retention period.
+
+### 2.3 Public-gallery candidate
+
+A public-gallery candidate is offered for public display on a place or service record.
+
+Examples:
+
+- exterior;
+- interior;
+- product;
+- menu;
+- payment sign;
+- checkout terminal;
+- approved cover image.
+
+Public display requires rights review, privacy review, quality review, target matching, metadata removal, and generation of an approved public derivative.
+
+### 2.4 Dual-purpose media
+
+One uploaded image may appear relevant both as evidence and as gallery material, but each purpose receives a separate decision and rights basis.
+
+The system records separate relationships or creates separate reviewed derivatives rather than treating one approval as universal.
+
+---
+
+## 3. Media roles
+
+Supported public or review roles include:
+
+```text
+cover
+gallery
+exterior
+interior
+product
+menu
+payment_sign
+checkout_terminal
+evidence_image
+owner_verification_proof
+```
+
+### 3.1 Cover image
+
+- zero or one active cover per public record;
+- suitable for responsive crops;
+- accurately represents the target;
+- not dependent on small embedded text;
+- no unresolved privacy or trademark confusion.
+
+### 3.2 Gallery image
+
+- may show relevant context beyond the cover;
+- display order is reviewed;
+- duplicate or near-duplicate images may be rejected;
+- galleries remain optional.
+
+### 3.3 Payment sign and checkout terminal
+
+These may provide useful payment context but require special review for:
+
+- QR codes;
+- wallet addresses;
+- transaction identifiers;
+- customer information;
+- screen reflections;
+- device serial numbers;
+- obsolete payment instructions.
+
+---
+
+## 4. Accepted input formats and limits
+
+Initial accepted upload formats:
+
+```text
+JPEG
+PNG
+WebP
+HEIC
+HEIF
+```
+
+Initial public derivative formats:
+
+```text
+WebP
+JPEG
+```
+
+### 4.1 File limits
+
+```text
+maximum per file: 5 MB
+regular submission total: 20 MB
+claim or photos submission total: 40 MB
+```
+
+These are product safeguards and may be revised through a documented policy change.
+
+### 4.2 Submission count limits
+
+| Submission route | Evidence or proof | Public-gallery candidates |
+|---|---:|---:|
+| Suggest | 4 | 2 |
+| Payment report | 3 | 0 |
+| Problem report | 4 | 0 |
+| Claim | 3 | 8 |
+| Photos | 0 | 8 |
+
+Limits prevent accidental overcollection and abuse. A reviewer may request a specific replacement rather than encouraging additional bulk uploads.
+
+### 4.3 Unsupported content
+
+Unsupported or rejected content includes:
+
+- executable files;
+- archives;
+- vector files with active content unless a later controlled path is added;
+- animated media unless explicitly supported;
+- corrupted files;
+- disguised file types;
+- oversized images that cannot be processed safely;
+- content outside the selected target or purpose.
+
+---
+
+## 5. Upload and storage architecture
+
+### 5.1 Private quarantine
+
+User uploads go directly to private object storage through a short-lived, scoped upload authorization.
+
+The upload authorization limits:
+
+- object path;
+- file count;
+- file size;
+- content type where possible;
+- expiration;
+- submission relationship.
+
+A successful object upload does not create an approved media record.
+
+### 5.2 Storage responsibilities
+
+```text
+Neon
+- media metadata
+- rights basis
+- review status
+- target relationships
+- hashes
+- dimensions
+- retention dates
+- public derivative references
+
+Private R2 or equivalent
+- original uploads
+- evidence media
+- ownership proof
+- quarantine derivatives
+
+Public R2 or equivalent
+- approved public derivatives only
+```
+
+### 5.3 Object keys
+
+Object keys must not contain:
+
+- email addresses;
+- business secrets;
+- wallet addresses;
+- public status tokens;
+- user-supplied filenames;
+- unnecessary target names;
+- predictable private references.
+
+### 5.4 Original filenames
+
+Original filenames are not used as public URLs. They may be discarded or stored only as restricted metadata when needed for review.
+
+### 5.5 Direct public access
+
+Original and quarantine objects are never made public through object-bucket permissions.
+
+Review access uses authenticated application paths or short-lived signed URLs with no-store behavior.
+
+---
+
+## 6. Validation pipeline
+
+An upload moves through these states:
+
+```text
+uploaded
+→ validated
+→ pending_review
+→ approved_private | approved_public | rejected
+→ deleted when retention ends
+```
+
+### 6.1 Initial validation
+
+The system checks:
+
+- object exists;
+- size is within limit;
+- magic bytes match a supported format;
+- image decoder can read the file;
+- pixel dimensions are within safe processing limits;
+- file is not an archive or executable;
+- content hash is computed;
+- duplicate and known-abuse hashes are checked;
+- submission and purpose relationships are valid.
+
+### 6.2 Safe decoding and re-encoding
+
+Before public use, the image is decoded and re-encoded through the approved processing pipeline.
+
+Re-encoding:
+
+- removes hidden payloads not needed for display;
+- strips metadata;
+- normalizes orientation;
+- creates bounded dimensions;
+- produces supported public formats.
+
+### 6.3 Metadata removal
+
+Public derivatives remove:
+
+- EXIF;
+- GPS coordinates;
+- device model and serial data;
+- capture software metadata;
+- embedded thumbnails;
+- unnecessary color-profile or comment metadata where safe.
+
+The reviewed capture date may remain as structured database metadata when useful and permitted.
+
+### 6.4 Duplicate detection
+
+Exact and perceptual hashes may identify:
+
+- repeated uploads;
+- near-duplicate gallery candidates;
+- previously rejected material;
+- reuse across unrelated targets.
+
+A duplicate flag requires review; it does not automatically prove misuse.
+
+---
+
+## 7. Privacy and safety review
+
+Before public approval, reviewers check for:
+
+- recognizable faces;
+- children;
+- vehicle license plates;
+- addresses unrelated to the listed business;
+- receipts and order details;
+- names, email addresses, phone numbers, or account identifiers;
+- wallet addresses;
+- transaction hashes;
+- QR codes;
+- payment links;
+- private screens or messages;
+- access badges;
+- security systems;
+- sensitive medical, religious, political, or other contextual information;
+- dangerous or unlawful content.
+
+### 7.1 Redaction
+
+When a useful public image contains limited removable private information, a reviewer may approve a redacted derivative.
+
+Redaction is applied to a derivative. The private original remains restricted until deletion under the applicable retention schedule.
+
+### 7.2 QR codes and wallet addresses
+
+A public image containing a payment QR or wallet address requires confirmation that:
+
+- it is intended for public payment use;
+- it belongs to the correct target;
+- it is current;
+- publication does not expose a personal or temporary address;
+- displaying it will not cause users to bypass the intended checkout flow.
+
+When these conditions are not clearly met, the QR or address is obscured in the public derivative.
+
+### 7.3 Faces and license plates
+
+Incidental faces and plates are removed, blurred, cropped, or otherwise made non-identifiable unless a documented rights and privacy basis permits public display.
+
+### 7.4 Evidence minimization
+
+Reviewers should request the least sensitive evidence sufficient for the decision.
+
+A submitter should not be asked to provide a seed phrase, private key, full wallet history, identity document, full bank record, or unnecessary personal account access.
+
+---
+
+## 8. Rights review
+
+### 8.1 Accepted rights bases
+
+Public media requires one of these documented bases:
+
+- submitted by the copyright holder;
+- submitted by an authorized business representative with authority over the media;
+- written permission from the rights holder;
+- compatible open license;
+- public-domain status with documented basis;
+- created by CryptoPayMap.
+
+### 8.2 Unaccepted sources
+
+CryptoPayMap does not publish media copied without permission from:
+
+- Google Maps or similar map services;
+- business websites;
+- social-media posts;
+- review platforms;
+- delivery platforms;
+- third-party directories;
+- processor marketing pages;
+- other businesses;
+- stock-photo sites without a compatible license.
+
+Linking to a source page does not grant republication rights.
+
+### 8.3 Evidence-only permission
+
+Evidence-only permission authorizes CryptoPayMap to:
+
+- receive;
+- store privately;
+- validate;
+- process for review;
+- create internal review derivatives;
+- retain according to policy;
+- use the reviewed factual conclusion.
+
+It does not authorize public gallery display or open-data redistribution of the original.
+
+### 8.4 Public-gallery permission
+
+A contributor offering public-gallery media confirms that they own the media or are authorized to license it and grants CryptoPayMap a non-exclusive, worldwide, royalty-free permission to:
+
+- host;
+- display;
+- resize;
+- crop;
+- re-encode;
+- create responsive derivatives;
+- use the media on the applicable listing and in project promotion;
+- remove the media when required.
+
+The contributor retains ownership.
+
+The media is not automatically licensed to third parties under ODC-By or CC BY.
+
+### 8.5 Open-licensed media
+
+An open-licensed item records:
+
+- license name and version;
+- source URL;
+- creator;
+- attribution text;
+- modification notice;
+- compatibility with the intended use.
+
+A license label without a traceable source is insufficient.
+
+### 8.6 Business claims and media authority
+
+Verified business representation does not automatically prove rights in every supplied image. The claimant confirms authority for each media item or provides a separate rights basis.
+
+---
+
+## 9. Accuracy and target review
+
+A public image must accurately represent the target.
+
+Reviewers verify:
+
+- correct business or service;
+- correct branch where location-specific;
+- reasonable capture date;
+- current branding where materially relevant;
+- no unrelated storefront or product;
+- no misleading crop;
+- no representation of temporary payment material as permanent acceptance;
+- no image from another branch presented as the listed location.
+
+### 9.1 AI-generated and stock imagery
+
+AI-generated or generic stock imagery must not be used to represent a real place, real terminal, real payment sign, or real acceptance route.
+
+A neutral category illustration may be used as a clearly non-photographic placeholder when it cannot reasonably be mistaken for the real business.
+
+### 9.2 Historic media
+
+Historic images may be retained as evidence or history but are not used as the active cover unless clearly labeled and still accurate.
+
+---
+
+## 10. Public derivative pipeline
+
+Initial public derivatives may include:
+
+```text
+cover-large   1600 × 900
+cover-medium   960 × 540
+card           480 × 320
+thumbnail      160 × 160
+```
+
+### 10.1 Processing requirements
+
+- preserve useful subject content;
+- avoid stretching;
+- apply reviewed crop rules;
+- generate bounded dimensions;
+- use reasonable compression;
+- remove private metadata;
+- maintain color and orientation;
+- record output hash, dimensions, MIME type, and creation time;
+- keep the processing engine replaceable.
+
+### 10.2 Cover crops
+
+A cover may require multiple responsive crops. The original is never exposed as a fallback public URL.
+
+### 10.3 Alt text
+
+Public media requires concise alt text that describes relevant visible content without asserting unverified payment facts.
+
+Preferred:
+
+> Exterior of Example Café with a Bitcoin payment sign near the entrance.
+
+Avoid:
+
+> This café always accepts Bitcoin.
+
+Verification claims belong in structured record content, not image alt text.
+
+### 10.4 Processing failure
+
+If processing fails:
+
+- the original remains private;
+- no public URL is generated;
+- the media cannot become `approved_public`;
+- the reviewer may request a replacement;
+- the public listing continues with another approved image or placeholder.
+
+---
+
+## 11. Review decisions
+
+### 11.1 Approved private
+
+`approved_private` means the media may be retained for evidence or ownership review but is not public.
+
+### 11.2 Approved public
+
+`approved_public` requires:
+
+- target match;
+- public-purpose selection;
+- valid rights basis;
+- privacy review;
+- safe derivative;
+- public storage key;
+- alt text;
+- attribution where required;
+- no unresolved safety issue.
+
+### 11.3 Rejected
+
+Rejection reasons may include:
+
+```text
+unsupported_format
+corrupt_file
+file_too_large
+malware_or_active_content
+wrong_target
+duplicate_or_low_value
+insufficient_quality
+no_rights_basis
+privacy_risk
+sensitive_payment_information
+misleading_or_outdated
+ai_or_stock_misrepresentation
+prohibited_content
+```
+
+### 11.4 Deleted
+
+`deleted` records the removal outcome. The object is removed according to storage operations, while limited decision and hash metadata may remain when lawful and necessary for audit or duplicate control.
+
+---
+
+## 12. Submission and media decision separation
+
+A submission resolution and media resolution are independent.
+
+Examples:
+
+- a suggestion is accepted as a candidate while all images are rejected;
+- a payment report is accepted as evidence while its screenshot remains private;
+- a business claim is verified while its gallery images require rights clarification;
+- a problem report causes an image takedown without changing the acceptance claim;
+- a listing is confirmed with no image and uses a category placeholder.
+
+The status page displays each public media decision separately from the submission's factual resolution.
+
+---
+
+## 13. Retention
+
+Initial retention rules:
+
+| Media category | Retention |
+|---|---|
+| Rejected or duplicate upload | Delete object 30 days after submission closure |
+| Private evidence media | Delete object 180 days after final resolution unless a documented review, dispute, or legal basis requires longer retention |
+| Owner-verification proof | Delete object 90 days after verification completion, rejection, expiry, or revocation unless a documented basis requires longer retention |
+| Approved public media | Retain while published and until removal, replacement, rights expiry, or record retirement requires review |
+
+### 13.1 Retention metadata
+
+Each private object has:
+
+- media purpose;
+- review status;
+- final resolution date;
+- `delete_after` date;
+- hold or exception reason where applicable;
+- deletion result.
+
+### 13.2 Audit retention
+
+After an object is deleted, the system may retain limited metadata such as:
+
+- content hash;
+- decision;
+- reason code;
+- rights outcome;
+- deletion timestamp;
+- target relationship;
+- audit event.
+
+The retained metadata must not reconstruct the deleted personal or private content.
+
+### 13.3 Retention extensions
+
+An extension requires a documented reason, such as:
+
+- active rights dispute;
+- active privacy request;
+- unresolved submission;
+- security investigation;
+- legal preservation requirement.
+
+Extensions are reviewed and are not indefinite by default.
+
+---
+
+## 14. Removal and takedown
+
+### 14.1 Request channels
+
+A person may report:
+
+- unauthorized image use;
+- personal information;
+- incorrect attribution;
+- wrong business or branch;
+- misleading or outdated image;
+- trademark confusion;
+- safety concern;
+- private evidence exposure.
+
+### 14.2 Urgent hiding
+
+A credible privacy, rights, or safety report may immediately set:
+
+```text
+visibility = restricted
+```
+
+or remove the public derivative while review continues.
+
+This media action does not automatically change the underlying acceptance claim.
+
+### 14.3 Review target
+
+Removal requests are reviewed promptly, with a normal target of completing the initial decision within 30 days. Urgent exposure may be hidden immediately.
+
+This target is an operational goal, not a guarantee.
+
+### 14.4 Replacement
+
+When the issue affects only one image, the record may continue using another approved image or a category placeholder.
+
+### 14.5 Cached copies
+
+After removal, the system invalidates or replaces accessible cached copies under project control and records the action.
+
+---
+
+## 15. MVP-A and MVP-B media scope
+
+### 15.1 MVP-A
+
+MVP-A supports operator-managed media only.
+
+- operator uploads through an authenticated path;
+- processing uses an internal controlled script or service;
+- originals remain private;
+- only approved derivatives are public;
+- public listings support placeholders when no media exists.
+
+### 15.2 MVP-B
+
+MVP-B adds user uploads.
+
+- short-lived scoped upload authorization;
+- direct upload to quarantine;
+- asynchronous or controlled processing;
+- per-file validation;
+- submission and media review queues;
+- public status decisions;
+- retention and deletion jobs.
+
+The processing engine remains replaceable and does not require one proprietary image-transformation provider.
+
+---
+
+## 16. Public presentation
+
+### 16.1 No-image state
+
+A listing with no approved media uses a category-based placeholder or neutral interface treatment.
+
+The placeholder is clearly illustrative and does not depict a fabricated version of the real business.
+
+### 16.2 Gallery behavior
+
+Suggested behavior:
+
+```text
+0 images   placeholder
+1 image    large cover
+2–4        cover plus grid
+5+         cover, selected thumbnails, and View all
+```
+
+Mobile galleries use touch-friendly horizontal navigation and accessible controls.
+
+### 16.3 Attribution
+
+Required media attribution appears near the image, in the gallery detail, or through an accessible attribution control appropriate to the license.
+
+Attribution is not hidden only in source code or inaccessible metadata.
+
+### 16.4 Download and reuse
+
+Public display does not imply a general download or reuse license. The interface and data manifest distinguish media rights from public data and text licenses.
+
+---
+
+## 17. Security requirements
+
+- quarantine objects are private;
+- signed review URLs are short-lived;
+- file signatures are validated;
+- image decoding runs with bounded resources;
+- dimensions and decompression limits prevent image bombs;
+- user filenames are not executed or trusted;
+- HTML and SVG active content are not accepted through the initial image path;
+- logs redact storage secrets and signed URLs;
+- public object keys are unguessable enough to avoid exposing review history;
+- deletion jobs are idempotent;
+- a failed public derivative cannot fall back to the private original;
+- upload and processing events are auditable.
+
+Detailed security controls are defined in the security architecture.
+
+---
+
+## 18. Media checklist
+
+Before public approval, verify:
+
+- [ ] The target and branch are correct.
+- [ ] The media purpose is explicit.
+- [ ] The file passed signature, decode, dimension, and size validation.
+- [ ] The source and rights basis are documented.
+- [ ] Public-gallery permission is present.
+- [ ] Faces, plates, receipts, QR codes, wallet addresses, and personal information were reviewed.
+- [ ] Metadata and GPS were removed from the public derivative.
+- [ ] The image is not unauthorized third-party material.
+- [ ] The image is not AI-generated or stock media presented as the real target.
+- [ ] The public derivative was re-encoded and stored separately from the original.
+- [ ] Alt text is accurate and does not make unverified claims.
+- [ ] Attribution is visible where required.
+- [ ] Retention and deletion dates are assigned to private material.
+- [ ] Submission resolution and media resolution remain separate.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -9,11 +9,11 @@ Phase 0 — Public specifications and development control
 
 ## Current implementation item
 
-`P0-05 — Verification, sources, and licenses`
+`P0-06 — Submission and media policies`
 
 ## Active pull request
 
-[#6 — P0-05: Define verification, source, and license policies](https://github.com/badjoke-lab/cryptopaymap/pull/6)
+[#7 — P0-06: Define submission and media policies](https://github.com/badjoke-lab/cryptopaymap/pull/7)
 
 ## Latest completed work
 
@@ -23,17 +23,18 @@ Phase 0 — Public specifications and development control
 - `P0-02 — Product constitution` completed through [pull request #3](https://github.com/badjoke-lab/cryptopaymap/pull/3), merged as `d09849c`.
 - `P0-03 — Information architecture` completed through [pull request #4](https://github.com/badjoke-lab/cryptopaymap/pull/4), merged as `09b9807`.
 - `P0-04 — Data architecture` completed through [pull request #5](https://github.com/badjoke-lab/cryptopaymap/pull/5), merged as `6e7392d`.
+- `P0-05 — Verification, sources, and licenses` completed through [pull request #6](https://github.com/badjoke-lab/cryptopaymap/pull/6), merged as `a7b475b`.
 
 ## Current deliverables
 
-- `docs/VERIFICATION_POLICY.md`
-- `docs/SOURCE_AND_LICENSE_POLICY.md`
+- `docs/SUBMISSION_WORKFLOW.md`
+- `docs/MEDIA_POLICY.md`
 
 ## Next
 
-1. Review and merge pull request #6 when its completion criteria are satisfied.
-2. Mark P0-05 completed in `docs/IMPLEMENTATION_PLAN.md`.
-3. Start `P0-06 — Submission and media policies`.
+1. Review and merge pull request #7 when its completion criteria are satisfied.
+2. Mark P0-06 completed in `docs/IMPLEMENTATION_PLAN.md`.
+3. Start `P0-07 — Technical, UX, security, and privacy architecture`.
 
 ## Blocked
 

--- a/docs/SUBMISSION_WORKFLOW.md
+++ b/docs/SUBMISSION_WORKFLOW.md
@@ -1,0 +1,875 @@
+# CryptoPayMap submission workflow
+
+## Purpose
+
+This document defines how public suggestions, payment reports, problem reports, business claims, and photo submissions move from intake to review, decision, canonical change, and public publication.
+
+The central rule is:
+
+> A submission never changes public canonical data automatically.
+
+Every submission is stored separately, checked, reviewed, and resolved through an explicit decision. A public change is considered published only after the canonical transaction and public-export validation both succeed.
+
+---
+
+## 1. Submission principles
+
+1. **Original input is preserved.** Normalization and reviewer edits never overwrite the safely parsed original payload.
+2. **Submission state is not claim state.** A resolved submission does not automatically confirm, stale, end, or publish an acceptance claim.
+3. **Review is field-level where useful.** One submitted field may be approved while another is rejected or held.
+4. **Candidate is a valid outcome.** Useful but insufficient information may become a private candidate rather than a public record.
+5. **Holds are time-bounded.** Every hold has a reason, required action, and next review date.
+6. **Private material remains private.** Contact details, transaction URLs, receipts, ownership proof, and restricted media are never exposed through public status pages or exports.
+7. **Publication fails closed.** A canonical change is not reported as public until the export and publication run succeed.
+8. **Urgent privacy and rights reports take priority.** Temporary hiding may occur before the underlying factual review is complete.
+9. **Ownership does not bypass verification.** A verified business representative may propose authoritative corrections, but acceptance claims still follow the verification policy.
+10. **No account is required for the MVP.** A public reference and secret status link provide submission follow-up.
+
+---
+
+## 2. Public submission routes
+
+| Route | Submission type | Primary use |
+|---|---|---|
+| `/suggest` | `suggest` | Suggest a new physical place or online service. |
+| `/payment-report` | `payment_report` | Report a successful or failed payment. |
+| `/report` | `problem_report` | Report incorrect, ended, duplicate, privacy, rights, or other problematic information. |
+| `/claim` | `claim` | Begin verification as a business or service representative. |
+| `/photos` | `photos` | Submit public-gallery media for an existing record. |
+
+`/contribute` explains which route to use, how review works, how private information is handled, and that submission does not guarantee publication.
+
+A private follow-up route uses:
+
+```text
+/submission-status/{public-id}
+```
+
+The route reveals useful information only after separate secret-token validation. It is excluded from public navigation, indexing, and sitemaps.
+
+---
+
+## 3. Common intake contract
+
+Every submission receives:
+
+- an internal UUID;
+- an opaque public reference such as `CPM-S-2026-000123`;
+- a submission type;
+- a workflow status;
+- a safely parsed immutable original payload;
+- a status-token hash;
+- submitted and updated timestamps;
+- an audit event.
+
+The plaintext status secret is shown or delivered once and is never stored in plaintext.
+
+### 3.1 Optional contact
+
+Contact information is optional for ordinary suggestions, payment reports, problem reports, and photos.
+
+Contact is required when:
+
+- a claim verification method needs communication;
+- a reviewer requests information and the submitter chooses email follow-up;
+- another legal or operational requirement makes contact necessary.
+
+Stored contact data is encrypted. A normalized hash may be retained for duplicate or abuse control. Public status pages never display the full email address.
+
+### 3.2 Relationship disclosure
+
+Suggestion and claim forms ask the submitter to identify their relationship to the business or service.
+
+Examples:
+
+- customer;
+- employee;
+- owner or authorized representative;
+- payment provider;
+- independent researcher;
+- other.
+
+Relationship disclosure informs review but does not automatically determine evidence strength.
+
+### 3.3 Evidence links
+
+Evidence URLs are validated for:
+
+- supported URL scheme;
+- plausible public or private purpose;
+- duplicate submissions;
+- dangerous or local-network destinations;
+- prohibited embedded credentials;
+- target relevance.
+
+A URL may be stored privately even when its reviewed summary supports a public claim.
+
+---
+
+## 4. Suggest a place or service
+
+### 4.1 Required information
+
+A suggestion asks for:
+
+- physical place or online service;
+- business or service name;
+- official website where available;
+- physical address and map position for a place, or service URL for an online service;
+- country and city or locality where applicable;
+- category;
+- accepted asset;
+- network, when known;
+- direct-wallet or processor-checkout route;
+- processor, when applicable;
+- payment method;
+- How to pay;
+- observation date;
+- at least one evidence URL or an approved evidence attachment;
+- submitter relationship to the target;
+- required submission and rights acknowledgements.
+
+### 4.2 Unknown network
+
+A suggestion may be accepted for review when the network is unknown.
+
+It cannot become a confirmed direct-payment claim until the network is identified and verified.
+
+### 4.3 Suggestion outcomes
+
+Possible outcomes include:
+
+- approved and published as a confirmed record;
+- partially approved;
+- accepted as a private candidate;
+- more information requested;
+- placed on hold;
+- not approved;
+- duplicate;
+- no change;
+- withdrawn.
+
+A useful suggestion with weak evidence normally becomes a private candidate rather than a misleading public record.
+
+---
+
+## 5. Payment report
+
+### 5.1 Target
+
+A payment report normally starts from a public place or service detail page with the target preselected.
+
+The reviewer must verify that the report applies to the selected location, service, product, region, and date.
+
+### 5.2 Requested information
+
+- payment date;
+- successful or failed result;
+- asset;
+- network;
+- route;
+- payment method;
+- observed steps;
+- terminal, QR, invoice, payment-link, or checkout context;
+- optional public evidence URL;
+- optional private transaction URL;
+- optional evidence media;
+- optional notes.
+
+The form does not require:
+
+- payment amount;
+- submitter name;
+- wallet address;
+- transaction ID in plain text;
+- account creation.
+
+### 5.3 Sensitive payment evidence
+
+Private transaction URLs, receipts, wallet information, and screenshots are restricted by default.
+
+Reviewers use only the minimum material necessary to determine:
+
+- target;
+- date;
+- route;
+- asset;
+- network;
+- success or failure;
+- relevance to the existing claim.
+
+The public record uses a reviewed summary rather than the original private proof.
+
+### 5.4 Positive report behavior
+
+A positive report may:
+
+- add accepted evidence to an existing claim;
+- reconfirm an unchanged claim;
+- propose a new asset, network, route, or method as a separate reviewed change;
+- support a candidate.
+
+A report of a new asset or network never silently overwrites the existing claim.
+
+### 5.5 Negative report behavior
+
+One ordinary failure report normally:
+
+- creates negative evidence;
+- creates a priority recheck;
+- leaves the public state unchanged;
+- does not automatically remove or end the claim.
+
+Two credible independent reports within 30 days normally support:
+
+```text
+confirmed → stale
+```
+
+Strong official removal or closure evidence may support stale or ended status under the verification policy.
+
+---
+
+## 6. Problem report
+
+### 6.1 Report types
+
+```text
+no_longer_accepts_crypto
+business_closed
+payment_failed
+wrong_asset
+wrong_network
+wrong_instructions
+wrong_address
+duplicate
+unauthorized_image
+privacy_issue
+other
+```
+
+### 6.2 Requested information
+
+- target record;
+- report type;
+- observed date;
+- explanation;
+- proposed correction where applicable;
+- optional evidence URL;
+- optional restricted evidence media;
+- optional contact.
+
+### 6.3 Urgent reports
+
+The following may trigger immediate temporary hiding before the factual review is complete:
+
+- exposed personal information;
+- unauthorized or dangerous media;
+- a materially false listing that creates an immediate safety risk;
+- a serious legal or rights concern.
+
+Temporary hiding changes visibility, not verification status.
+
+### 6.4 Duplicate and no-change outcomes
+
+Duplicate and no-change are separate from rejection.
+
+- **Duplicate:** the same actionable report or proposal is already under review or resolved.
+- **No change:** the submission was reviewed, but the canonical record already reflects the supported information or no update is justified.
+
+Useful new evidence from a duplicate submission may still be linked to the existing review.
+
+---
+
+## 7. Business or service claim
+
+### 7.1 Claim input
+
+A claim asks for:
+
+- claimant role;
+- business or service identity;
+- official website;
+- official-domain email where applicable;
+- affected records, locations, branches, or service scopes;
+- current payment details;
+- proposed corrections;
+- preferred ownership-verification method;
+- optional ownership-proof media;
+- optional public-gallery media;
+- required authority and rights acknowledgements.
+
+### 7.2 Verification methods
+
+Supported MVP methods may include:
+
+- code sent to an official-domain email;
+- temporary code placed on an official website;
+- DNS TXT record;
+- contact from an official social account;
+- approved partner-assisted verification.
+
+### 7.3 Claim form does not verify ownership
+
+Submitting a form creates a pending claim submission. It does not:
+
+- create verified ownership;
+- grant editing rights;
+- confirm acceptance;
+- bypass evidence review;
+- suppress contradictory evidence;
+- change public ranking or status.
+
+### 7.4 Ownership outcome
+
+An approved ownership verification records the relationship and its scope.
+
+The relationship may expire or be revoked. Business-provided changes still pass canonical review and publication validation.
+
+---
+
+## 8. Photo submission
+
+A photo submission asks for:
+
+- target place or service;
+- capture date;
+- image role;
+- description;
+- rights holder or authorization basis;
+- public-display permission;
+- required privacy and rights acknowledgements.
+
+Photo submissions are public-gallery candidates, not verification evidence by default. A payment sign or terminal image may also be reviewed separately as evidence when appropriate.
+
+Media review rules are defined in `MEDIA_POLICY.md`.
+
+---
+
+## 9. Automated intake checks
+
+Before human review, the system performs applicable checks.
+
+### 9.1 Request and abuse controls
+
+- Turnstile or equivalent bot check;
+- rate limiting;
+- request-size limit;
+- supported content type;
+- idempotency or duplicate-request protection;
+- blocked URL schemes;
+- safe parsing;
+- HTML and script rejection where plain text is expected.
+
+### 9.2 Field validation
+
+- required fields;
+- length limits;
+- valid dates;
+- valid country and registry values;
+- valid coordinates;
+- asset and network compatibility without inference;
+- processor requirement for processor checkout;
+- target record existence;
+- public reference format;
+- file count and size limits.
+
+### 9.3 Duplicate detection
+
+Potential duplicates may use:
+
+- target and submission type;
+- normalized URL;
+- normalized business name and address;
+- evidence URL;
+- content hash;
+- media hash;
+- recent submission history.
+
+Automatic duplicate detection flags a submission for review. It does not silently discard useful evidence.
+
+### 9.4 Automated checks do not approve
+
+Passing intake checks means only that the submission may enter review. It does not determine factual truth, ownership, rights, or publication eligibility.
+
+---
+
+## 10. Workflow states
+
+### 10.1 Main path
+
+```text
+received
+→ triage
+→ in_review
+→ resolved
+```
+
+### 10.2 Information request
+
+```text
+in_review
+→ needs_information
+→ in_review
+```
+
+### 10.3 Hold
+
+```text
+in_review
+→ on_hold
+→ in_review
+```
+
+### 10.4 Exceptional terminal paths
+
+```text
+received → rejected_spam
+received → duplicate
+received → withdrawn
+in_review → withdrawn
+```
+
+### 10.5 Public-facing labels
+
+| Internal status or resolution | Public-facing label |
+|---|---|
+| `received`, `triage` | Received |
+| `in_review` | Under review |
+| `needs_information` | More information needed |
+| `on_hold` | On hold |
+| `approved` | Approved |
+| `partially_approved` | Partially approved |
+| `accepted_as_candidate` | Accepted as a candidate |
+| `not_approved` | Not approved |
+| `duplicate`, `no_change`, `withdrawn` | Closed |
+
+Public labels never expose internal notes, priority, reviewer identity, abuse signals, or private evidence.
+
+---
+
+## 11. Triage
+
+Triage determines:
+
+- submission type;
+- new record or existing target;
+- target identity;
+- duplicate relationship;
+- urgency;
+- evidence accessibility;
+- personal-information risk;
+- media-rights risk;
+- registry conflicts;
+- whether the submission belongs in the product scope;
+- the reviewer queue.
+
+Triage may correct classification without altering the immutable original payload.
+
+---
+
+## 12. Reviewer workspace
+
+A submission review presents three distinct values where applicable:
+
+```text
+Current canonical value
+Submitted value
+Reviewer normalized value
+```
+
+The workspace also displays:
+
+- original payload;
+- proposed changes;
+- target identity;
+- duplicate candidates;
+- evidence classification;
+- private and public evidence separation;
+- media decisions;
+- submission events;
+- ownership-verification state;
+- canonical impact preview;
+- public-export impact preview.
+
+### 12.1 Reviewer actions
+
+- Request information;
+- place on hold;
+- accept as a private candidate;
+- approve selected fields;
+- approve all eligible fields;
+- reject selected fields;
+- not approve the submission;
+- mark duplicate;
+- close with no change;
+- temporarily hide affected public material;
+- withdraw at the submitter's request;
+- create or link a recheck.
+
+---
+
+## 13. Field-level decisions
+
+Each proposed field may receive:
+
+```text
+approve
+reject
+hold
+```
+
+### 13.1 Approved fields
+
+Approved fields are included in the canonical transaction only if the resulting canonical record passes all applicable validation.
+
+### 13.2 Rejected fields
+
+Rejected fields record a reason. Rejection of one field does not invalidate unrelated useful fields.
+
+### 13.3 Held fields
+
+Held fields remain unresolved and require a hold record. A partially approved submission may publish approved fields while held fields remain private, provided the resulting canonical record remains valid and not misleading.
+
+### 13.4 Conflicting field combinations
+
+The reviewer cannot approve a combination that violates canonical invariants, such as:
+
+- direct wallet with an unknown network;
+- processor checkout without a processor;
+- confirmed status without qualifying evidence;
+- public media without rights and privacy approval;
+- a location pin from platform capability alone.
+
+---
+
+## 14. Holds
+
+### 14.1 Required hold fields
+
+```text
+hold_reason
+placed_on_hold_at
+next_review_at
+required_action
+```
+
+### 14.2 Hold reasons
+
+```text
+awaiting_official_confirmation
+conflicting_evidence
+location_ambiguous
+brand_scope_unclear
+rights_review
+technical_verification
+asset_network_unregistered
+```
+
+### 14.3 Review cadence
+
+A hold is reviewed at an appropriate checkpoint, normally 30, 60, or 90 days after placement depending on the required action.
+
+At or before 90 days, the reviewer normally chooses one of these outcomes:
+
+- return to active review;
+- accept as a private candidate;
+- not approve;
+- close with no change;
+- replace the hold with a new explicitly justified review path.
+
+Indefinite passive holds are not permitted.
+
+### 14.4 Public hold message
+
+The submitter sees a concise public reason and requested action. Internal risk analysis and reviewer notes remain private.
+
+---
+
+## 15. Information requests
+
+A reviewer may request:
+
+- target clarification;
+- observation date;
+- asset or network clarification;
+- payment steps;
+- official source;
+- ownership verification;
+- media rights confirmation;
+- privacy-safe replacement evidence.
+
+The status link allows the submitter to:
+
+- read the request;
+- reply;
+- add evidence;
+- replace a rejected attachment where permitted;
+- withdraw.
+
+New responses append to submission history and never overwrite the original payload.
+
+---
+
+## 16. Resolutions
+
+```text
+approved
+partially_approved
+accepted_as_candidate
+not_approved
+duplicate
+no_change
+withdrawn
+```
+
+### 16.1 Approved
+
+All accepted proposed changes were applied through a valid canonical transaction and any required public publication succeeded.
+
+### 16.2 Partially approved
+
+At least one proposed change was applied while another was rejected or held.
+
+The public status explains only the approved and unresolved outcome needed by the submitter.
+
+### 16.3 Accepted as a candidate
+
+The information is useful for further investigation but does not meet public confirmation requirements.
+
+The candidate remains private.
+
+### 16.4 Not approved
+
+The submission does not justify a canonical public change.
+
+Common reasons include:
+
+```text
+out_of_scope
+insufficient_evidence
+unverifiable
+false_or_misleading
+spam_or_promotion
+no_media_rights
+contains_unnecessary_personal_information
+repeated_duplicate
+```
+
+### 16.5 Duplicate
+
+The actionable matter is already represented by another submission or review.
+
+### 16.6 No change
+
+The current canonical record already reflects the supported information or the review does not justify a change.
+
+### 16.7 Withdrawn
+
+The submitter withdrew the submission before final resolution. Lawful audit, abuse-control, or rights metadata may remain according to retention policy.
+
+---
+
+## 17. Canonical transaction
+
+Approved changes are applied in one controlled database transaction that may include:
+
+- entity or location changes;
+- acceptance-claim changes;
+- asset, network, route, or method relationships;
+- evidence;
+- verification events;
+- approved media metadata;
+- ownership-verification state;
+- submission decision;
+- audit event.
+
+If any required operation fails, the transaction rolls back.
+
+### 17.1 Publication run
+
+After canonical commit:
+
+```text
+canonical change
+→ publication pending
+→ public projection generation
+→ schema, privacy, provenance, and license validation
+→ publication succeeds or fails
+```
+
+The submitter is not told that a change is public while the publication run is pending or failed.
+
+### 17.2 Publication failure
+
+When publication fails:
+
+- the last valid public snapshot remains available;
+- the submission resolution records publication pending or failed internally;
+- the submitter sees a non-misleading processing state;
+- an operator can retry or roll back according to operations policy.
+
+---
+
+## 18. Secret status link
+
+### 18.1 Access
+
+The status page requires:
+
+- public submission reference;
+- separate secret token or signed access mechanism;
+- rate limiting;
+- noindex and no-store behavior where appropriate.
+
+The URL or token must not be included in analytics, referrer leakage, public logs, or support screenshots.
+
+### 18.2 Displayed information
+
+The submitter may see:
+
+- public reference;
+- submission type;
+- current public-facing status;
+- submitted date;
+- information requests;
+- public hold reason;
+- final resolution;
+- linked public record after publication;
+- per-media public decision;
+- allowed response actions.
+
+### 18.3 Hidden information
+
+The page never shows:
+
+- internal priority;
+- reviewer identity;
+- private evidence from other people;
+- abuse signals;
+- internal notes;
+- ownership-proof details;
+- another submission's content;
+- canonical candidate queues.
+
+### 18.4 Token loss
+
+A lost token is not recoverable through public enumeration. A secure recovery path may use the verified contact address when one exists.
+
+---
+
+## 19. Notifications
+
+The MVP may notify a submitter when:
+
+- a submission is received;
+- more information is needed;
+- a hold requires action;
+- the submission is resolved;
+- a public change is successfully published;
+- submitted media is approved or rejected.
+
+Notifications contain the minimum necessary information and do not embed sensitive evidence or full status secrets in message previews.
+
+---
+
+## 20. Privacy and retention
+
+Submission retention separates:
+
+- immutable audit facts;
+- contact data;
+- private evidence;
+- media originals;
+- status history;
+- abuse-control hashes;
+- canonical contributions.
+
+Deletion schedules and media-specific retention are defined in `MEDIA_POLICY.md` and the privacy architecture.
+
+A deletion request is reviewed for:
+
+- personal data;
+- evidence value;
+- legal retention;
+- rights disputes;
+- public canonical facts;
+- audit necessity.
+
+Removing private source material does not automatically remove a separately verified public factual claim.
+
+---
+
+## 21. Administrative routes
+
+### 21.1 Queue
+
+`/admin/submissions`
+
+Filters may include:
+
+- type;
+- workflow status;
+- target type;
+- urgency;
+- evidence status;
+- media status;
+- ownership-verification status;
+- age;
+- duplicate group;
+- hold review date.
+
+### 21.2 Detail
+
+`/admin/submissions/{id}`
+
+Recommended order:
+
+1. submission summary;
+2. current canonical record;
+3. original, submitted, and normalized values;
+4. proposed field diff;
+5. evidence review;
+6. media review;
+7. ownership verification where applicable;
+8. submission and audit history;
+9. decision controls;
+10. publication result.
+
+---
+
+## 22. Audit requirements
+
+Every material transition records:
+
+- actor type;
+- action;
+- subject;
+- previous and new workflow state;
+- reason code;
+- timestamp;
+- correlation ID where applicable;
+- public message where applicable;
+- private note where needed.
+
+The audit trail is private by default. Public history is generated from reviewed public verification events, not raw audit payloads.
+
+---
+
+## 23. Workflow checklist
+
+Before resolving a submission, verify:
+
+- [ ] The original payload remains preserved.
+- [ ] The target and submission type are correct.
+- [ ] Duplicate relationships were reviewed.
+- [ ] Evidence was classified under the verification policy.
+- [ ] Private and public evidence are separated.
+- [ ] Media received independent rights and privacy decisions.
+- [ ] Each proposed field has approve, reject, or hold state where needed.
+- [ ] Holds have reasons and future review dates.
+- [ ] The canonical transaction preserves all invariants.
+- [ ] Ownership verification does not bypass acceptance verification.
+- [ ] Public messages contain no internal notes or personal data.
+- [ ] Publication validation succeeded before reporting a public result.
+- [ ] Retention and deletion schedules were assigned.


### PR DESCRIPTION
## Implementation item

`P0-06`

## Purpose

Define the complete public-submission lifecycle and the independent media lifecycle, including intake, immutable originals, review, field-level decisions, time-bounded holds, private status access, canonical transactions, quarantine, rights, privacy, derivatives, retention, and takedown.

## Changes

- add `docs/SUBMISSION_WORKFLOW.md`
- add `docs/MEDIA_POLICY.md`

## Out of scope

- application and API implementation
- final encryption and token-transport design
- database migrations
- final asynchronous image-processing provider
- public legal terms text

## Completion criteria

- [x] Submissions never update canonical public records automatically.
- [x] Partial approval, requests for information, and time-bounded holds are defined.
- [x] Evidence media, ownership proof, and public-gallery candidates are separate purposes.
- [x] Rights, privacy review, retention, deletion, and takedown behavior are defined.
- [x] Publication success is required before a submitter is told that an approved change is public.
- [x] Secret status access exposes no private review data.

## Important policy decisions

- original submission payloads remain immutable
- submitted, normalized, and canonical values remain distinct
- each proposed field can be approved, rejected, or held
- ordinary failure reports do not automatically end a claim
- submission resolution and media resolution are independent
- all uploads enter private quarantine
- public derivatives are re-encoded, metadata-stripped, and stored separately from originals
- public gallery permission does not apply automatically to evidence or ownership proof

## Publication, privacy, and integrity

- [x] No public account is required for the MVP.
- [x] Contact, transaction, ownership, and original-media data remain private.
- [x] Candidate outcomes remain private.
- [x] Rights and privacy issues may temporarily hide media without changing claim status.
- [x] Private originals can never be used as public fallback URLs.

## Public impact

Documentation only. These workflows become public-facing contracts when the contribution and media systems are implemented.

## Rollback

Revert the P0-06 documentation commits.