### PR TITLE
P0-07: Define technical, UX, security, and privacy architecture

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -29,8 +29,8 @@ This document tracks public, repository-level implementation work. It is not the
 | P0-03 | Information architecture | Completed | P0-02 | [#4](https://github.com/badjoke-lab/cryptopaymap/pull/4) |
 | P0-04 | Data architecture | Completed | P0-02 | [#5](https://github.com/badjoke-lab/cryptopaymap/pull/5) |
 | P0-05 | Verification, sources, and licenses | Completed | P0-04 | [#6](https://github.com/badjoke-lab/cryptopaymap/pull/6) |
-| P0-06 | Submission and media policies | In progress | P0-04, P0-05 | [#7](https://github.com/badjoke-lab/cryptopaymap/pull/7) |
-| P0-07 | Technical, UX, security, and privacy architecture | Planned | P0-03, P0-04 | — |
+| P0-06 | Submission and media policies | Completed | P0-04, P0-05 | [#7](https://github.com/badjoke-lab/cryptopaymap/pull/7) |
+| P0-07 | Technical, UX, security, and privacy architecture | In progress | P0-03, P0-04 | [#8](https://github.com/badjoke-lab/cryptopaymap/pull/8) |
 | P0-08 | Operations, migration, launch, and public roadmap | Planned | P0-03 through P0-07 | — |
 
 ### P0-01 — Development control

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -9,11 +9,11 @@ Phase 0 — Public specifications and development control
 
 ## Current implementation item
 
-`P0-06 — Submission and media policies`
+`P0-07 — Technical, UX, security, and privacy architecture`
 
 ## Active pull request
 
-[#7 — P0-06: Define submission and media policies](https://github.com/badjoke-lab/cryptopaymap/pull/7)
+[#8 — P0-07: Define technical, UX, security, and privacy architecture](https://github.com/badjoke-lab/cryptopaymap/pull/8)
 
 ## Latest completed work
 
@@ -24,17 +24,18 @@ Phase 0 — Public specifications and development control
 - `P0-03 — Information architecture` completed through [pull request #4](https://github.com/badjoke-lab/cryptopaymap/pull/4), merged as `09b9807`.
 - `P0-04 — Data architecture` completed through [pull request #5](https://github.com/badjoke-lab/cryptopaymap/pull/5), merged as `6e7392d`.
 - `P0-05 — Verification, sources, and licenses` completed through [pull request #6](https://github.com/badjoke-lab/cryptopaymap/pull/6), merged as `a7b475b`.
+- `P0-06 — Submission and media policies` completed through [pull request #7](https://github.com/badjoke-lab/cryptopaymap/pull/7), merged as `f3a8076`.
 
 ## Current deliverables
 
-- `docs/SUBMISSION_WORKFLOW.md`
-- `docs/MEDIA_POLICY.md`
+- `docs/TECH_ARCHITECTURE.md`
+- `docs/SECURITY_AND_PRIVACY.md`
 
 ## Next
 
-1. Review and merge pull request #7 when its completion criteria are satisfied.
-2. Mark P0-06 completed in `docs/IMPLEMENTATION_PLAN.md`.
-3. Start `P0-07 — Technical, UX, security, and privacy architecture`.
+1. Review and merge pull request #8 when its completion criteria are satisfied.
+2. Mark P0-07 completed in `docs/IMPLEMENTATION_PLAN.md`.
+3. Start `P0-08 — Operations, migration, launch, and public roadmap`.
 
 ## Blocked
 

--- a/docs/SECURITY_AND_PRIVACY.md
+++ b/docs/SECURITY_AND_PRIVACY.md
@@ -1,0 +1,1023 @@
+# CryptoPayMap security and privacy architecture
+
+## Purpose
+
+This document defines the security and privacy controls for CryptoPayMap's public site, administration, submissions, private status access, operational database, public exports, media storage, analytics, logging, deployment, and incident response.
+
+Security requirements are guided by applicable OWASP Application Security Verification Standard categories and by the documented behavior of the selected infrastructure. Implementation details may evolve, but the trust boundaries and privacy invariants in this document remain mandatory.
+
+---
+
+## 1. Security principles
+
+1. **Public by projection, not by default.** Operational tables and object stores are private unless an explicit reviewed public projection or derivative exists.
+2. **Least privilege.** Every Worker, workflow, token, upload authorization, administrator, and storage binding receives only the permissions it needs.
+3. **Server-side authorization.** Client-side route hiding and UI state are never trusted as access control.
+4. **Validate at every trust boundary.** Browser, API, database, object storage, import, and public export boundaries each enforce their own validation.
+5. **Fail closed.** Missing authorization, invalid evidence, failed export, failed media processing, or unclear visibility prevents publication.
+6. **Minimize sensitive data.** Do not collect information that is unnecessary for verification, contribution, security, or lawful operation.
+7. **Separate secrets from identifiers.** Public IDs, internal UUIDs, status secrets, credentials, and signed URLs are distinct values.
+8. **Private proof supports conclusions without becoming public.** Evidence, contacts, receipts, ownership proof, and originals remain restricted.
+9. **Preserve the last valid public state.** Operational failure does not replace valid public artifacts with partial or invalid output.
+10. **Audit material decisions.** Authentication, authorization failure, canonical changes, verification changes, publication, and media decisions create safe audit events.
+
+---
+
+## 2. Data classification
+
+### 2.1 Public
+
+Examples:
+
+- confirmed, stale, or ended public acceptance claims;
+- approved public place and service details;
+- public evidence summaries and source links;
+- public verification history;
+- approved public media derivatives;
+- public registries, statistics, updates, roadmap, and changelog;
+- required attribution and license metadata.
+
+### 2.2 Internal
+
+Examples:
+
+- source candidates;
+- review queues;
+- normalized proposals;
+- reviewer decisions not intended for publication;
+- audit history;
+- publication failure summaries;
+- operational metrics;
+- duplicate groups;
+- internal identifiers.
+
+### 2.3 Restricted
+
+Examples:
+
+- submission contacts;
+- private transaction URLs;
+- receipts;
+- wallet addresses supplied as evidence;
+- ownership-verification material;
+- private correspondence;
+- private evidence images;
+- quarantine originals;
+- private signed URLs;
+- status-token hashes;
+- abuse-control signals;
+- database credentials and infrastructure secrets.
+
+### 2.4 Secret
+
+Examples:
+
+- database connection strings;
+- API tokens;
+- Cloudflare Access service credentials;
+- Turnstile secret keys;
+- R2 credentials;
+- encryption keys;
+- signing keys;
+- deployment credentials;
+- plaintext submission-status secrets before delivery.
+
+Secret values are never stored in the repository, public artifacts, browser bundles, analytics, ordinary logs, or support documentation.
+
+---
+
+## 3. Threat model
+
+The architecture considers at least these threats:
+
+- unauthorized access to administration;
+- privilege escalation;
+- submission spam and automated abuse;
+- forged Turnstile responses;
+- status-link enumeration or token leakage;
+- cross-site scripting;
+- cross-site request forgery;
+- SQL injection;
+- server-side request forgery through evidence URLs;
+- unsafe redirects;
+- malicious or disguised media uploads;
+- decompression bombs and resource exhaustion;
+- private object exposure;
+- public-export leakage;
+- log leakage;
+- secret leakage through commits or builds;
+- denial of service;
+- duplicate or replayed mutations;
+- poisoned imports;
+- dependency compromise;
+- incorrect ownership claims;
+- unauthorized media publication;
+- cache or CDN persistence after takedown;
+- accidental exposure through preview environments;
+- stale offline payment information presented as current.
+
+Security review is repeated when a new trust boundary, data class, external provider, or public mutation path is added.
+
+---
+
+## 4. Trust boundaries
+
+```text
+Untrusted browser input
+→ public edge and API validation
+→ application authorization and domain validation
+→ operational database or private object storage
+→ reviewed canonical transaction
+→ public projection validation
+→ public artifact or derivative
+```
+
+### 4.1 Browser
+
+The browser is untrusted. Client validation, hidden controls, and application state can be modified by the user.
+
+### 4.2 Public edge
+
+Cloudflare provides TLS termination, request controls, rate limiting where configured, Turnstile integration, and route separation. Application validation remains required.
+
+### 4.3 Worker or server code
+
+Workers and Functions enforce:
+
+- authentication and authorization;
+- request validation;
+- domain invariants;
+- object-key scope;
+- rate limits and idempotency;
+- safe database and storage access;
+- minimal responses.
+
+### 4.4 Database
+
+The database is the operational source of truth, not a public API. Access is limited to approved server-side environments and workflows.
+
+### 4.5 Object storage
+
+Private and public objects use separate buckets or clearly separated access policies. Private originals cannot become public by changing only a URL.
+
+### 4.6 Public build and exports
+
+Build and export processes receive only the data required for public projection. They do not serialize operational tables directly.
+
+---
+
+## 5. Administration security
+
+### 5.1 Cloudflare Access
+
+Administration routes and APIs are protected by a Cloudflare Access application or an equivalent identity-aware control.
+
+Requirements:
+
+- default deny;
+- explicit allow policy;
+- server-side validation of Access assertions;
+- issuer and audience validation;
+- token expiration validation;
+- trusted identity extraction only after signature verification;
+- no reliance on an unverified email header;
+- protected API routes as well as protected pages.
+
+### 5.2 Authorization
+
+Initial administration may use one broad operator role, but route and action checks remain explicit so later roles can be introduced.
+
+Potential future scopes:
+
+- candidate review;
+- evidence review;
+- media review;
+- ownership verification;
+- publication;
+- audit read;
+- security administration.
+
+High-impact actions such as publication, mass changes, or rights removal may require a separate confirmation step.
+
+### 5.3 Session handling
+
+- use Secure, HttpOnly, and appropriate SameSite cookie settings where application cookies are needed;
+- do not place administrator tokens in local storage;
+- set bounded session lifetime;
+- require reauthentication or equivalent confirmation for sensitive configuration changes where appropriate;
+- clear session state on logout;
+- prevent sensitive pages from being cached publicly.
+
+### 5.4 Administration responses
+
+Administration endpoints return only fields required by the current view. They do not expose complete private tables through generic query endpoints.
+
+---
+
+## 6. Public submission protection
+
+### 6.1 Turnstile
+
+Turnstile is a bot-abuse signal, not authorization or factual verification.
+
+Requirements:
+
+- validate every token on the server through Siteverify;
+- reject missing, expired, failed, or replayed tokens;
+- validate expected hostname and action values where configured;
+- keep the secret key server-side;
+- handle challenge failure accessibly;
+- do not treat a successful token as evidence that content is trustworthy.
+
+### 6.2 Rate limits
+
+Rate limits may consider:
+
+- route;
+- submission type;
+- public target;
+- recent duplicate hashes;
+- validated client and edge signals;
+- upload authorization count;
+- failed status-token attempts.
+
+Rate-limit responses reveal no private record existence.
+
+### 6.3 Idempotency
+
+Mutating endpoints use an idempotency key or equivalent replay control when repeated requests could create duplicate submissions, events, publication runs, or media objects.
+
+An idempotency key is scoped to the authenticated or public operation and expires after a bounded period.
+
+### 6.4 Input limits
+
+Every request defines:
+
+- maximum body size;
+- maximum field length;
+- maximum collection size;
+- supported content type;
+- supported URL scheme;
+- accepted registry values;
+- date and coordinate bounds;
+- file count and size limits.
+
+Unexpected fields are rejected or ignored according to an explicit schema, never merged blindly into canonical objects.
+
+---
+
+## 7. Submission status security
+
+### 7.1 Public reference and secret
+
+A submission status record uses:
+
+- an opaque public reference;
+- a high-entropy secret;
+- a stored one-way token hash;
+- constant-time comparison where applicable;
+- rate limiting;
+- token rotation or revocation support.
+
+The public reference alone reveals no useful private status.
+
+### 7.2 Token transport
+
+Sensitive status secrets are not placed in analytics events, logs, support screenshots, referrer-bearing third-party links, or page titles.
+
+Where a secret is transported in a URL for initial usability:
+
+- the page immediately establishes an appropriate short-lived session or otherwise minimizes continued URL exposure;
+- Referrer-Policy prevents leakage;
+- the page uses no-store behavior;
+- third-party resources are minimized or excluded;
+- the secret is removed from the visible URL where practical.
+
+### 7.3 Status projection
+
+The status API returns a purpose-built safe projection containing only:
+
+- public reference;
+- public-facing workflow state;
+- requested action;
+- public hold or resolution reason;
+- linked public record after successful publication;
+- media decisions belonging to the same submission;
+- permitted response actions.
+
+It never returns internal notes, priority, reviewer identity, abuse signals, other submissions, raw ownership proof, or private evidence.
+
+### 7.4 Recovery
+
+Token recovery requires a verified contact path where one exists. The system does not provide a public lookup by email, business name, or reference alone.
+
+---
+
+## 8. Request validation and output encoding
+
+### 8.1 Shared schemas
+
+Zod or an equivalent schema layer validates:
+
+- request shape;
+- field types;
+- controlled values;
+- normalized URLs;
+- dates;
+- coordinates;
+- identifiers;
+- file metadata;
+- public response projections.
+
+Server validation is authoritative.
+
+### 8.2 Canonicalization
+
+Normalize before duplicate and policy comparison:
+
+- Unicode and whitespace where appropriate;
+- asset and network aliases;
+- country codes;
+- URLs and hostnames;
+- business names for matching only;
+- coordinates within documented precision;
+- media MIME type after file inspection.
+
+Canonicalization does not silently change user meaning. Original input remains available for review.
+
+### 8.3 HTML and rich text
+
+User-submitted fields are plain text unless a field explicitly supports a reviewed markup subset.
+
+- never render untrusted HTML directly;
+- escape output according to context;
+- sanitize allowed markup on the server;
+- disallow scriptable URL schemes;
+- validate externally supplied links;
+- use safe link attributes where new browsing context is opened.
+
+### 8.4 Redirects and navigation
+
+Redirect destinations and programmatic navigation use allowlisted internal routes or validated absolute URLs. User input is never passed directly to a redirect or Astro `navigate()` call.
+
+---
+
+## 9. Database security
+
+### 9.1 Query safety
+
+- use parameterized queries;
+- avoid string-built SQL from user input;
+- review raw SQL;
+- use transactions for canonical changes;
+- enforce foreign keys and constraints;
+- use least-privilege database roles when supported;
+- separate migration and runtime permissions where practical.
+
+### 9.2 Connection secrets
+
+Database credentials are runtime secrets or bindings. They do not appear in:
+
+- `.env` files committed to Git;
+- static builds;
+- client-side environment variables;
+- error pages;
+- public CI logs;
+- documentation examples using real values.
+
+### 9.3 Sensitive columns
+
+Sensitive values use appropriate protection:
+
+- email encrypted at rest in the application data model;
+- normalized email hash for duplicate or abuse control;
+- status secrets hashed;
+- internal notes excluded from public projections;
+- storage keys restricted;
+- private payload access limited to required operations.
+
+### 9.4 Transactions
+
+A canonical review transaction includes all required domain changes and audit events. Partial failure rolls back.
+
+Publication is a separate validated state. A committed canonical change does not falsely imply public release.
+
+### 9.5 Backup security
+
+Backups are encrypted and access-controlled. Restore testing uses restricted environments and does not copy production personal data into public previews.
+
+---
+
+## 10. URL and server-side request forgery protection
+
+Evidence URLs and official-site URLs are untrusted input.
+
+### 10.1 Accepted schemes
+
+Initial public links allow `https` and, only where explicitly justified, `http` for legacy public sources.
+
+The system rejects:
+
+- `file:`;
+- `javascript:`;
+- `data:` where not explicitly required;
+- `ftp:`;
+- local application schemes;
+- embedded credentials;
+- malformed hostnames.
+
+### 10.2 Server fetching
+
+If the system fetches a submitted URL:
+
+- resolve DNS safely;
+- block loopback, link-local, private, multicast, and metadata-service address ranges;
+- repeat checks after redirects and DNS resolution;
+- limit redirects;
+- set connect and response timeouts;
+- limit response size;
+- restrict content types;
+- avoid sending internal credentials or cookies;
+- use a dedicated outbound fetch path;
+- record a safe error rather than response bodies containing secrets.
+
+### 10.3 Archive services
+
+Private and restricted URLs are never sent to public archive services.
+
+---
+
+## 11. Media upload security
+
+### 11.1 Presigned upload authorization
+
+Presigned R2 URLs or equivalent upload grants are bearer credentials.
+
+Requirements:
+
+- generate them on the server;
+- grant one operation on one randomized object path;
+- use short expiration;
+- limit expected size and type through application controls;
+- associate the object with one submission and purpose;
+- never expose R2 API credentials;
+- validate the resulting object before review;
+- do not treat successful upload as approval.
+
+### 11.2 File validation
+
+- verify magic bytes;
+- decode with a supported image library;
+- reject disguised or active content;
+- bound pixel count and decompression;
+- compute cryptographic hash;
+- use duplicate and known-rejection controls;
+- normalize orientation;
+- re-encode public derivatives;
+- remove metadata and GPS;
+- scan or inspect according to the implemented media threat model.
+
+### 11.3 Storage separation
+
+- originals and evidence remain in private quarantine;
+- public derivatives use a separate public path or bucket;
+- public code never falls back to a private original;
+- private signed GET URLs are short-lived and no-store;
+- public object keys do not expose private identifiers or filenames.
+
+### 11.4 Deletion
+
+Deletion jobs are idempotent, audited, and verify object removal. Public cache invalidation is part of takedown handling.
+
+---
+
+## 12. Public export security
+
+### 12.1 Explicit projections
+
+Public data is generated from named public projections. Operational tables are never serialized directly.
+
+### 12.2 Leakage validation
+
+Exports fail when they contain or resemble prohibited fields, including:
+
+- email or contact fields;
+- IP addresses;
+- status-token hashes or secrets;
+- private transaction URLs;
+- wallet addresses supplied privately;
+- receipt data;
+- ownership proof;
+- internal notes;
+- private storage keys;
+- audit payloads;
+- source-candidate priority;
+- private queue state.
+
+Validation uses both schema allowlists and targeted deny checks.
+
+### 12.3 Eligibility validation
+
+Exports include only records that satisfy:
+
+- eligible canonical state;
+- public visibility;
+- publishable identity and scope;
+- required asset, network, route, method, instructions, evidence, and date;
+- provenance and license requirements;
+- public media approval where media is included.
+
+### 12.4 Atomic publication
+
+Artifacts are generated to a temporary versioned location, validated, hashed, and only then promoted as current.
+
+A failed run leaves the previous public version unchanged.
+
+---
+
+## 13. Cross-site request forgery and browser security
+
+### 13.1 CSRF
+
+State-changing authenticated requests use appropriate protections:
+
+- SameSite cookies;
+- anti-CSRF token where cookie-based authentication requires it;
+- Origin and Referer checks where appropriate;
+- no state changes through GET;
+- explicit content types;
+- reauthentication or confirmation for high-impact actions.
+
+### 13.2 CORS
+
+CORS is deny-by-default.
+
+- public read files may allow documented cross-origin GET access;
+- mutation APIs allow only approved origins;
+- credentials are never combined with wildcard origin;
+- presigned upload CORS allows only required methods, headers, and origins.
+
+### 13.3 Security headers
+
+Public and private responses apply an appropriate baseline:
+
+- Content-Security-Policy;
+- Referrer-Policy;
+- X-Content-Type-Options;
+- frame-ancestors through CSP;
+- Permissions-Policy;
+- Strict-Transport-Security on production HTTPS;
+- restrictive cache headers for private routes.
+
+The exact CSP is tested with MapLibre workers, media, analytics, Turnstile, and application assets. Broad `unsafe-inline` or wildcard sources are avoided where practical.
+
+### 13.4 Clickjacking
+
+Administration, status pages, and sensitive contribution responses deny framing. Public pages allow framing only if an explicit product need is approved.
+
+---
+
+## 14. Secrets management
+
+### 14.1 Storage
+
+Secrets are stored in approved Cloudflare, GitHub, and database secret facilities.
+
+### 14.2 Scope
+
+Separate secrets by:
+
+- environment;
+- service;
+- purpose;
+- read or write capability.
+
+Preview environments do not receive production mutation or private-data credentials unless explicitly approved.
+
+### 14.3 Rotation
+
+Secrets have an owner, purpose, creation date, and rotation or revocation procedure.
+
+Rotate immediately after suspected exposure, collaborator removal, provider compromise, or accidental logging.
+
+### 14.4 Repository controls
+
+- `.env*` files are ignored except safe examples;
+- examples contain placeholders;
+- CI scans for common secret formats after the code foundation exists;
+- commit history is treated as exposed if a secret is committed, even after file deletion;
+- response is rotate first, then remove and investigate.
+
+---
+
+## 15. Logging and audit
+
+### 15.1 Security events
+
+Log safe structured events for:
+
+- successful and failed administrator authentication where available;
+- authorization failures;
+- input validation failures by error code;
+- rate-limit and Turnstile failures;
+- status-token failures without logging the token;
+- canonical state changes;
+- ownership decisions;
+- media approvals, rejections, and deletions;
+- publication success and failure;
+- secret or configuration changes;
+- backup and restore operations.
+
+### 15.2 Prohibited log content
+
+Do not log:
+
+- passwords or private keys;
+- access tokens;
+- status secrets;
+- signed URLs;
+- full email addresses where not necessary;
+- raw submission bodies;
+- receipts;
+- transaction URLs;
+- wallet addresses supplied privately;
+- ownership proof;
+- database credentials;
+- unredacted private storage keys.
+
+### 15.3 Log integrity
+
+- restrict log access;
+- use timestamps and correlation IDs;
+- protect logs against casual modification;
+- define retention;
+- avoid exposing detailed internal errors to users;
+- keep public error messages safe and actionable.
+
+---
+
+## 16. Privacy data inventory
+
+### 16.1 Data collected by public browsing
+
+Minimize to ordinary delivery and aggregate analytics data required to serve and protect the site.
+
+CryptoPayMap does not create a persistent user profile for ordinary public browsing in the MVP.
+
+### 16.2 Browser geolocation
+
+Geolocation is requested only after a user action.
+
+- used in the browser to center or assist local discovery where practical;
+- not required for manual search;
+- not stored as a precise location history;
+- not included in analytics;
+- not attached to submissions unless the user intentionally selects a public business location.
+
+### 16.3 Search analytics
+
+Approved structured search-demand data may include:
+
+- canonical country;
+- canonical city;
+- asset;
+- network;
+- category;
+- result-count bucket;
+- date.
+
+Do not retain for analytics:
+
+- raw coordinates;
+- exact current location;
+- full free-text query;
+- persistent device ID;
+- private submission reference;
+- status token.
+
+### 16.4 Submission data
+
+Submission data may include:
+
+- factual business and payment details;
+- evidence URLs;
+- optional contact;
+- private payment evidence;
+- media;
+- relationship disclosure;
+- ownership-verification material.
+
+Each category has a purpose, visibility, retention, and deletion path.
+
+---
+
+## 17. Privacy minimization
+
+### 17.1 Do not request
+
+Ordinary payment reports do not request:
+
+- legal name;
+- payment amount;
+- wallet address;
+- private key or seed phrase;
+- full transaction history;
+- government identity document;
+- unrelated account credentials.
+
+### 17.2 Evidence redaction
+
+Forms and help text instruct submitters to remove unnecessary:
+
+- names;
+- addresses;
+- wallet identifiers;
+- balances;
+- transaction history;
+- order details;
+- device information.
+
+Review tools support redacted public summaries and derivatives.
+
+### 17.3 Purpose limitation
+
+Data collected for verification, abuse prevention, rights review, or contact is not repurposed for advertising profiles or sold as personal data.
+
+---
+
+## 18. Retention and deletion
+
+### 18.1 Default principles
+
+- retain only while needed for the documented purpose;
+- assign deletion dates to temporary restricted data;
+- separate object deletion from limited audit metadata;
+- review retention extensions;
+- make deletion jobs idempotent and auditable.
+
+### 18.2 Media
+
+Media retention follows `MEDIA_POLICY.md`.
+
+### 18.3 Contacts
+
+Submission contacts are deleted or anonymized after the follow-up and dispute period unless a documented continuing purpose applies.
+
+The exact period is configured and disclosed before public submission launch.
+
+### 18.4 Status secrets
+
+Expired or closed status access may be revoked after the disclosed follow-up period. The hash may be deleted when no longer required.
+
+### 18.5 Analytics
+
+Structured internal search-demand events are retained for a limited period, initially no more than 90 days, after which only aggregate rollups remain.
+
+### 18.6 Deletion requests
+
+A deletion request evaluates:
+
+- identity and authority;
+- requested data category;
+- public factual record versus personal source material;
+- legal or audit retention;
+- active dispute;
+- public caches and derivatives;
+- downstream processors under project control.
+
+Removing personal evidence does not automatically remove a separately verified public fact.
+
+---
+
+## 19. Analytics and third parties
+
+### 19.1 Cloudflare Web Analytics
+
+Use privacy-conscious aggregate analytics without building cross-site user profiles.
+
+### 19.2 Third-party scripts
+
+Third-party scripts require review for:
+
+- necessity;
+- data collected;
+- cookies or identifiers;
+- Content Security Policy impact;
+- privacy disclosure;
+- failure behavior;
+- availability and performance.
+
+Avoid third-party scripts on secret status and administration pages unless strictly required and explicitly reviewed.
+
+### 19.3 Advertising and sponsorship
+
+Future sponsorship or advertising integrations cannot receive private submissions, precise location history, ownership proof, or administrator data.
+
+Commercial relationships do not affect verification.
+
+---
+
+## 20. Preview and development environments
+
+- use synthetic or sanitized data;
+- do not copy production restricted records by default;
+- protect non-public previews;
+- use separate secrets and buckets;
+- prevent search indexing;
+- expire preview deployments where practical;
+- avoid placing status secrets in test fixtures;
+- ensure test analytics do not contaminate production data.
+
+---
+
+## 21. Dependency and supply-chain security
+
+- use a lockfile;
+- review dependency ownership and maintenance;
+- enable dependency vulnerability reporting after foundation setup;
+- pin GitHub Actions to reviewed versions or commit SHAs according to repository policy;
+- minimize workflow permissions;
+- use read-only permissions by default;
+- separate build from production publication credentials;
+- review install scripts and native dependencies;
+- generate or retain a software bill of materials when the project reaches release readiness;
+- remove abandoned or unused packages.
+
+A compromised dependency is treated as a security incident even when no direct exploit is confirmed.
+
+---
+
+## 22. CI and deployment security
+
+### 22.1 Pull requests
+
+Untrusted pull-request code does not receive production secrets.
+
+### 22.2 Workflow permissions
+
+Workflows declare minimal permissions. Write access is enabled only for the step or workflow that requires it.
+
+### 22.3 Publication
+
+Production publication requires:
+
+- reviewed main commit;
+- successful checks;
+- valid artifact or export;
+- environment-scoped credentials;
+- auditable publication event.
+
+### 22.4 Build output
+
+The build is scanned or inspected to ensure it contains no:
+
+- server secrets;
+- private environment files;
+- restricted data fixtures;
+- source maps containing secrets;
+- private media;
+- operational database dumps.
+
+---
+
+## 23. Availability and abuse resilience
+
+- bounded request and upload sizes;
+- timeouts;
+- rate limits;
+- cacheable public data;
+- previous valid public snapshot;
+- background or queued heavy work;
+- circuit breaking where external services fail;
+- no unlimited retry loops;
+- controlled batch sizes;
+- database indexes for public and review queries;
+- separate public browsing from administration and publication load.
+
+The public site should continue serving the last valid public data during temporary database or review-system failure.
+
+---
+
+## 24. Backup and recovery
+
+Backups cover:
+
+- canonical database;
+- migrations;
+- public artifacts;
+- media metadata;
+- required private objects while within retention;
+- configuration needed for recovery without exposing secrets in documentation.
+
+Recovery procedures verify:
+
+- backup integrity;
+- restoration into a restricted environment;
+- publication from restored canonical data;
+- no accidental resurrection of deleted private objects;
+- correct secret rotation after recovery where needed.
+
+---
+
+## 25. Incident response
+
+### 25.1 Incident categories
+
+- secret exposure;
+- unauthorized administration access;
+- public private-data leak;
+- malicious media exposure;
+- compromised dependency;
+- database corruption;
+- false publication;
+- rights or privacy takedown failure;
+- denial of service;
+- lost or exposed status-token set.
+
+### 25.2 Immediate actions
+
+Depending on incident:
+
+- revoke or rotate secrets;
+- disable affected route or workflow;
+- temporarily hide affected public records or media;
+- preserve safe audit evidence;
+- stop publication;
+- restore previous public snapshot;
+- isolate compromised credentials or environment;
+- invalidate signed URLs and caches;
+- assess affected data and users.
+
+### 25.3 Recovery
+
+- fix root cause;
+- validate corrected controls;
+- restore safe service;
+- review related records;
+- document technical timeline and actions;
+- determine notification and disclosure obligations;
+- add regression tests or monitoring.
+
+Public incident communication contains verified facts and avoids exposing secrets, attack details that create immediate risk, or private user information.
+
+---
+
+## 26. Security testing
+
+Security checks expand with implementation.
+
+### 26.1 Automated
+
+- dependency scanning;
+- secret scanning;
+- lint and type checks;
+- unit tests for authorization and state transitions;
+- schema and public-leakage tests;
+- upload validation fixtures;
+- redirect and URL validation tests;
+- security-header checks;
+- public build inspection.
+
+### 26.2 Manual
+
+- administrator access bypass attempts;
+- IDOR review;
+- status-token enumeration and leakage review;
+- CSRF review;
+- XSS and unsafe URL review;
+- SSRF review;
+- upload polyglot and decompression review;
+- public-export privacy review;
+- browser back and cache behavior on private pages;
+- takedown and cache invalidation;
+- backup restoration.
+
+### 26.3 Release gate
+
+High-severity unresolved security or privacy defects block production launch.
+
+---
+
+## 27. Security and privacy checklist
+
+Before production launch, verify:
+
+- [ ] Administration pages and APIs require validated Access authorization.
+- [ ] Turnstile is validated server-side.
+- [ ] Rate limits and idempotency cover public mutations.
+- [ ] Status references cannot be enumerated into useful private data.
+- [ ] Status secrets are not stored in plaintext or leaked through logs and analytics.
+- [ ] Input schemas, URL validation, output encoding, and redirect allowlists are implemented.
+- [ ] Database queries are parameterized and credentials are server-side only.
+- [ ] Evidence fetching blocks private and metadata address ranges.
+- [ ] Upload URLs are short-lived and single-object scoped.
+- [ ] Private originals and approved public derivatives are separated.
+- [ ] Public exports pass schema, privacy, provenance, and license checks.
+- [ ] Security headers and CORS are tested.
+- [ ] Logs omit restricted content and record security-relevant events safely.
+- [ ] Browser geolocation is optional and not stored as precise history.
+- [ ] Retention and deletion jobs are operational.
+- [ ] Preview environments use isolated secrets and sanitized data.
+- [ ] CI workflows use least privilege and untrusted code receives no production secrets.
+- [ ] Backups can be restored without resurrecting deleted restricted data.
+- [ ] Incident rollback and previous-public-snapshot recovery are tested.

--- a/docs/TECH_ARCHITECTURE.md
+++ b/docs/TECH_ARCHITECTURE.md
@@ -1,0 +1,972 @@
+# CryptoPayMap technical architecture
+
+## Purpose
+
+This document defines the technical boundaries for CryptoPayMap's public site, interactive application surfaces, public data delivery, administration, submissions, media processing, state management, testing, deployment, accessibility, performance, and future scaling.
+
+The architecture is designed to provide application-quality mobile interaction without turning every page into a large single-page application.
+
+---
+
+## 1. Architecture goals
+
+1. Deliver a fast, indexable public site.
+2. Treat Places, contribution flows, and administration as coordinated application experiences.
+3. Keep public browsing available from generated public data even when the operational database is unavailable.
+4. Separate source candidates, operational canonical data, and public projections.
+5. Preserve browser navigation, shareable URLs, and accessibility.
+6. Avoid unnecessary client-side JavaScript outside interactive surfaces.
+7. Keep infrastructure and processing components replaceable.
+8. Fail closed when public-data, privacy, or publication validation fails.
+9. Support a small initial dataset without blocking future region, viewport, or tile-based delivery.
+10. Keep secrets and private records out of public builds and browser bundles.
+
+---
+
+## 2. System overview
+
+```text
+Public browser
+├─ Astro-rendered pages
+├─ React application areas
+├─ MapLibre GL JS
+└─ Generated public JSON / GeoJSON
+
+Cloudflare
+├─ static site hosting and edge cache
+├─ Workers or Functions APIs
+├─ Access for administration
+├─ Turnstile for public submissions
+├─ private and public R2 media storage
+└─ Web Analytics
+
+Neon Postgres
+├─ source and candidate layer
+├─ canonical records
+├─ evidence and verification history
+├─ submissions and private contacts
+├─ media metadata
+├─ audit history
+└─ publication runs
+
+GitHub Actions
+├─ checks
+├─ schema and public-export validation
+├─ build
+├─ controlled publication support
+└─ scheduled maintenance workflows where approved
+```
+
+---
+
+## 3. Web application structure
+
+### 3.1 Astro responsibilities
+
+Astro is the page and content framework for:
+
+- Home;
+- About;
+- Methodology;
+- Sources and Licenses;
+- Data;
+- Stats initial HTML;
+- Updates;
+- Roadmap;
+- Changelog;
+- Support;
+- Partners;
+- legal and contact pages;
+- generated asset, network, category, country, and city pages;
+- initial HTML for place and service detail pages.
+
+These pages are statically generated where practical.
+
+### 3.2 React responsibilities
+
+React is used for cohesive interactive application areas:
+
+- `PlacesApp`;
+- Online Services explorer where interaction justifies it;
+- contribution forms;
+- secret submission-status interaction;
+- administration and review;
+- media upload and review;
+- advanced Stats interactions.
+
+React is not added to a page solely for static presentation.
+
+### 3.3 Places as one application area
+
+The `/places` discovery surface is one coordinated React application boundary:
+
+```text
+PlacesApp
+├─ search
+├─ filters
+├─ map
+├─ result list
+├─ selected place
+├─ desktop detail panel
+├─ mobile bottom sheet
+├─ URL synchronization
+├─ loading, empty, and error states
+├─ toasts
+└─ browser-history integration
+```
+
+Map, list, filters, selected place, and bottom sheet are not implemented as unrelated independently hydrated islands. They share one state contract and one selection lifecycle.
+
+### 3.4 Page transitions
+
+Astro page navigation may use `ClientRouter` and browser-native view transitions where they improve continuity.
+
+Requirements:
+
+- normal browser navigation remains the baseline;
+- transitions never block navigation;
+- browser forward and back remain correct;
+- reduced-motion preferences disable nonessential animation;
+- forms or links that require full navigation can opt out;
+- URL values passed to programmatic navigation are validated by application code.
+
+React application-state animation is handled separately from document navigation.
+
+---
+
+## 4. State ownership
+
+State is assigned by responsibility.
+
+### 4.1 Server state — TanStack Query
+
+Use for:
+
+- API responses;
+- private administration queries;
+- submission-status responses;
+- controlled retries;
+- cache invalidation;
+- mutation status;
+- background refresh where appropriate.
+
+Generated public JSON loaded once for static pages does not require TanStack Query by default.
+
+### 4.2 Shared client UI state — Zustand
+
+Use for coordinated application state such as:
+
+- selected place;
+- map/list presentation mode;
+- mobile bottom-sheet state;
+- temporary map viewport;
+- list scroll restoration;
+- non-shareable UI preferences within the current session.
+
+### 4.3 Shareable and restorable state — URL
+
+The URL owns state that users may share, bookmark, refresh, or restore through browser history:
+
+- search query;
+- asset;
+- network;
+- category;
+- payment route;
+- public status filter;
+- map/list mode;
+- selected public slug;
+- map center and zoom when useful.
+
+URL updates are bounded and avoid generating excessive browser-history entries during map movement.
+
+### 4.4 Local component state
+
+Use React local state for temporary values that do not need cross-component synchronization, such as:
+
+- one open disclosure;
+- local input focus;
+- an uncommitted form section;
+- a transient animation state.
+
+### 4.5 Persisted browser state
+
+Persist only low-risk presentation preferences.
+
+Do not persist:
+
+- exact browser geolocation history;
+- private status tokens;
+- private evidence URLs;
+- submission contacts;
+- ownership-proof state;
+- administration data.
+
+---
+
+## 5. Public data delivery
+
+### 5.1 Initial delivery model
+
+Public pages read generated, validated artifacts:
+
+```text
+/data/place-pins.json
+/data/places.json
+/data/places.geojson
+/data/online-services.json
+/data/stats.json
+/data/updates.json
+/data/assets.json
+/data/networks.json
+/data/manifest.json
+/version.json
+```
+
+The operational database is not queried on every public page request.
+
+### 5.2 Map payload strategy
+
+The first map request uses a compact pin projection containing only fields required to:
+
+- render clusters or markers;
+- identify public status;
+- show a small selection preview;
+- load the public place detail when selected.
+
+Large evidence collections, full histories, internal IDs, private metadata, and full media objects are excluded.
+
+### 5.3 Publication behavior
+
+```text
+canonical change
+→ publication run
+→ projection generation
+→ schema validation
+→ privacy and provenance validation
+→ artifact hashing
+→ release
+```
+
+A failed run:
+
+- does not replace the last valid snapshot;
+- does not expose partially generated files;
+- records a private failure summary;
+- does not tell a submitter that publication succeeded.
+
+### 5.4 Cache behavior
+
+- versioned assets may use long immutable caching;
+- current manifest and version files use shorter cache lifetimes;
+- publication changes invalidate affected edge cache entries;
+- private routes use no-store or appropriately restrictive caching;
+- signed media URLs are never cached as public assets.
+
+### 5.5 Scaling path
+
+The public-data access layer must allow later replacement with:
+
+- region-split JSON;
+- viewport APIs;
+- PMTiles;
+- vector tiles;
+- edge-cached query responses;
+- incremental publication.
+
+UI code consumes a data-access interface rather than assuming that all future records always arrive from one global file.
+
+---
+
+## 6. Mapping
+
+### 6.1 MapLibre GL JS
+
+MapLibre GL JS is the browser map renderer.
+
+Responsibilities:
+
+- vector-tile or compatible style rendering;
+- camera and interaction handling;
+- clusters and public markers;
+- selected-marker state;
+- accessible controls outside the canvas;
+- event integration with `PlacesApp`.
+
+### 6.2 Basemap and styles
+
+The basemap and style source must:
+
+- permit the intended use;
+- provide required attribution;
+- remain configurable outside application logic;
+- avoid embedding secret keys in the repository;
+- support a migration path to another compatible style provider.
+
+The initial plan may use OpenFreeMap or another approved compatible source, but the map-rendering contract does not depend on one commercial provider.
+
+### 6.3 Search this area
+
+Map movement updates temporary viewport state. It does not automatically replace the result set.
+
+The user activates **Search this area**, which:
+
+1. commits the visible bounds or center and zoom to the query state;
+2. requests or filters the applicable public data;
+3. preserves existing results while loading;
+4. updates the URL at a controlled point.
+
+### 6.4 Accessibility alternative
+
+Every public map result exists in an operable list. Essential actions are available without canvas interaction.
+
+---
+
+## 7. Mobile application experience
+
+### 7.1 Application shell
+
+Interactive mobile surfaces provide:
+
+- safe-area support;
+- persistent global navigation where appropriate;
+- touch-friendly controls;
+- clear page or application title;
+- predictable browser back behavior;
+- explicit loading, empty, error, and success states.
+
+### 7.2 Touch targets
+
+Interactive targets aim for at least 44 by 44 CSS pixels unless a larger surrounding target provides equivalent usability.
+
+### 7.3 Bottom sheet
+
+The Places bottom sheet supports:
+
+```text
+closed
+peek
+expanded
+```
+
+It must:
+
+- remain keyboard operable;
+- expose semantic dialog or region behavior appropriate to its state;
+- avoid trapping users when a full detail page is more appropriate;
+- respond to viewport and safe-area changes;
+- preserve selection through List / Map mode changes;
+- support reduced motion.
+
+### 7.4 Gesture policy
+
+Gestures supplement visible controls and never become the only way to:
+
+- close a sheet;
+- open details;
+- change List / Map mode;
+- submit a form;
+- navigate back.
+
+### 7.5 Offline and installation
+
+MVP includes:
+
+- Web App Manifest;
+- application name;
+- icons;
+- theme and background colors;
+- standalone display support;
+- valid start URL.
+
+The MVP does not promise broad offline acceptance data. Stale payment information must not be silently presented as current because it was cached offline.
+
+Later offline support may include only clearly dated application shell and recently viewed records with freshness warnings.
+
+---
+
+## 8. Motion and feedback
+
+### 8.1 Motion tokens
+
+```text
+instant  80 ms
+fast     140 ms
+normal   220 ms
+slow     320 ms
+```
+
+These are semantic starting points, not mandatory durations for every platform.
+
+### 8.2 Appropriate motion
+
+Use motion for:
+
+- button press feedback;
+- marker and card selection;
+- bottom-sheet transitions;
+- filter expansion;
+- result updates;
+- page continuity;
+- gallery navigation;
+- success or error feedback.
+
+### 8.3 Inappropriate motion
+
+Avoid:
+
+- continuously moving backgrounds;
+- long introductions;
+- map-obscuring animation;
+- excessive parallax;
+- animation that delays input;
+- full-screen fades for routine state changes.
+
+### 8.4 Reduced motion
+
+`prefers-reduced-motion` disables or minimizes nonessential motion while preserving understandable state changes.
+
+---
+
+## 9. Design system foundation
+
+### 9.1 Tokens
+
+Initial semantic tokens include:
+
+```text
+primary:          #0F766E
+primary-subtle:   #CCFBF1
+text-primary:     #0F172A
+status-confirmed: #059669
+status-stale:     #D97706
+status-ended:     #64748B
+status-error:     #DC2626
+```
+
+Tokens are represented through CSS custom properties so a later theme can be added without replacing component APIs.
+
+### 9.2 Typography and icons
+
+- system UI font stack;
+- Lucide icons;
+- icons supplement text and accessible labels rather than replacing them where meaning is unclear.
+
+### 9.3 Geometry
+
+```text
+card radius:   12 px
+button radius: 10 px
+pill radius:   999 px
+```
+
+### 9.4 Breakpoints
+
+Initial responsive breakpoints:
+
+```text
+640
+768
+1024
+1280
+```
+
+Components respond to available space rather than relying only on device labels.
+
+### 9.5 UI primitives
+
+The foundation includes:
+
+- typography;
+- buttons;
+- inputs;
+- selects and comboboxes;
+- chips;
+- cards;
+- dialogs;
+- bottom sheet;
+- popovers;
+- toasts;
+- skeletons;
+- empty and error states;
+- status badges;
+- responsive application shell;
+- gallery;
+- tabs;
+- form stepper.
+
+Radix Primitives may provide accessible behavior where appropriate. Public component APIs remain project-owned.
+
+### 9.6 Dark mode
+
+Dark mode is outside the MVP. Tokens must not prevent a later theme.
+
+---
+
+## 10. Forms
+
+### 10.1 Form stack
+
+- React Hook Form for interactive form state where useful;
+- Zod for shared request and domain validation;
+- server-side validation remains authoritative;
+- browser validation improves feedback but never replaces server validation.
+
+### 10.2 Multi-step forms
+
+Contribution forms may use steps when the sequence improves comprehension.
+
+Requirements:
+
+- preserve entered data across recoverable errors;
+- expose a clear current step;
+- allow safe back navigation;
+- summarize before submission;
+- do not submit partial canonical changes from the browser;
+- upload media through scoped private paths;
+- separate required payment facts from optional contact and media.
+
+### 10.3 Idempotency
+
+Mutating requests use an idempotency mechanism where duplicate submission would create harmful repeated records or uploads.
+
+---
+
+## 11. Administration
+
+### 11.1 Protection
+
+Administration is protected by Cloudflare Access or an equivalent identity-aware edge control.
+
+The MVP does not implement a separate public administrator-account system.
+
+### 11.2 Administration application
+
+The React administration application covers:
+
+- dashboard;
+- candidate queue;
+- claim editor;
+- evidence review;
+- rechecks;
+- submissions;
+- media;
+- publication runs;
+- audit history.
+
+### 11.3 Server trust boundary
+
+Administration authorization is checked by the server or trusted edge on every protected request. Hiding a route in the client is not authorization.
+
+### 11.4 Audit
+
+Material actions generate audit events with:
+
+- actor identity or trusted actor reference;
+- action;
+- target;
+- before and after values where appropriate;
+- timestamp;
+- correlation ID.
+
+---
+
+## 12. API boundaries
+
+### 12.1 Public read APIs
+
+The preferred public read path is generated data. Dynamic public APIs are added only when needed for scale or a documented product capability.
+
+### 12.2 Submission APIs
+
+Submission endpoints handle:
+
+- Turnstile validation;
+- rate limits;
+- safe parsing;
+- registry validation;
+- duplicate controls;
+- private contact encryption;
+- status-token generation and hashing;
+- immutable payload storage;
+- private upload authorization.
+
+### 12.3 Status APIs
+
+Status endpoints require the public reference and secret access mechanism. They return a minimal public-safe projection and never expose raw submission records.
+
+### 12.4 Administration APIs
+
+Administration APIs provide scoped operations rather than generic table access.
+
+Examples:
+
+- review candidate;
+- record evidence decision;
+- create proposed canonical diff;
+- resolve submission fields;
+- start publication run;
+- retry failed publication;
+- record media decision.
+
+### 12.5 Health and operational endpoints
+
+Health endpoints reveal only the minimum necessary operational status. They do not expose connection strings, detailed errors, record counts from private queues, or infrastructure secrets.
+
+---
+
+## 13. Database access
+
+### 13.1 Drizzle ORM
+
+Drizzle manages:
+
+- typed schema definitions;
+- typed queries;
+- reviewed migrations;
+- transaction boundaries.
+
+Complex reporting or migration work may use reviewed parameterized SQL where it is clearer or safer.
+
+### 13.2 Neon serverless driver
+
+Workers or other approved serverless runtimes connect to Neon through the serverless driver using HTTP for suitable one-shot operations and an approved transaction-capable path where interactive transactions require it.
+
+Client browsers never receive database credentials.
+
+### 13.3 Connection behavior
+
+- secrets are runtime bindings;
+- public builds do not contain database URLs;
+- connection and query timeouts are bounded;
+- retries are limited to safe operations;
+- transaction retries account for idempotency;
+- logs redact statements or values that may contain private data.
+
+### 13.4 Migration behavior
+
+- migration files are reviewable;
+- destructive changes require backup and recovery planning;
+- schema and application deployment order is documented;
+- old and new versions coexist where required for safe rollout;
+- failed migration does not corrupt the last valid public export.
+
+---
+
+## 14. Media processing
+
+### 14.1 MVP-A
+
+Operator-managed uploads use an authenticated processing path, initially supported by a controlled Node.js and Sharp workflow or an equivalent replaceable processor.
+
+### 14.2 MVP-B
+
+Public users upload directly to private quarantine through short-lived scoped authorization.
+
+Processing may be asynchronous, but the system must preserve:
+
+- status transitions;
+- idempotency;
+- bounded resources;
+- private originals;
+- approved public derivatives;
+- deletion schedules;
+- audit events.
+
+### 14.3 Replaceable processor
+
+The application depends on a media-processing interface, not one vendor-specific transformation URL format.
+
+---
+
+## 15. Testing architecture
+
+### 15.1 Unit tests — Vitest
+
+Examples:
+
+- registry normalization;
+- state transitions;
+- evidence eligibility helpers;
+- public-projection filters;
+- URL serialization;
+- export validation;
+- retention-date calculation.
+
+### 15.2 Component tests — React Testing Library
+
+Examples:
+
+- forms;
+- filters;
+- bottom sheet;
+- status badges;
+- dialogs;
+- keyboard interactions;
+- empty and error states.
+
+### 15.3 End-to-end tests — Playwright
+
+Required flows include:
+
+- map and list discovery;
+- filter and URL restoration;
+- marker and list synchronization;
+- detail and browser-back restoration;
+- mobile bottom sheet;
+- suggestion;
+- payment report;
+- problem report;
+- claim;
+- private submission status;
+- administrative review;
+- canonical publication;
+- legacy redirects.
+
+### 15.4 Accessibility checks
+
+- automated axe checks;
+- keyboard-only review;
+- focus-order review;
+- representative screen-reader review;
+- reduced-motion review;
+- map alternative review.
+
+### 15.5 Data tests
+
+- schemas;
+- orphan references;
+- duplicates;
+- invalid coordinates;
+- missing network;
+- missing How to pay;
+- insufficient evidence;
+- expired confirmations;
+- public/private leakage;
+- missing provenance or license metadata.
+
+---
+
+## 16. Continuous integration
+
+Every applicable pull request runs available checks for its affected area.
+
+Initial code CI should include:
+
+- formatting or linting;
+- type checking;
+- unit tests;
+- build;
+- documentation-link or format checks where useful.
+
+As features are added, CI expands to:
+
+- component tests;
+- end-to-end tests;
+- accessibility checks;
+- migration checks;
+- public-export fixtures;
+- privacy leakage checks;
+- dependency and secret scanning.
+
+Checks are not reported as passed unless they actually ran and passed.
+
+---
+
+## 17. Deployment
+
+### 17.1 Environments
+
+```text
+local
+preview
+staging
+production
+```
+
+Preview and staging never use production private data unless an explicitly approved sanitized process exists.
+
+### 17.2 Public site
+
+The default public delivery is a static Astro build deployed to Cloudflare Pages or an equivalent static edge host.
+
+A Cloudflare Astro server adapter is introduced only for routes that require server rendering; static routes remain prerendered where practical.
+
+### 17.3 APIs
+
+Dynamic APIs deploy as Cloudflare Workers or Pages Functions with separate environment bindings.
+
+### 17.4 Publication
+
+Public dataset publication is a controlled action. Application deployment and public-data publication may be independent so a failed data export does not require a code rollback.
+
+### 17.5 Rollback
+
+- code deployments retain a previous known-good deployment;
+- public artifacts retain the previous valid snapshot;
+- database changes include recovery or compatibility plans;
+- redirects and route changes are verified before production switch.
+
+---
+
+## 18. Observability
+
+### 18.1 Public analytics
+
+Cloudflare Web Analytics provides privacy-conscious aggregate traffic measurement.
+
+Additional search-demand events, where approved, use canonical values such as:
+
+- country;
+- city;
+- asset;
+- network;
+- category;
+- result-count bucket;
+- date.
+
+Do not record exact browser location, raw coordinate history, full free-text search, or persistent device identifiers for this purpose.
+
+### 18.2 Operational logs
+
+Logs use structured events and correlation IDs.
+
+Logs must redact:
+
+- secrets;
+- authorization headers;
+- signed URLs;
+- status tokens;
+- email addresses;
+- private evidence;
+- wallet addresses or transaction data supplied privately;
+- database connection values.
+
+### 18.3 Error monitoring
+
+Error reports contain:
+
+- stable error code;
+- route or operation;
+- deployment version;
+- correlation ID;
+- safe technical context.
+
+They do not include raw private payloads by default.
+
+---
+
+## 19. Performance budgets
+
+Targets for representative public pages:
+
+```text
+LCP  ≤ 2.5 seconds
+INP  ≤ 200 milliseconds
+CLS  ≤ 0.1
+```
+
+These are measured goals, not claims that every network and device will always meet them.
+
+### 19.1 Performance practices
+
+- hydrate only interactive areas;
+- load MapLibre only on map surfaces;
+- use compact pin data;
+- defer noncritical media;
+- provide responsive image derivatives;
+- keep existing results visible during refetch;
+- avoid heavy React rerenders during map movement;
+- virtualize large lists if measurement shows a need;
+- split or tile data before one global payload becomes excessive;
+- use edge caching for public artifacts.
+
+### 19.2 Performance regression
+
+Representative budgets become CI or staging checks after the application foundation exists.
+
+---
+
+## 20. Accessibility target
+
+The product targets WCAG 2.2 AA conformance for the supported public and administrative flows.
+
+Requirements include:
+
+- semantic structure;
+- visible focus;
+- keyboard operation;
+- appropriate labels and descriptions;
+- focus management for dialogs and sheets;
+- text alternatives;
+- error association;
+- status not communicated by color alone;
+- sufficient contrast;
+- touch-friendly controls;
+- reduced motion;
+- a list alternative to the map.
+
+A map canvas is never the only route to listing information or actions.
+
+---
+
+## 21. Dependency policy
+
+- prefer maintained dependencies with clear ownership and release history;
+- pin versions through the lockfile;
+- update in bounded pull requests;
+- review breaking changes before upgrade;
+- remove unused packages;
+- avoid packages that duplicate platform capabilities without a clear benefit;
+- review client bundle impact;
+- run security scanning after code foundation exists;
+- do not expose dependency demonstration keys or sample secrets.
+
+The architecture names responsibilities rather than freezing a major version before implementation.
+
+---
+
+## 22. Initial technology set
+
+```text
+Astro
+TypeScript
+React
+Tailwind CSS
+CSS custom properties
+Radix Primitives
+Lucide
+Motion for React
+TanStack Query
+Zustand
+React Hook Form
+Zod
+MapLibre GL JS
+Drizzle ORM
+Neon serverless driver
+Cloudflare Pages / Workers / Access / Turnstile / R2
+Vitest
+React Testing Library
+Playwright
+```
+
+A technology may be replaced through a documented decision when the replacement preserves the required architecture and improves security, maintenance, performance, accessibility, or portability.
+
+---
+
+## 23. Technical completion checklist
+
+Before the foundation phase is considered complete, verify:
+
+- [ ] Astro and React responsibilities are separated.
+- [ ] Places is one coordinated React application area.
+- [ ] URL, server, shared UI, and local state ownership is documented and implemented.
+- [ ] Public pages can use validated generated data without per-request database access.
+- [ ] Dynamic APIs keep database and storage credentials server-side.
+- [ ] Administration is protected by server-enforced access control.
+- [ ] Submission and status APIs return minimal projections.
+- [ ] Private originals cannot become public fallbacks.
+- [ ] Map interaction has a complete list alternative.
+- [ ] Mobile safe areas, browser back, bottom sheet, and reduced motion work.
+- [ ] Applicable lint, type, test, build, accessibility, and export checks run.
+- [ ] Public artifact failure preserves the last valid snapshot.
+- [ ] Performance and accessibility targets are measured on representative flows.


### PR DESCRIPTION
## Implementation item

`P0-07`

## Purpose

Define the technical responsibility boundaries for Astro, React application areas, Places state, public data delivery, mapping, mobile interaction, Cloudflare, Neon, media processing, testing, accessibility, performance, security, privacy, and incident recovery.

## Changes

- add `docs/TECH_ARCHITECTURE.md`
- add `docs/SECURITY_AND_PRIVACY.md`

## Out of scope

- application code
- dependency version pinning
- database migrations
- final infrastructure identifiers and secrets
- production legal text

## Completion criteria

- [x] Static and interactive application responsibilities are separated.
- [x] Places is one coordinated React application area.
- [x] Mobile app shell, bottom sheet, URL state, browser back, motion, and accessibility requirements are explicit.
- [x] Public exports cannot include private review or submission fields.
- [x] Administration authorization is server-enforced.
- [x] Public submissions, status access, evidence URLs, uploads, logging, and publication have explicit security boundaries.

## Important architecture decisions

- public browsing uses validated generated artifacts rather than per-request database access
- Astro owns content and indexable pages; React owns cohesive application surfaces
- Map, list, filters, selected place, and bottom sheet remain inside one `PlacesApp`
- TanStack Query, Zustand, URL state, and local state have separate responsibilities
- Cloudflare Access protects administration and its API routes
- Turnstile tokens require server-side validation
- R2 upload grants are short-lived and scoped to one operation and object path
- public artifacts are generated atomically and preserve the last valid snapshot
- private originals can never be public fallbacks

## Publication, privacy, and integrity

- [x] Exact geolocation and raw search text are excluded from analytics.
- [x] Status secrets, signed URLs, contacts, evidence, and storage keys are excluded from logs.
- [x] Public exports use explicit allowlisted projections and leakage checks.
- [x] Preview environments do not receive production private data by default.
- [x] Security incidents can stop publication and restore the prior public snapshot.

## Public impact

Documentation only. The architecture becomes enforceable through Phase 1 implementation and release gates.

## Rollback

Revert the P0-07 documentation commits.