### PR TITLE
P1-09: Add PWA manifest and installability baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The repository implementation plan is for development tracking. The public produ
 - [Database foundation](docs/DATABASE_FOUNDATION.md)
 - [Testing and quality](docs/TESTING.md)
 - [Cloudflare staging](docs/CLOUDFLARE_STAGING.md)
+- [PWA baseline](docs/PWA.md)
 - [Security and privacy architecture](docs/SECURITY_AND_PRIVACY.md)
 
 ### Operations and release
@@ -92,4 +93,4 @@ Repository-wide working rules are defined in [AGENTS.md](AGENTS.md). Pull reques
 
 ## Current phase
 
-Phase 0 public specifications are complete. Phase 1 establishes the application foundation, development tooling, design system base, state-management boundaries, staging path, and quality checks.
+Phase 0 public specifications are complete. Phase 1 establishes the application foundation, development tooling, design system base, state-management boundaries, staging path, installability baseline, and quality checks.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -44,8 +44,8 @@ Phase 0 established the public product, route, data, verification, submission, m
 | P1-05 | Client, server, and URL-state boundaries | Completed | P1-01 | [#15](https://github.com/badjoke-lab/cryptopaymap/pull/15) |
 | P1-06 | Zod, Drizzle, and migration foundation | Completed | P1-01 | [#16](https://github.com/badjoke-lab/cryptopaymap/pull/16) |
 | P1-07 | CI and test foundation | Completed | P1-01 | [#17](https://github.com/badjoke-lab/cryptopaymap/pull/17) |
-| P1-08 | Cloudflare staging foundation | In progress | P1-01, P1-07 | [#18](https://github.com/badjoke-lab/cryptopaymap/pull/18) |
-| P1-09 | PWA manifest and installability baseline | Planned | P1-02 | — |
+| P1-08 | Cloudflare staging foundation | Completed | P1-01, P1-07 | [#18](https://github.com/badjoke-lab/cryptopaymap/pull/18) |
+| P1-09 | PWA manifest and installability baseline | In progress | P1-02 | [#19](https://github.com/badjoke-lab/cryptopaymap/pull/19) |
 | P1-10 | Accessibility baseline | Planned | P1-03, P1-04 | — |
 | P1-11 | Public Roadmap and Changelog content loaders | Planned | P1-01 | — |
 | P1-12 | Phase 1 integration and quality audit | Planned | P1-02 through P1-11 | — |
@@ -206,11 +206,16 @@ Provision the Cloudflare Pages staging project and GitHub `staging` environment 
 
 **Deliverables**
 
-- web app manifest, names, icons, theme metadata, standalone display, and start URL
+- scoped web app manifest
+- standard and maskable application icons
+- shared theme, icon, and installability metadata
+- artifact and unit-test validation
+- explicit no-service-worker freshness boundary
 
 **Completion criteria**
 
 - installability metadata validates;
+- the static artifact contains the manifest and declared icons;
 - stale payment data is not cached as permanent offline truth;
 - advanced offline behavior remains deferred.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -9,11 +9,11 @@ Phase 1 — Foundation
 
 ## Current implementation item
 
-`P1-08 — Cloudflare staging foundation`
+`P1-09 — PWA manifest and installability baseline`
 
 ## Active pull request
 
-[#18 — P1-08: Add Cloudflare Pages staging foundation](https://github.com/badjoke-lab/cryptopaymap/pull/18)
+[#19 — P1-09: Add PWA manifest and installability baseline](https://github.com/badjoke-lab/cryptopaymap/pull/19)
 
 ## Latest completed work
 
@@ -21,22 +21,25 @@ Phase 1 — Foundation
 - P1-01 through P1-05 completed through pull requests #11 through #15.
 - P1-06 schema and migration foundation completed through pull request #16.
 - P1-07 CI and test foundation completed through pull request #17.
+- P1-08 Cloudflare staging foundation completed through pull request #18.
 
-## P1-08 in progress
+## P1-09 in progress
 
-- pinned Wrangler and a static Cloudflare Pages staging contract
-- manual deployment workflow scoped to the GitHub `staging` environment
-- baseline security and cache headers
-- deployable `dist` artifact validation and upload
-- local Pages preview commands
-- Node-only staging validation separated from browser application type checking
+- scoped standalone web app manifest
+- standard and maskable application icons
+- shared manifest, icon, theme, and mobile metadata
+- staging artifact validation for PWA files
+- manifest and icon cache policy
+- installability and no-offline-cache tests
+- PWA scope and freshness documentation
 
 ## Next
 
-1. Complete all repository checks for pull request #18.
-2. Merge P1-08 without requiring Cloudflare credentials or a live Pages project.
-3. Start P1-09 PWA manifest and installability baseline.
-4. Provision and connect the external Cloudflare staging project after P1-09 through P1-11 are merged and before the P1-12 integration audit is closed.
+1. Complete all repository checks for pull request #19.
+2. Merge P1-09 without adding a service worker or offline payment-data cache.
+3. Start P1-10 accessibility baseline.
+4. Keep Cloudflare unconnected through P1-10 and P1-11.
+5. Provision and verify the external staging project before closing P1-12.
 
 ## Blocked
 

--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -1,0 +1,56 @@
+# CryptoPayMap PWA baseline
+
+## Purpose
+
+CryptoPayMap is a web application with installable metadata. The Phase 1 baseline makes the shared application shell installable without turning current payment information into permanent offline data.
+
+## Included in P1-09
+
+- `/manifest.webmanifest`
+- shared document-head metadata
+- standard and maskable vector application icons
+- standalone display mode
+- root start URL and root application scope
+- explicit theme and background colors
+- artifact and unit-test validation
+- short-lived manifest caching and revalidated icon caching
+
+## Deliberately excluded
+
+P1-09 does not add:
+
+- a service worker;
+- offline page or data caching;
+- background synchronization;
+- push notifications;
+- saved places;
+- recently viewed data;
+- an install prompt controlled by application code.
+
+These capabilities require separate product and freshness decisions. Payment acceptance data must not remain available as apparently current information after its normal revalidation boundary.
+
+## Manifest contract
+
+```text
+id: /
+start_url: /
+scope: /
+display: standalone
+theme_color: #0f766e
+background_color: #f8fafc
+```
+
+The manifest contains both a standard icon and a maskable icon. The current vector assets are repository-controlled application icons and may be replaced by finalized brand artwork in a later reviewed change.
+
+## Validation
+
+The repository verifies that:
+
+- the manifest parses as JSON;
+- installability fields are present;
+- standard and maskable icons are declared;
+- the shared layout links the manifest and application icon;
+- the production artifact contains the manifest and icons;
+- no service worker or cache registration is introduced.
+
+A live browser installability inspection is performed on the Cloudflare staging deployment during the P1-12 integration audit.

--- a/public/_headers
+++ b/public/_headers
@@ -9,3 +9,9 @@
 
 /data/*
   Cache-Control: public, max-age=300, must-revalidate
+
+/manifest.webmanifest
+  Cache-Control: public, max-age=300, must-revalidate
+
+/icons/*
+  Cache-Control: public, max-age=86400, must-revalidate

--- a/public/icons/cryptopaymap-maskable.svg
+++ b/public/icons/cryptopaymap-maskable.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="CryptoPayMap">
+  <rect width="512" height="512" fill="#0f766e" />
+  <path d="M256 112c-70.7 0-128 56.3-128 125.9 0 95.6 110.2 152.5 121.2 157.9a15.4 15.4 0 0 0 13.6 0c11-5.4 121.2-62.3 121.2-157.9C384 168.3 326.7 112 256 112Z" fill="#ccfbf1" />
+  <circle cx="256" cy="234" r="66" fill="#0f766e" />
+  <path d="M228 213h62a24 24 0 0 1 0 48h-14m10-48-58 70m0-70h62a24 24 0 0 1 0 48h-62" fill="none" stroke="#ffffff" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/icons/cryptopaymap.svg
+++ b/public/icons/cryptopaymap.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="CryptoPayMap">
+  <rect width="512" height="512" rx="96" fill="#0f766e" />
+  <path d="M256 80c-88.4 0-160 70.4-160 157.3 0 119.5 137.8 190.6 151.5 197.4a19.2 19.2 0 0 0 17 0C278.2 427.9 416 356.8 416 237.3 416 150.4 344.4 80 256 80Z" fill="#ccfbf1" />
+  <circle cx="256" cy="232" r="82" fill="#0f766e" />
+  <path d="M220 206h78a30 30 0 0 1 0 60h-18m12-60-72 88m0-88h78a30 30 0 0 1 0 60h-78" fill="none" stroke="#ffffff" stroke-width="22" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,30 @@
+{
+  "id": "/",
+  "name": "CryptoPayMap",
+  "short_name": "CryptoPayMap",
+  "description": "Find verified physical places and online services where cryptocurrency can be used at checkout.",
+  "lang": "en",
+  "dir": "ltr",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone", "minimal-ui", "browser"],
+  "orientation": "any",
+  "background_color": "#f8fafc",
+  "theme_color": "#0f766e",
+  "categories": ["navigation", "finance", "travel", "utilities"],
+  "icons": [
+    {
+      "src": "/icons/cryptopaymap.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/cryptopaymap-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/scripts/check-staging-artifact.mjs
+++ b/scripts/check-staging-artifact.mjs
@@ -2,7 +2,14 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { extname, join } from 'node:path';
 
 const outputDirectory = 'dist';
-const requiredFiles = ['index.html', '_headers', 'data/foundation-place.json'];
+const requiredFiles = [
+  'index.html',
+  '_headers',
+  'data/foundation-place.json',
+  'manifest.webmanifest',
+  'icons/cryptopaymap.svg',
+  'icons/cryptopaymap-maskable.svg',
+];
 
 for (const relativePath of requiredFiles) {
   const absolutePath = join(outputDirectory, relativePath);
@@ -26,7 +33,17 @@ for (const fragment of requiredHeaderFragments) {
   }
 }
 
-const textExtensions = new Set(['.css', '.html', '.js', '.json', '.map', '.svg', '.txt', '']);
+const textExtensions = new Set([
+  '.css',
+  '.html',
+  '.js',
+  '.json',
+  '.map',
+  '.svg',
+  '.txt',
+  '.webmanifest',
+  '',
+]);
 const forbiddenMarkers = ['CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_ACCOUNT_ID', 'DATABASE_URL='];
 
 function scanDirectory(directory) {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,6 +22,12 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="description" content={description} />
     <meta name="theme-color" content="#0f766e" />
+    <meta name="color-scheme" content="light" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="CryptoPayMap" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icons/cryptopaymap.svg" type="image/svg+xml" />
     <title>{title}</title>
     <ClientRouter fallback="swap" />
   </head>

--- a/tests/pwa-manifest.test.mjs
+++ b/tests/pwa-manifest.test.mjs
@@ -1,0 +1,62 @@
+// @vitest-environment node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readRepositoryFile(path) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+describe('PWA installability baseline', () => {
+  it('defines a scoped standalone web app manifest', () => {
+    const manifest = JSON.parse(readRepositoryFile('public/manifest.webmanifest'));
+
+    expect(manifest.id).toBe('/');
+    expect(manifest.name).toBe('CryptoPayMap');
+    expect(manifest.short_name).toBe('CryptoPayMap');
+    expect(manifest.start_url).toBe('/');
+    expect(manifest.scope).toBe('/');
+    expect(manifest.display).toBe('standalone');
+    expect(manifest.theme_color).toBe('#0f766e');
+    expect(manifest.background_color).toBe('#f8fafc');
+  });
+
+  it('provides standard and maskable application icons', () => {
+    const manifest = JSON.parse(readRepositoryFile('public/manifest.webmanifest'));
+
+    expect(manifest.icons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          src: '/icons/cryptopaymap.svg',
+          sizes: 'any',
+          type: 'image/svg+xml',
+          purpose: 'any',
+        }),
+        expect.objectContaining({
+          src: '/icons/cryptopaymap-maskable.svg',
+          sizes: 'any',
+          type: 'image/svg+xml',
+          purpose: 'maskable',
+        }),
+      ]),
+    );
+  });
+
+  it('links installability metadata from the shared document head', () => {
+    const layout = readRepositoryFile('src/layouts/BaseLayout.astro');
+
+    expect(layout).toContain('rel="manifest" href="/manifest.webmanifest"');
+    expect(layout).toContain('rel="icon" href="/icons/cryptopaymap.svg"');
+    expect(layout).toContain('name="theme-color" content="#0f766e"');
+    expect(layout).toContain('name="mobile-web-app-capable" content="yes"');
+  });
+
+  it('does not introduce an offline cache for payment data', () => {
+    const serviceWorkerPath = new URL('../public/sw.js', import.meta.url);
+    const layout = readRepositoryFile('src/layouts/BaseLayout.astro');
+
+    expect(existsSync(serviceWorkerPath)).toBe(false);
+    expect(layout).not.toContain('serviceWorker.register');
+    expect(layout).not.toContain('caches.open');
+  });
+});


### PR DESCRIPTION
## Implementation item

`P1-09`

## Purpose

Add installable web-application metadata without introducing a service worker or treating payment acceptance data as permanent offline truth.

## Changes

- add a scoped standalone web app manifest
- add standard and maskable vector application icons
- link manifest, icon, and mobile application metadata from the shared layout
- validate PWA files in the deployable staging artifact
- add explicit cache policies for manifest and icons
- add unit tests for the installability and freshness boundary
- document the PWA baseline and deferred offline capabilities
- synchronize project status and implementation tracking

## Out of scope

- service worker
- offline data or page cache
- push notifications
- background sync
- application-controlled install prompts
- finalized production branding artwork

## Completion criteria

- [x] Manifest metadata validates.
- [x] Standard and maskable icons are present.
- [x] Shared pages expose the manifest and theme metadata.
- [x] The static artifact contains all PWA files.
- [x] No offline cache or service-worker registration is introduced.
- [x] Formatting, linting, type, schema, migration, tests, build, and artifact checks succeed.

## Checks

Foundation validation run #189 completed successfully on the final head.

## Public impact

Foundation only. No product Changelog entry is required.

## Rollback

Revert this merge before later installability or packaging work depends on it.