### PR TITLE
P1-10: Add accessibility baseline and automated checks

### DIFF
--- a/.github/workflows/p1-01-validate.yml
+++ b/.github/workflows/p1-01-validate.yml
@@ -56,6 +56,10 @@ jobs:
         if: always()
         run: set -o pipefail && npm run build 2>&1 | tee validation-build.log
 
+      - name: Check accessibility foundation
+        if: always()
+        run: set -o pipefail && npm run accessibility:check 2>&1 | tee validation-accessibility.log
+
       - name: Check staging artifact
         if: always()
         run: set -o pipefail && npm run staging:check 2>&1 | tee validation-staging.log
@@ -82,6 +86,7 @@ jobs:
             validation-database.log
             validation-test.log
             validation-build.log
+            validation-accessibility.log
             validation-staging.log
           if-no-files-found: warn
           retention-days: 7

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm run lint
 npm run check
 npm run test
 npm run build
+npm run accessibility:check
 npm run staging:check
 npm run quality
 npm run pages:dev
@@ -78,6 +79,7 @@ The repository implementation plan is for development tracking. The public produ
 - [Testing and quality](docs/TESTING.md)
 - [Cloudflare staging](docs/CLOUDFLARE_STAGING.md)
 - [PWA baseline](docs/PWA.md)
+- [Accessibility baseline](docs/ACCESSIBILITY.md)
 - [Security and privacy architecture](docs/SECURITY_AND_PRIVACY.md)
 
 ### Operations and release
@@ -93,4 +95,4 @@ Repository-wide working rules are defined in [AGENTS.md](AGENTS.md). Pull reques
 
 ## Current phase
 
-Phase 0 public specifications are complete. Phase 1 establishes the application foundation, development tooling, design system base, state-management boundaries, staging path, installability baseline, and quality checks.
+Phase 0 public specifications are complete. Phase 1 establishes the application foundation, development tooling, design system base, state-management boundaries, staging path, installability, accessibility, and quality checks.

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,0 +1,94 @@
+# CryptoPayMap accessibility baseline
+
+## Goal
+
+CryptoPayMap targets a WCAG 2.2 AA-oriented implementation. Accessibility is a shared foundation requirement for public discovery, contribution flows, and protected administration rather than a final launch-only review.
+
+P1-10 establishes the minimum contract that later pages and application areas must preserve.
+
+## Document structure
+
+Every shared page provides:
+
+- a declared document language;
+- a non-empty page title;
+- a visible-on-focus skip link;
+- a programmatically focusable main landmark;
+- labeled primary and footer navigation;
+- one page-level `h1` on the foundation page;
+- no positive `tabindex` values;
+- no automatic focus without a specific reviewed interaction need.
+
+The main landmark uses `tabindex="-1"` so keyboard users can move directly to content through the skip link without placing the landmark in the normal tab sequence.
+
+## Keyboard and focus
+
+Interactive controls must:
+
+- use native buttons, links, inputs, and form semantics where possible;
+- expose a visible focus indicator;
+- meet the shared 44px-oriented touch-target baseline;
+- remain operable by keyboard;
+- avoid custom tab ordering;
+- return focus predictably after modal surfaces close.
+
+Dialog and sheet primitives use Radix-managed modal semantics, focus containment, Escape handling, and trigger-focus restoration. They also expose visible, named close buttons.
+
+## Forms
+
+Shared form fields connect:
+
+- visible labels through `for` and `id`;
+- hints and errors through `aria-describedby`;
+- invalid state through `aria-invalid`;
+- immediate validation messages through `role="alert"` when appropriate.
+
+Placeholder text is not a substitute for a label.
+
+## Status and loading
+
+Status cannot be communicated by color alone. Badges and panels contain text labels, while decorative icons are hidden from assistive technology.
+
+Loading placeholders expose a text alternative through a status region rather than relying on animation or shape alone.
+
+## Motion
+
+The shared motion system respects `prefers-reduced-motion`. Reduced motion removes nonessential animation while preserving state changes and task completion.
+
+Astro page transitions and React interaction motion have separate ownership. The application must not duplicate route announcements already supplied by Astro's client router.
+
+## Map and discovery requirements
+
+Future map features must always provide a synchronized list or equivalent non-map route. A user must be able to:
+
+- search and filter without operating the map;
+- reach every public place result through the list or detail route;
+- understand selected and filtered state without color alone;
+- restore map and list state through normal browser navigation.
+
+Map-only interaction is not an acceptable completion state.
+
+## Automated checks
+
+The repository runs three accessibility-related layers:
+
+1. component tests for labels, descriptions, modal semantics, close controls, and keyboard dismissal;
+2. static build checks for document language, title, landmarks, navigation labels, headings, duplicate IDs, accessible control names, labels, and forbidden focus patterns;
+3. existing formatting, lint, type, build, and reduced-motion checks.
+
+`npm run accessibility:check` runs against the generated `dist/index.html` and fails closed when a required foundation contract is missing.
+
+## Manual verification gate
+
+P1-12 performs the first integrated manual review on the real Cloudflare staging deployment after P1-09 through P1-11 are complete. That review covers:
+
+- keyboard-only traversal;
+- visible focus;
+- skip-link behavior;
+- dialog and sheet focus containment and restoration;
+- reduced-motion behavior;
+- browser accessibility tree and route announcements;
+- mobile zoom and touch targets;
+- representative screen-reader flows.
+
+Automated checks support but do not replace this manual review.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -45,8 +45,8 @@ Phase 0 established the public product, route, data, verification, submission, m
 | P1-06 | Zod, Drizzle, and migration foundation | Completed | P1-01 | [#16](https://github.com/badjoke-lab/cryptopaymap/pull/16) |
 | P1-07 | CI and test foundation | Completed | P1-01 | [#17](https://github.com/badjoke-lab/cryptopaymap/pull/17) |
 | P1-08 | Cloudflare staging foundation | Completed | P1-01, P1-07 | [#18](https://github.com/badjoke-lab/cryptopaymap/pull/18) |
-| P1-09 | PWA manifest and installability baseline | In progress | P1-02 | [#19](https://github.com/badjoke-lab/cryptopaymap/pull/19) |
-| P1-10 | Accessibility baseline | Planned | P1-03, P1-04 | — |
+| P1-09 | PWA manifest and installability baseline | Completed | P1-02 | [#19](https://github.com/badjoke-lab/cryptopaymap/pull/19) |
+| P1-10 | Accessibility baseline | In progress | P1-03, P1-04 | [#20](https://github.com/badjoke-lab/cryptopaymap/pull/20) |
 | P1-11 | Public Roadmap and Changelog content loaders | Planned | P1-01 | — |
 | P1-12 | Phase 1 integration and quality audit | Planned | P1-02 through P1-11 | — |
 
@@ -223,13 +223,22 @@ Provision the Cloudflare Pages staging project and GitHub `staging` environment 
 
 **Deliverables**
 
-- semantic shell, keyboard baseline, focus rules, reduced-motion integration, and automated accessibility checks
+- focusable skip-link target and semantic shared shell
+- labeled navigation and document landmark validation
+- field, dialog, and sheet accessibility tests
+- fail-closed generated-artifact accessibility checks
+- dedicated local and CI accessibility command with retained logs
+- keyboard, focus, forms, status, motion, map-alternative, and manual-review documentation
 
 **Completion criteria**
 
 - foundation supports WCAG 2.2 AA-oriented implementation;
+- skip-link navigation reaches a programmatically focusable main landmark;
+- shared fields expose labels, descriptions, invalid state, and errors;
+- modal surfaces expose names, descriptions, close controls, Escape handling, and managed focus;
+- positive tabindex, duplicate IDs, unnamed controls, and unlabeled inputs fail the foundation check;
 - map-only interaction is never assumed;
-- sheets and dialogs have verified focus behavior.
+- automated checks complement rather than replace the P1-12 manual staging review.
 
 ### P1-11 — Public Roadmap and Changelog content loaders
 
@@ -254,7 +263,7 @@ Provision the Cloudflare Pages staging project and GitHub `staging` environment 
 **Completion criteria**
 
 - the responsive shell and sheet foundation exist;
-- linting, type checking, unit tests, and builds run in CI;
+- linting, type checking, unit tests, accessibility checks, and builds run in CI;
 - state, schema, deployment, and content foundations match the public architecture;
 - the first credential-scoped Cloudflare staging deployment has been verified or a documented external provisioning blocker is recorded;
 - no secrets or private planning documents are committed.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -9,11 +9,11 @@ Phase 1 — Foundation
 
 ## Current implementation item
 
-`P1-09 — PWA manifest and installability baseline`
+`P1-10 — Accessibility baseline`
 
 ## Active pull request
 
-[#19 — P1-09: Add PWA manifest and installability baseline](https://github.com/badjoke-lab/cryptopaymap/pull/19)
+[#20 — P1-10: Add accessibility baseline and automated checks](https://github.com/badjoke-lab/cryptopaymap/pull/20)
 
 ## Latest completed work
 
@@ -22,23 +22,24 @@ Phase 1 — Foundation
 - P1-06 schema and migration foundation completed through pull request #16.
 - P1-07 CI and test foundation completed through pull request #17.
 - P1-08 Cloudflare staging foundation completed through pull request #18.
+- P1-09 PWA manifest and installability baseline completed through pull request #19.
 
-## P1-09 in progress
+## P1-10 in progress
 
-- scoped standalone web app manifest
-- standard and maskable application icons
-- shared manifest, icon, theme, and mobile metadata
-- staging artifact validation for PWA files
-- manifest and icon cache policy
-- installability and no-offline-cache tests
-- PWA scope and freshness documentation
+- focusable main landmark for skip-link navigation
+- build-time document and landmark validation
+- duplicate ID, focus-order, accessible-name, and form-label checks
+- field, dialog, and sheet accessibility tests
+- accessibility quality command integrated into preview, deployment, and CI
+- accessibility validation logs
+- keyboard, motion, status, form, map-alternative, and manual-review contract
 
 ## Next
 
-1. Complete all repository checks for pull request #19.
-2. Merge P1-09 without adding a service worker or offline payment-data cache.
-3. Start P1-10 accessibility baseline.
-4. Keep Cloudflare unconnected through P1-10 and P1-11.
+1. Complete all repository checks for pull request #20.
+2. Merge P1-10 after the accessibility artifact and component checks are green.
+3. Start P1-11 public Roadmap and Changelog content loaders.
+4. Keep Cloudflare unconnected through P1-11.
 5. Provision and verify the external staging project before closing P1-12.
 
 ## Blocked

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "db:generate": "drizzle-kit generate",
     "db:check": "drizzle-kit check",
     "db:migrate": "drizzle-kit migrate",
+    "accessibility:check": "node scripts/check-accessibility-foundation.mjs",
     "staging:check": "node scripts/check-staging-artifact.mjs",
-    "pages:dev": "npm run build && npm run staging:check && wrangler pages dev",
-    "pages:deploy:staging": "npm run build && npm run staging:check && wrangler pages deploy dist --project-name cryptopaymap-staging --branch staging",
-    "quality": "npm run format:check && npm run lint && npm run check && npm run schema:check && npm run db:check && npm run test && npm run build && npm run staging:check"
+    "pages:dev": "npm run build && npm run accessibility:check && npm run staging:check && wrangler pages dev",
+    "pages:deploy:staging": "npm run build && npm run accessibility:check && npm run staging:check && wrangler pages deploy dist --project-name cryptopaymap-staging --branch staging",
+    "quality": "npm run format:check && npm run lint && npm run check && npm run schema:check && npm run db:check && npm run test && npm run build && npm run accessibility:check && npm run staging:check"
   },
   "dependencies": {
     "@astrojs/react": "6.0.0",

--- a/scripts/check-accessibility-foundation.mjs
+++ b/scripts/check-accessibility-foundation.mjs
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+const documentPath = 'dist/index.html';
+
+if (!existsSync(documentPath)) {
+  throw new Error('Build output is missing dist/index.html. Run the static build first.');
+}
+
+const html = readFileSync(documentPath, 'utf8');
+
+function requireMatch(pattern, message) {
+  if (!pattern.test(html)) {
+    throw new Error(message);
+  }
+}
+
+requireMatch(/<html\b[^>]*\blang=["']en["']/i, 'The document must declare an English language.');
+requireMatch(/<title>\s*[^<]+\s*<\/title>/i, 'The document must include a non-empty title.');
+requireMatch(
+  /<a\b[^>]*\bclass=["'][^"']*skip-link[^"']*["'][^>]*\bhref=["']#main-content["']/i,
+  'The document must expose a skip link to the main landmark.',
+);
+requireMatch(
+  /<main\b[^>]*\bid=["']main-content["'][^>]*\btabindex=["']-1["']/i,
+  'The main landmark must be a programmatically focusable skip-link target.',
+);
+requireMatch(/<nav\b[^>]*\baria-label=["']Primary["']/i, 'Primary navigation needs a label.');
+requireMatch(/<nav\b[^>]*\baria-label=["']Footer["']/i, 'Footer navigation needs a label.');
+
+const headingCount = html.match(/<h1\b/gi)?.length ?? 0;
+if (headingCount !== 1) {
+  throw new Error(`Expected exactly one h1 in the foundation page, found ${headingCount}.`);
+}
+
+const ids = [...html.matchAll(/\sid=(["'])(.*?)\1/gi)].map((match) => match[2]);
+const duplicateIds = ids.filter((id, index) => ids.indexOf(id) !== index);
+if (duplicateIds.length > 0) {
+  throw new Error(`Duplicate document ids found: ${[...new Set(duplicateIds)].join(', ')}`);
+}
+
+if (/\btabindex=["'](?:[1-9]\d*)["']/i.test(html)) {
+  throw new Error('Positive tabindex values are not allowed.');
+}
+
+if (/\bautofocus(?:\s|=|>)/i.test(html)) {
+  throw new Error('Autofocus is not allowed in the shared foundation page.');
+}
+
+for (const image of html.match(/<img\b[^>]*>/gi) ?? []) {
+  if (!/\balt=(["']).*?\1/i.test(image)) {
+    throw new Error(`Image is missing an alt attribute: ${image}`);
+  }
+}
+
+for (const button of html.match(/<button\b[^>]*>[\s\S]*?<\/button>/gi) ?? []) {
+  const openingTag = button.match(/^<button\b[^>]*>/i)?.[0] ?? '';
+  const text = button
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const hasExplicitName = /\baria-(?:label|labelledby)=(["']).+?\1/i.test(openingTag);
+
+  if (!hasExplicitName && text.length === 0) {
+    throw new Error(`Button is missing an accessible name: ${openingTag}`);
+  }
+}
+
+for (const input of html.match(/<input\b[^>]*>/gi) ?? []) {
+  const id = input.match(/\bid=(["'])(.*?)\1/i)?.[2];
+  const hasExplicitName = /\baria-(?:label|labelledby)=(["']).+?\1/i.test(input);
+  const hasAssociatedLabel = id
+    ? new RegExp(`<label\\b[^>]*\\bfor=["']${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']`, 'i').test(
+        html,
+      )
+    : false;
+
+  if (!hasExplicitName && !hasAssociatedLabel) {
+    throw new Error(`Input is missing an accessible label: ${input}`);
+  }
+}
+
+console.log('Accessibility foundation checks passed.');

--- a/scripts/check-accessibility-foundation.mjs
+++ b/scripts/check-accessibility-foundation.mjs
@@ -14,6 +14,17 @@ function requireMatch(pattern, message) {
   }
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function hasAssociatedLabel(element) {
+  const id = element.match(/\bid=(["'])(.*?)\1/i)?.[2];
+  if (!id) return false;
+
+  return new RegExp(`<label\\b[^>]*\\bfor=["']${escapeRegExp(id)}["']`, 'i').test(html);
+}
+
 requireMatch(/<html\b[^>]*\blang=["']en["']/i, 'The document must declare an English language.');
 requireMatch(/<title>\s*[^<]+\s*<\/title>/i, 'The document must include a non-empty title.');
 requireMatch(
@@ -60,21 +71,15 @@ for (const button of html.match(/<button\b[^>]*>[\s\S]*?<\/button>/gi) ?? []) {
     .trim();
   const hasExplicitName = /\baria-(?:label|labelledby)=(["']).+?\1/i.test(openingTag);
 
-  if (!hasExplicitName && text.length === 0) {
+  if (!hasExplicitName && !hasAssociatedLabel(openingTag) && text.length === 0) {
     throw new Error(`Button is missing an accessible name: ${openingTag}`);
   }
 }
 
 for (const input of html.match(/<input\b[^>]*>/gi) ?? []) {
-  const id = input.match(/\bid=(["'])(.*?)\1/i)?.[2];
   const hasExplicitName = /\baria-(?:label|labelledby)=(["']).+?\1/i.test(input);
-  const hasAssociatedLabel = id
-    ? new RegExp(`<label\\b[^>]*\\bfor=["']${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']`, 'i').test(
-        html,
-      )
-    : false;
 
-  if (!hasExplicitName && !hasAssociatedLabel) {
+  if (!hasExplicitName && !hasAssociatedLabel(input)) {
     throw new Error(`Input is missing an accessible label: ${input}`);
   }
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -34,7 +34,7 @@ const {
   <body class="app-shell">
     <a class="skip-link" href="#main-content">Skip to content</a>
     <SiteHeader />
-    <main id="main-content" class="min-w-0">
+    <main id="main-content" class="min-w-0" tabindex="-1">
       <slot />
     </main>
     <SiteFooter />

--- a/tests/accessibility-foundation.test.tsx
+++ b/tests/accessibility-foundation.test.tsx
@@ -24,11 +24,7 @@ describe('accessibility foundation', () => {
     );
 
     rerender(
-      <TextField
-        id="business-name"
-        label="Business name"
-        error="Business name is required."
-      />,
+      <TextField id="business-name" label="Business name" error="Business name is required." />,
     );
 
     expect(input).toHaveAttribute('aria-invalid', 'true');

--- a/tests/accessibility-foundation.test.tsx
+++ b/tests/accessibility-foundation.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { Button } from '../src/components/ui/Button';
+import { ModalDialog } from '../src/components/ui/Dialog';
+import { TextField } from '../src/components/ui/Field';
+import { Sheet } from '../src/components/ui/Sheet';
+
+describe('accessibility foundation', () => {
+  it('associates field labels, hints, errors, and invalid state', () => {
+    const { rerender } = render(
+      <TextField
+        id="business-name"
+        label="Business name"
+        hint="Use the public name shown by the business."
+      />,
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Business name' });
+    expect(input).toHaveAttribute('aria-describedby', 'business-name-hint');
+    expect(screen.getByText('Use the public name shown by the business.')).toHaveAttribute(
+      'id',
+      'business-name-hint',
+    );
+
+    rerender(
+      <TextField
+        id="business-name"
+        label="Business name"
+        error="Business name is required."
+      />,
+    );
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'business-name-error');
+    expect(screen.getByRole('alert')).toHaveTextContent('Business name is required.');
+  });
+
+  it('exposes dialog title, description, and close control', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModalDialog
+        trigger={<Button>Open evidence</Button>}
+        title="Evidence summary"
+        description="Review the source before relying on this listing."
+      >
+        <p>Official merchant payment page.</p>
+      </ModalDialog>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open evidence' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Evidence summary' });
+    expect(dialog).toHaveAccessibleDescription('Review the source before relying on this listing.');
+    expect(screen.getByRole('button', { name: 'Close dialog' })).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Close dialog' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('exposes sheet title, description, and close control', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Sheet
+        trigger={<Button>Open place details</Button>}
+        title="Place details"
+        description="Review payment instructions for the selected place."
+      >
+        <p>Bitcoin Lightning is confirmed.</p>
+      </Sheet>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open place details' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Place details' });
+    expect(dialog).toHaveAccessibleDescription(
+      'Review payment instructions for the selected place.',
+    );
+    expect(screen.getByRole('button', { name: 'Close sheet' })).toBeVisible();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Implementation item

`P1-10`

## Purpose

Establish a fail-closed accessibility foundation for the shared document shell and interactive primitives before map, submission, and administration features are built.

## Changes

- make the skip-link main target programmatically focusable
- add build-artifact checks for language, title, landmarks, navigation labels, heading structure, duplicate IDs, focus order, accessible names, and form labels
- recognize visible labels for native inputs and button-based controls such as the shared Select
- add component tests for field descriptions and errors
- add component tests for dialog and sheet semantics, close controls, and Escape dismissal
- add a dedicated accessibility command to local quality, Pages preview, staging deployment, and CI
- preserve accessibility validation logs
- document keyboard, focus, forms, motion, status, map-alternative, and manual staging requirements
- synchronize project status and implementation tracking

## Out of scope

- feature-specific map accessibility
- final screen-reader certification
- full production-page audit
- Cloudflare provisioning
- replacing manual accessibility testing with automation

## Completion criteria

- [x] Skip-link navigation reaches a focusable main landmark.
- [x] Shared navigation and document landmarks are validated after build.
- [x] Form fields expose labels, descriptions, invalid state, and alerts.
- [x] Dialog and sheet primitives expose names, descriptions, close controls, and keyboard dismissal.
- [x] Reduced-motion and map-alternative requirements remain explicit.
- [x] Accessibility checks run in ordinary CI without Cloudflare credentials.
- [x] Formatting, linting, type, schema, migration, tests, build, accessibility, and staging artifact checks succeed.

## Checks

Foundation validation run #206 completed successfully on the final head, including the new accessibility artifact gate and staging artifact upload.

## Public impact

Foundation only. No product Changelog entry is required.

## Rollback

Revert this merge before later public or administrative interfaces depend on the accessibility contract.