### PR TITLE
P1-12: Add Phase 1 integration audit

### DIFF
--- a/.github/workflows/p1-01-validate.yml
+++ b/.github/workflows/p1-01-validate.yml
@@ -60,6 +60,10 @@ jobs:
         if: always()
         run: set -o pipefail && npm run accessibility:check 2>&1 | tee validation-accessibility.log
 
+      - name: Check Phase 1 files
+        if: always()
+        run: set -o pipefail && node scripts/check-phase-1-foundation.mjs 2>&1 | tee validation-phase-1.log
+
       - name: Check staging artifact
         if: always()
         run: set -o pipefail && npm run staging:check 2>&1 | tee validation-staging.log
@@ -87,6 +91,7 @@ jobs:
             validation-test.log
             validation-build.log
             validation-accessibility.log
+            validation-phase-1.log
             validation-staging.log
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run full quality gate
         run: npm run quality
 
+      - name: Check Phase 1 files
+        run: node scripts/check-phase-1-foundation.mjs
+
       - name: Upload deployable artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npm run check
 npm run test
 npm run build
 npm run accessibility:check
+node scripts/check-phase-1-foundation.mjs
 npm run staging:check
 npm run quality
 npm run pages:dev
@@ -45,6 +46,7 @@ See:
 
 - [Project status](docs/PROJECT_STATUS.md)
 - [Repository implementation plan](docs/IMPLEMENTATION_PLAN.md)
+- [Phase 1 integration audit](docs/PHASE_1_AUDIT.md)
 - [Public product roadmap](docs/ROADMAP.md)
 
 The repository implementation plan is for development tracking. The public product roadmap describes user-facing capabilities. They are intentionally separate.
@@ -96,4 +98,4 @@ Repository-wide working rules are defined in [AGENTS.md](AGENTS.md). Pull reques
 
 ## Current phase
 
-Phase 0 public specifications are complete. Phase 1 establishes the application foundation, design system, state boundaries, staging path, installability, accessibility, public content loaders, and quality checks.
+Phase 1 integration auditing is active. The repository foundation is assembled, and live Cloudflare staging verification remains the external completion gate before Phase 2.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -9,7 +9,8 @@ This document tracks public, repository-level implementation work. It is not the
 
 - Stable implementation item IDs are independent of pull request numbers.
 - Repository reality, merged pull requests, and CI results take precedence if this file disagrees.
-- Each item records dependencies, deliverables, completion criteria, and the pull request when known.
+- Each active or planned item records dependencies, deliverables, and completion criteria.
+- Completed items remain linked to their pull requests.
 - Unplanned work uses `FIX-`, `SEC-`, or `DATA-` prefixes without renumbering planned items.
 
 Status values: `Planned`, `In progress`, `Completed`, `Deferred`, `Revised`.
@@ -18,292 +19,135 @@ Status values: `Planned`, `In progress`, `Completed`, `Deferred`, `Revised`.
 
 **Status:** Completed
 
-| ID | Item | Status | Pull request |
-|---|---|---|---|
-| P0-01 | Development control | Completed | [#1](https://github.com/badjoke-lab/cryptopaymap/pull/1) |
-| P0-02 | Product constitution | Completed | [#3](https://github.com/badjoke-lab/cryptopaymap/pull/3) |
-| P0-03 | Information architecture | Completed | [#4](https://github.com/badjoke-lab/cryptopaymap/pull/4) |
-| P0-04 | Data architecture | Completed | [#5](https://github.com/badjoke-lab/cryptopaymap/pull/5) |
-| P0-05 | Verification, sources, and licenses | Completed | [#6](https://github.com/badjoke-lab/cryptopaymap/pull/6) |
-| P0-06 | Submission and media policies | Completed | [#7](https://github.com/badjoke-lab/cryptopaymap/pull/7) |
-| P0-07 | Technical, UX, security, and privacy architecture | Completed | [#8](https://github.com/badjoke-lab/cryptopaymap/pull/8) |
-| P0-08 | Operations, migration, launch, and public roadmap | Completed | [#9](https://github.com/badjoke-lab/cryptopaymap/pull/9) |
-
-Phase 0 established the public product, route, data, verification, submission, media, technical, security, privacy, migration, launch, and roadmap contracts. Internal-only planning documents remain outside the public repository.
+| ID | Item | Pull request |
+|---|---|---|
+| P0-01 | Development control | [#1](https://github.com/badjoke-lab/cryptopaymap/pull/1) |
+| P0-02 | Product constitution | [#3](https://github.com/badjoke-lab/cryptopaymap/pull/3) |
+| P0-03 | Information architecture | [#4](https://github.com/badjoke-lab/cryptopaymap/pull/4) |
+| P0-04 | Data architecture | [#5](https://github.com/badjoke-lab/cryptopaymap/pull/5) |
+| P0-05 | Verification, sources, and licenses | [#6](https://github.com/badjoke-lab/cryptopaymap/pull/6) |
+| P0-06 | Submission and media policies | [#7](https://github.com/badjoke-lab/cryptopaymap/pull/7) |
+| P0-07 | Technical, UX, security, and privacy architecture | [#8](https://github.com/badjoke-lab/cryptopaymap/pull/8) |
+| P0-08 | Operations, migration, launch, and public roadmap | [#9](https://github.com/badjoke-lab/cryptopaymap/pull/9) |
 
 ## Phase 1 — Foundation
 
 **Status:** In progress
 
-| ID | Item | Status | Depends on | Pull request |
-|---|---|---|---|---|
-| P1-01 | Repository and application foundation | Completed | Phase 0 | [#11](https://github.com/badjoke-lab/cryptopaymap/pull/11) |
-| P1-02 | Tailwind, design tokens, and responsive application shell | Completed | P1-01 | [#12](https://github.com/badjoke-lab/cryptopaymap/pull/12) |
-| P1-03 | Reusable UI primitives and interaction states | Completed | P1-02 | [#13](https://github.com/badjoke-lab/cryptopaymap/pull/13) |
-| P1-04 | Motion tokens and reduced-motion behavior | Completed | P1-02, P1-03 | [#14](https://github.com/badjoke-lab/cryptopaymap/pull/14) |
-| P1-05 | Client, server, and URL-state boundaries | Completed | P1-01 | [#15](https://github.com/badjoke-lab/cryptopaymap/pull/15) |
-| P1-06 | Zod, Drizzle, and migration foundation | Completed | P1-01 | [#16](https://github.com/badjoke-lab/cryptopaymap/pull/16) |
-| P1-07 | CI and test foundation | Completed | P1-01 | [#17](https://github.com/badjoke-lab/cryptopaymap/pull/17) |
-| P1-08 | Cloudflare staging foundation | Completed | P1-01, P1-07 | [#18](https://github.com/badjoke-lab/cryptopaymap/pull/18) |
-| P1-09 | PWA manifest and installability baseline | Completed | P1-02 | [#19](https://github.com/badjoke-lab/cryptopaymap/pull/19) |
-| P1-10 | Accessibility baseline | Completed | P1-03, P1-04 | [#20](https://github.com/badjoke-lab/cryptopaymap/pull/20) |
-| P1-11 | Public Roadmap and Changelog content loaders | In progress | P1-01 | [#21](https://github.com/badjoke-lab/cryptopaymap/pull/21) |
-| P1-12 | Phase 1 integration and quality audit | Planned | P1-02 through P1-11 | — |
-
-### P1-01 — Repository and application foundation
-
-**Deliverables**
-
-- Astro, React, and strict TypeScript foundation
-- package scripts, npm lockfile, and environment contract
-- static application entry and base layout
-- read-only validation workflow
-
-**Completion criteria**
-
-- locked install, Astro check, and static build pass;
-- React is used only for interactive application areas;
-- no secret or private configuration is committed.
-
-### P1-02 — Design tokens and responsive shell
-
-**Deliverables**
-
-- Tailwind CSS 4 integration
-- semantic brand, state, surface, radius, shadow, and breakpoint tokens
-- responsive header, main, and footer shell
-- safe-area, focus, touch-target, skip-link, and reduced-motion baseline
-- design-system foundation documentation
-
-**Completion criteria**
-
-- locked install, check, and build pass;
-- shell works at 640 / 768 / 1024 / 1280 breakpoints;
-- public status is never communicated by color alone;
-- dark mode remains deferred without being structurally blocked.
-
-### P1-03 — Reusable UI primitives and interaction states
-
-**Deliverables**
-
-- Button, TextField, SelectField, Badge, and Card
-- modal Dialog and bottom/right Sheet
-- Toast provider and notice
-- Skeleton and empty/loading/success/warning/error StatePanel
-- integrated demonstration and public component contract
-- Radix and Lucide dependency foundation
-
-**Completion criteria**
-
-- locked install, Astro check, and static build pass;
-- fields connect labels, hints, errors, and ARIA state;
-- modal surfaces provide managed focus, Escape behavior, and visible close controls;
-- controls expose consistent focus and touch targets;
-- primitives are reusable by discovery, submissions, and administration;
-- no private data or automatic canonical mutation is introduced.
-
-### P1-04 — Motion tokens and reduced-motion behavior
-
-**Deliverables**
-
-- Motion for React dependency and locked graph
-- `instant`, `fast`, `normal`, and `slow` duration tokens
-- shared standard, enter, and exit easing tokens
-- MotionConfig reduced-motion policy and animated state replacement
-- CSS `data-state` motion for Dialog, Sheet, Select, and Toast
-- Astro ClientRouter page-transition boundary
-- documented map and bottom-sheet motion constraints
-
-**Completion criteria**
-
-- locked install, Astro check, and static build pass;
-- motion improves orientation or feedback rather than decoration;
-- reduced-motion users receive equivalent usable states;
-- controls remain immediately responsive;
-- route, React state, and portal motion have separate ownership;
-- map interaction is not blocked by animation.
-
-### P1-05 — Client, server, and URL-state boundaries
-
-**Deliverables**
-
-- TanStack Query server-state foundation
-- per-island Zustand application-state foundation
-- deterministic URL parsing and serialization
-- browser-history restoration and push/replace rules
-- public/private state boundary documentation
-- integrated state-ownership demonstration
-
-**Completion criteria**
-
-- locked install, Astro check, and static build pass;
-- server data, application UI state, shareable URL state, and local state have distinct ownership;
-- map, list, filter, selection, and browser-back state can be restored;
-- private workflow state never enters public URLs or public query keys.
-
-### P1-06 — Zod, Drizzle, and migration foundation
-
-**Deliverables**
-
-- pinned Zod, Drizzle ORM, Drizzle Kit, Neon serverless driver, and tsx dependencies
-- shared runtime validation schemas
-- foundational PostgreSQL enums
-- explicit Neon HTTP database factory
-- Drizzle PostgreSQL configuration
-- reviewable generated SQL migration and metadata
-- schema and migration commands
-- database environment contract without committed connection values
-- database foundation documentation
-- CI checks for runtime schemas and migration history
-
-**Completion criteria**
-
-- locked install, Astro and TypeScript check, runtime-schema check, migration-history check, and static build pass;
-- runtime validation reuses the structural values used by the database schema;
-- public static builds do not require database configuration or database access;
-- migrations remain reviewable SQL and are generated separately from application;
-- Phase 2 domain tables are not introduced prematurely.
-
-### P1-07 — CI and test foundation
-
-**Deliverables**
-
-- deterministic formatting and linting
-- deterministic type checking and build validation
-- unit and component-test runner
-- dependency caching
-- extension points for end-to-end, accessibility, and data checks
-- separately preserved validation logs
-
-**Completion criteria**
-
-- pull requests receive fail-closed checks;
-- no check is reported as passed unless it ran successfully;
-- validation logs remain inspectable.
-
-### P1-08 — Cloudflare staging foundation
-
-**Deliverables**
-
-- Cloudflare-compatible static build and staging contract
-- preview/production environment separation
-- cache and security-header baseline
-- manual credential-scoped deployment workflow
-- validated and uploaded `dist` artifact
-
-**Completion criteria**
-
-- repository checks and artifact creation require no Cloudflare credentials;
-- staging and production responsibilities remain distinct;
-- no candidate, submission, administration, database, or deployment secret is exposed;
-- live external staging provisioning may remain deferred until the Phase 1 staging verification gate.
-
-**External staging verification gate**
-
-Provision the Cloudflare Pages staging project and GitHub `staging` environment after P1-09 through P1-11 are merged. Run the first live deployment before P1-12 is closed so the integrated Phase 1 audit can verify the real Pages runtime without making ordinary pull requests depend on Cloudflare access.
-
-### P1-09 — PWA manifest and installability baseline
-
-**Deliverables**
-
-- scoped web app manifest
-- standard and maskable application icons
-- shared theme, icon, and installability metadata
-- artifact and unit-test validation
-- explicit no-service-worker freshness boundary
-
-**Completion criteria**
-
-- installability metadata validates;
-- the static artifact contains the manifest and declared icons;
-- stale payment data is not cached as permanent offline truth;
-- advanced offline behavior remains deferred.
-
-### P1-10 — Accessibility baseline
-
-**Deliverables**
-
-- focusable skip-link target and semantic shared shell
-- labeled navigation and document landmark validation
-- field, dialog, and sheet accessibility tests
-- fail-closed generated-artifact accessibility checks
-- dedicated local and CI accessibility command with retained logs
-- keyboard, focus, forms, status, motion, map-alternative, and manual-review documentation
-
-**Completion criteria**
-
-- foundation supports WCAG 2.2 AA-oriented implementation;
-- skip-link navigation reaches a programmatically focusable main landmark;
-- shared fields expose labels, descriptions, invalid state, and errors;
-- modal surfaces expose names, descriptions, close controls, Escape handling, and managed focus;
-- positive tabindex, duplicate IDs, unnamed controls, and unlabeled inputs fail the foundation check;
-- map-only interaction is never assumed;
-- automated checks complement rather than replace the P1-12 manual staging review.
-
-### P1-11 — Public Roadmap and Changelog content loaders
-
-**Deliverables**
-
-- separate Astro collections for structured Roadmap data and Changelog Markdown;
-- validated Roadmap sections, statuses, ordering, outcomes, capabilities, and dependencies;
-- validated Changelog versions, dates, summaries, draft state, and categories;
-- static `/roadmap` rendering grouped by Now, Next, Later, and Exploring;
-- draft-filtered `/changelog` rendering with Markdown release bodies and a pre-release empty state;
-- content separation tests and public content-loader documentation.
-
-**Completion criteria**
-
-- Roadmap uses capability milestones rather than repository execution counts;
-- Changelog records released product changes rather than every pull request;
-- draft Changelog entries are not rendered publicly;
-- invalid collection data fails type checking or the static build;
-- Roadmap and Changelog remain separate from Stats, Updates, and repository status.
+| ID | Item | Status | Pull request |
+|---|---|---|---|
+| P1-01 | Repository and application foundation | Completed | [#11](https://github.com/badjoke-lab/cryptopaymap/pull/11) |
+| P1-02 | Design tokens and responsive application shell | Completed | [#12](https://github.com/badjoke-lab/cryptopaymap/pull/12) |
+| P1-03 | Reusable UI primitives and interaction states | Completed | [#13](https://github.com/badjoke-lab/cryptopaymap/pull/13) |
+| P1-04 | Motion and reduced-motion behavior | Completed | [#14](https://github.com/badjoke-lab/cryptopaymap/pull/14) |
+| P1-05 | Query, UI, and URL-state boundaries | Completed | [#15](https://github.com/badjoke-lab/cryptopaymap/pull/15) |
+| P1-06 | Runtime schemas and migration foundation | Completed | [#16](https://github.com/badjoke-lab/cryptopaymap/pull/16) |
+| P1-07 | CI and test foundation | Completed | [#17](https://github.com/badjoke-lab/cryptopaymap/pull/17) |
+| P1-08 | Cloudflare staging contract | Completed | [#18](https://github.com/badjoke-lab/cryptopaymap/pull/18) |
+| P1-09 | PWA manifest and installability baseline | Completed | [#19](https://github.com/badjoke-lab/cryptopaymap/pull/19) |
+| P1-10 | Accessibility baseline | Completed | [#20](https://github.com/badjoke-lab/cryptopaymap/pull/20) |
+| P1-11 | Public Roadmap and Changelog content loaders | Completed | [#21](https://github.com/badjoke-lab/cryptopaymap/pull/21) |
+| P1-12 | Phase 1 integration and quality audit | In progress | [#22](https://github.com/badjoke-lab/cryptopaymap/pull/22) |
 
 ### P1-12 — Phase 1 integration and quality audit
 
 **Deliverables**
 
-- integrated foundation review
-- staging/build/CI verification
-- accessibility and publication-boundary audits
-- Phase 2 readiness record
+- integrated required-file, dependency, workflow, and generated-artifact audit;
+- public and internal publication-boundary checks;
+- CI and pre-deployment audit integration;
+- live Cloudflare staging checklist;
+- Phase 2 implementation breakdown.
 
-**Completion criteria**
+**Repository completion criteria**
 
-- the responsive shell and sheet foundation exist;
-- linting, type checking, unit tests, accessibility checks, and builds run in CI;
-- state, schema, deployment, and content foundations match the public architecture;
-- the first credential-scoped Cloudflare staging deployment has been verified or a documented external provisioning blocker is recorded;
-- no secrets or private planning documents are committed.
+- formatting, linting, type checking, runtime schemas, migrations, tests, and build pass;
+- accessibility, integrated foundation, and staging artifact checks pass;
+- deployable artifact upload succeeds;
+- no internal-only project documents are present in tracked public content.
+
+**External staging gate**
+
+After P1-11, provision the `cryptopaymap-staging` Cloudflare Pages project and GitHub `staging` environment. Run the manual staging workflow from merged `main`. P1-12 completes only after the live URL, commit, response headers, PWA files, public content pages, keyboard behavior, reduced motion, and mobile behavior are recorded and checked.
 
 ## Phase 2 — Data core
 
-Planned work covers registries, entities, locations, acceptance claims, evidence, verification events, source candidates, media metadata, legacy identifiers, imports, and validated public exports.
+**Status:** Planned
 
-Completion requires Candidate/canonical separation, auditable verification states, allowlisted public exports, and traceable source/license metadata.
+Phase 2 establishes the Candidate-to-canonical-to-public-export path. It does not add public submission forms or the full administration interface.
+
+| ID | Item | Depends on |
+|---|---|---|
+| P2-01 | Asset registry | P1-12 |
+| P2-02 | Network registry | P2-01 |
+| P2-03 | Payment method and route registries | P2-01, P2-02 |
+| P2-04 | Entity and location schema | P1-12 |
+| P2-05 | Acceptance claim schema and status rules | P2-03, P2-04 |
+| P2-06 | Claim asset and network combinations | P2-02, P2-03, P2-05 |
+| P2-07 | Evidence schema and source capture | P2-05 |
+| P2-08 | Verification event history | P2-05, P2-07 |
+| P2-09 | Source candidates, provenance, and duplicate boundaries | P2-04, P2-07 |
+| P2-10 | Media metadata and legacy identifiers | P2-04, P2-09 |
+| P2-11 | Public export schemas | P2-05 through P2-10 |
+| P2-12 | Export allowlist and leakage validator | P2-11 |
+| P2-13 | Physical-place candidate importer | P2-09, P2-10, P2-12 |
+| P2-14 | Online-service importer and Phase 2 integration audit | P2-09, P2-12, P2-13 |
+
+### P2-01 through P2-03 — Registries
+
+Create canonical asset, network, payment-method, and route registries. Preserve original source text while normalizing aliases. Do not infer a network from an asset symbol. Stablecoins and multi-network assets require explicit combinations.
+
+### P2-04 through P2-06 — Canonical acceptance model
+
+Create entities, locations, acceptance claims, and claim-asset combinations with reviewable SQL migrations. Separate brand, location, claim scope, direct-wallet routes, processor-checkout routes, and concrete payment methods.
+
+### P2-07 through P2-10 — Evidence, history, and provenance
+
+Create evidence, verification events, source candidates, provenance, media metadata, and legacy-ID mapping. Candidate records remain private and cannot be returned by public queries or exports.
+
+### P2-11 and P2-12 — Public export boundary
+
+Define compact map pins, physical places, GeoJSON, online services, registries, manifest, and version outputs. Use an allowlist rather than serializing database rows directly. Validation fails on Candidate, private evidence, contact, internal note, or private media leakage.
+
+### P2-13 and P2-14 — Importers and integration
+
+Import physical and online legacy records as source candidates rather than Confirmed records. Preserve provenance and legacy IDs, run duplicate checks, and prove the complete path with at least ten physical and ten online test records.
+
+**Phase 2 completion criteria**
+
+- Candidate and canonical records are structurally separate;
+- reviewable migrations are reversible or have documented rollback;
+- verification states and history are auditable;
+- only eligible public records enter validated exports;
+- source and license metadata remain traceable;
+- test imports produce no automatic Confirmed records.
 
 ## Phase 3 — Administration and review
 
-Planned work covers the protected administration shell, candidate review, claim editing, evidence review, state transitions, reconfirmation, media review, export control, and audit history.
+**Status:** Planned
 
-Completion requires a full candidate-to-confirmed-to-validated-export path and auditable stale/reconfirmed/ended transitions.
+Build the protected administration shell, review queue, candidate detail, claim editor, evidence review, state transitions, reconfirmation queue, media review, export controls, and audit history. Completion requires a full Candidate-to-Confirmed-to-public-export path and auditable stale, reconfirmed, and ended transitions.
 
 ## Phase 4 — Public core / MVP-A
 
-Planned work covers place details, Places, Online Services, Home, Stats, Updates, public Roadmap, Changelog, trust pages, and administrator-managed media.
+**Status:** Planned
 
-Completion requires mobile and desktop discovery with asset, network, route, instructions, evidence, freshness, and restorable map/list state.
+Build place detail, the coordinated Places application, MapLibre map, list, filters, URL restoration, mobile bottom sheet, online-service discovery, Home, Stats, Updates, public Roadmap, Changelog, trust pages, and administrator-managed media.
 
 ## Phase 5 — Public submissions / MVP-B
 
-Planned work covers suggestions, payment reports, problem reports, claims, photos, private status links, quarantine uploads, review queues, partial approval, requests for information, time-bounded holds, canonical transactions, and retention jobs.
+**Status:** Planned
 
-Completion requires review-gated, auditable, atomic contribution handling. MVP-B completion defines the formal MVP.
+Build suggestions, payment reports, problem reports, claims, photos, private status links, quarantine uploads, review diffs, requests for information, time-bounded holds, partial approval, canonical transactions, owner verification, negative-evidence handling, and retention jobs. Completion defines the formal MVP.
 
 ## Phase 6 — Launch and cutover
 
-Planned work covers migration audits, data quality, licensing, privacy, mobile, accessibility, performance, security, redirects, sitemap/robots, production cutover, monitoring, and rollback.
+**Status:** Planned
+
+Run data, license, privacy, mobile, accessibility, performance, security, redirect, sitemap, migration, backup, monitoring, and rollback checks before production-domain cutover.
 
 ## Phase 7 — Stabilization
 
-After cutover, the project verifies errors, redirects, search indexing, submissions, exports, mobile behavior, and migration completeness before retiring the legacy implementation.
+**Status:** Planned
+
+After cutover, verify errors, redirects, indexing, submissions, exports, mobile behavior, and migration completeness before retiring the legacy implementation.

--- a/docs/PHASE_1_AUDIT.md
+++ b/docs/PHASE_1_AUDIT.md
@@ -1,0 +1,20 @@
+# Phase 1 integration audit
+
+**Status:** In progress  
+**Item:** `P1-12`
+
+## Repository results
+
+P1-01 through P1-11 are merged. Their application shell, UI primitives, motion, state boundaries, database foundation, CI, staging contract, PWA metadata, accessibility baseline, and public content loaders are present.
+
+The automated audit checks required files, dependencies, commands, manifest settings, shared layout contracts, public content sources, staging workflow boundaries, public-build artifacts, and tracked-file publication boundaries.
+
+## External staging gate
+
+Create the Cloudflare Pages project `cryptopaymap-staging` and a GitHub environment named `staging`. Add environment values named `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, then manually run the `Deploy staging` workflow from merged `main`.
+
+Record the deployment URL and commit SHA. Verify Home, Roadmap, Changelog, manifest, icons, response headers, keyboard focus, skip-link behavior, reduced motion, mobile viewport behavior, and the absence of private configuration in public files.
+
+## Completion rule
+
+P1-12 completes only after repository CI is green and the live staging deployment is recorded and checked. Until then, Phase 1 remains in progress and no live staging URL is claimed.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -11,9 +11,9 @@ Phase 1 — Foundation
 
 `P1-12 — Phase 1 integration and quality audit`
 
-## Active work
+## Repository audit pull request
 
-P1-12 repository audit branch is active.
+[#22 — P1-12: Add Phase 1 integration audit](https://github.com/badjoke-lab/cryptopaymap/pull/22)
 
 ## Latest completed work
 
@@ -21,13 +21,13 @@ P1-12 repository audit branch is active.
 - P1-01 through P1-05 completed through pull requests #11 through #15.
 - P1-06 through P1-11 completed through pull requests #16 through #21.
 
-## P1-12 in progress
+## P1-12 repository checks
 
-- integrated foundation file and dependency checks
-- publication-boundary checks
-- generated artifact checks
-- CI and staging workflow integration
-- live staging checklist
+- integrated foundation file and dependency checks: passed
+- publication-boundary checks: passed
+- generated artifact checks: passed
+- formatting, linting, types, schemas, migrations, tests, build, accessibility, and staging checks: passed
+- deployable artifact upload: passed
 
 ## Cloudflare gate
 
@@ -35,8 +35,8 @@ Cloudflare staging should be connected now, after P1-11 and before P1-12 is clos
 
 ## Next
 
-1. Complete repository checks and open the P1-12 pull request.
-2. Provision and run Cloudflare staging.
+1. Merge the repository-side P1-12 audit.
+2. Provision and run Cloudflare staging from merged `main`.
 3. Record the live URL, commit, and verification result.
 4. Advance to Phase 2 only after both repository and live checks pass.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -9,40 +9,40 @@ Phase 1 — Foundation
 
 ## Current implementation item
 
-`P1-11 — Public Roadmap and Changelog content loaders`
+`P1-12 — Phase 1 integration and quality audit`
 
-## Active pull request
+## Active work
 
-[#21 — P1-11: Add public Roadmap and Changelog content loaders](https://github.com/badjoke-lab/cryptopaymap/pull/21)
+P1-12 repository audit branch is active.
 
 ## Latest completed work
 
 - Phase 0 public specifications completed.
 - P1-01 through P1-05 completed through pull requests #11 through #15.
-- P1-06 completed through pull request #16.
-- P1-07 completed through pull request #17.
-- P1-08 completed through pull request #18.
-- P1-09 completed through pull request #19.
-- P1-10 completed through pull request #20.
+- P1-06 through P1-11 completed through pull requests #16 through #21.
 
-## P1-11 in progress
+## P1-12 in progress
 
-- separate Roadmap and Changelog collections
-- structured Roadmap data and static page
-- validated Changelog metadata and static page
-- draft filtering and release-body rendering
-- content separation tests and documentation
+- integrated foundation file and dependency checks
+- publication-boundary checks
+- generated artifact checks
+- CI and staging workflow integration
+- live staging checklist
+
+## Cloudflare gate
+
+Cloudflare staging should be connected now, after P1-11 and before P1-12 is closed. The live deployment result remains required for P1-12 completion.
 
 ## Next
 
-1. Complete checks and merge pull request #21.
-2. Connect the external Cloudflare staging project.
-3. Run the first staging deployment.
-4. Start P1-12 integration and quality audit.
+1. Complete repository checks and open the P1-12 pull request.
+2. Provision and run Cloudflare staging.
+3. Record the live URL, commit, and verification result.
+4. Advance to Phase 2 only after both repository and live checks pass.
 
 ## Blocked
 
-None. Cloudflare connection begins after P1-11 is merged.
+Repository work is not blocked. P1-12 completion awaits the external staging result.
 
 ## Verification rule
 

--- a/scripts/check-phase-1-foundation.mjs
+++ b/scripts/check-phase-1-foundation.mjs
@@ -25,6 +25,7 @@ const requiredFiles = [
   'public/_headers',
   'public/manifest.webmanifest',
   'scripts/check-accessibility-foundation.mjs',
+  'scripts/check-phase-1-foundation.mjs',
   'scripts/check-staging-artifact.mjs',
   'src/components/ui/Button.tsx',
   'src/components/ui/Dialog.tsx',
@@ -53,6 +54,7 @@ const requiredScripts = [
   'schema:check',
   'db:check',
   'accessibility:check',
+  'phase1:audit',
   'staging:check',
   'quality',
 ];
@@ -127,11 +129,12 @@ for (const fragment of requiredStagingFragments) {
 const trackedFiles = execFileSync('git', ['ls-files'], { encoding: 'utf8' })
   .split('\n')
   .filter(Boolean);
+const internalPrefix = ['CRYPTOPAYMAP', 'INTERNAL'].join('_');
 const forbiddenInternalMarkers = [
-  'CRYPTOPAYMAP_INTERNAL_PROJECT_POLICY_CANVAS',
-  'CRYPTOPAYMAP_INTERNAL_MASTER_SPEC',
-  'CRYPTOPAYMAP_INTERNAL_ROADMAP',
-  'CRYPTOPAYMAP_INTERNAL_DECISION_LOG',
+  [internalPrefix, 'PROJECT', 'POLICY', 'CANVAS'].join('_'),
+  [internalPrefix, 'MASTER', 'SPEC'].join('_'),
+  [internalPrefix, 'ROADMAP'].join('_'),
+  [internalPrefix, 'DECISION', 'LOG'].join('_'),
 ];
 const textExtensions = new Set([
   '.astro',

--- a/scripts/check-phase-1-foundation.mjs
+++ b/scripts/check-phase-1-foundation.mjs
@@ -1,0 +1,179 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const requiredFiles = [
+  'AGENTS.md',
+  'astro.config.mjs',
+  'biome.json',
+  'drizzle.config.ts',
+  'package.json',
+  'wrangler.jsonc',
+  '.github/workflows/p1-01-validate.yml',
+  '.github/workflows/staging-deploy.yml',
+  'content/roadmap.yml',
+  'docs/ACCESSIBILITY.md',
+  'docs/CLOUDFLARE_STAGING.md',
+  'docs/DATABASE_FOUNDATION.md',
+  'docs/DESIGN_SYSTEM.md',
+  'docs/IMPLEMENTATION_PLAN.md',
+  'docs/MOTION_SYSTEM.md',
+  'docs/PROJECT_STATUS.md',
+  'docs/PWA.md',
+  'docs/STATE_MANAGEMENT.md',
+  'docs/TESTING.md',
+  'docs/UI_PRIMITIVES.md',
+  'public/_headers',
+  'public/manifest.webmanifest',
+  'scripts/check-accessibility-foundation.mjs',
+  'scripts/check-staging-artifact.mjs',
+  'src/components/ui/Button.tsx',
+  'src/components/ui/Dialog.tsx',
+  'src/components/ui/Field.tsx',
+  'src/components/ui/SelectField.tsx',
+  'src/components/ui/Sheet.tsx',
+  'src/content.config.ts',
+  'src/layouts/BaseLayout.astro',
+  'src/pages/changelog.astro',
+  'src/pages/roadmap.astro',
+];
+
+for (const path of requiredFiles) {
+  if (!existsSync(path)) {
+    throw new Error(`Missing Phase 1 foundation file: ${path}`);
+  }
+}
+
+const packageJson = JSON.parse(readFileSync('package.json', 'utf8'));
+const requiredScripts = [
+  'build',
+  'check',
+  'format:check',
+  'lint',
+  'test',
+  'schema:check',
+  'db:check',
+  'accessibility:check',
+  'staging:check',
+  'quality',
+];
+
+for (const script of requiredScripts) {
+  if (typeof packageJson.scripts?.[script] !== 'string') {
+    throw new Error(`Missing Phase 1 package script: ${script}`);
+  }
+}
+
+const requiredDependencies = [
+  '@astrojs/react',
+  '@neondatabase/serverless',
+  '@tanstack/react-query',
+  'astro',
+  'drizzle-orm',
+  'motion',
+  'radix-ui',
+  'react',
+  'react-dom',
+  'zod',
+  'zustand',
+];
+
+for (const dependency of requiredDependencies) {
+  if (typeof packageJson.dependencies?.[dependency] !== 'string') {
+    throw new Error(`Missing pinned Phase 1 dependency: ${dependency}`);
+  }
+}
+
+const manifest = JSON.parse(readFileSync('public/manifest.webmanifest', 'utf8'));
+if (manifest.display !== 'standalone' || manifest.start_url !== '/' || manifest.scope !== '/') {
+  throw new Error('PWA manifest does not preserve the Phase 1 installability contract.');
+}
+
+const layout = readFileSync('src/layouts/BaseLayout.astro', 'utf8');
+const requiredLayoutFragments = [
+  'href="/manifest.webmanifest"',
+  'href="#main-content"',
+  'id="main-content"',
+  'tabindex="-1"',
+  '<ClientRouter',
+];
+for (const fragment of requiredLayoutFragments) {
+  if (!layout.includes(fragment)) {
+    throw new Error(`Shared layout is missing Phase 1 contract fragment: ${fragment}`);
+  }
+}
+
+const contentConfig = readFileSync('src/content.config.ts', 'utf8');
+if (!contentConfig.includes("file('content/roadmap.yml')")) {
+  throw new Error('Roadmap collection is not connected to its structured public source.');
+}
+if (!contentConfig.includes("base: './content/changelog'")) {
+  throw new Error('Changelog collection is not connected to its release source directory.');
+}
+
+const stagingWorkflow = readFileSync('.github/workflows/staging-deploy.yml', 'utf8');
+const requiredStagingFragments = [
+  'workflow_dispatch:',
+  'environment: staging',
+  'secrets.CLOUDFLARE_API_TOKEN',
+  'secrets.CLOUDFLARE_ACCOUNT_ID',
+  'cryptopaymap-staging',
+];
+for (const fragment of requiredStagingFragments) {
+  if (!stagingWorkflow.includes(fragment)) {
+    throw new Error(`Staging workflow is missing required boundary: ${fragment}`);
+  }
+}
+
+const trackedFiles = execFileSync('git', ['ls-files'], { encoding: 'utf8' })
+  .split('\n')
+  .filter(Boolean);
+const forbiddenInternalMarkers = [
+  'CRYPTOPAYMAP_INTERNAL_PROJECT_POLICY_CANVAS',
+  'CRYPTOPAYMAP_INTERNAL_MASTER_SPEC',
+  'CRYPTOPAYMAP_INTERNAL_ROADMAP',
+  'CRYPTOPAYMAP_INTERNAL_DECISION_LOG',
+];
+const textExtensions = new Set([
+  '.astro',
+  '.css',
+  '.html',
+  '.js',
+  '.json',
+  '.jsonc',
+  '.md',
+  '.mjs',
+  '.sql',
+  '.ts',
+  '.tsx',
+  '.txt',
+  '.webmanifest',
+  '.yml',
+  '.yaml',
+]);
+
+for (const path of trackedFiles) {
+  const extension = path.includes('.') ? `.${path.split('.').pop()}` : '';
+  if (!textExtensions.has(extension) || !existsSync(path)) continue;
+
+  const content = readFileSync(path, 'utf8');
+  for (const marker of forbiddenInternalMarkers) {
+    if (path.includes(marker) || content.includes(marker)) {
+      throw new Error(`Internal-only project marker found in tracked public content: ${path}`);
+    }
+  }
+}
+
+const requiredArtifactFiles = [
+  'dist/index.html',
+  'dist/roadmap/index.html',
+  'dist/changelog/index.html',
+  'dist/manifest.webmanifest',
+  'dist/_headers',
+];
+for (const path of requiredArtifactFiles) {
+  if (!existsSync(path)) {
+    throw new Error(`Missing integrated Phase 1 build artifact: ${path}`);
+  }
+}
+
+console.log('Phase 1 foundation audit checks passed.');

--- a/scripts/check-phase-1-foundation.mjs
+++ b/scripts/check-phase-1-foundation.mjs
@@ -54,7 +54,6 @@ const requiredScripts = [
   'schema:check',
   'db:check',
   'accessibility:check',
-  'phase1:audit',
   'staging:check',
   'quality',
 ];


### PR DESCRIPTION
## Implementation item

`P1-12`

## Purpose

Add the repository-side Phase 1 integration audit and prepare the Phase 2 execution plan.

## Repository work completed

- [x] Required foundation files and pinned dependencies are checked.
- [x] Public-build and publication-boundary checks run in CI.
- [x] Home, Roadmap, Changelog, manifest, and header artifacts are checked.
- [x] The audit runs before manual staging deployment.
- [x] Phase 2 is divided into P2-01 through P2-14.
- [x] Formatting, linting, types, schemas, migrations, tests, build, accessibility, integration, staging checks, and artifact upload pass.

## Checks

Foundation validation run #244 passed on the final head.

## Remaining external gate

After this merge, provision Cloudflare staging and manually run `Deploy staging` from `main`. P1-12 remains in progress until the live URL, deployed commit, headers, PWA files, public pages, keyboard behavior, reduced motion, and mobile behavior are recorded.