### PR TITLE
P1-12: Record live Cloudflare staging verification

### DIFF
--- a/docs/PHASE_1_AUDIT.md
+++ b/docs/PHASE_1_AUDIT.md
@@ -1,20 +1,51 @@
 # Phase 1 integration audit
 
-**Status:** In progress  
+**Status:** Live staging pending  
 **Item:** `P1-12`
 
 ## Repository results
 
-P1-01 through P1-11 are merged. Their application shell, UI primitives, motion, state boundaries, database foundation, CI, staging contract, PWA metadata, accessibility baseline, and public content loaders are present.
+P1-01 through P1-11 are merged. The repository-side P1-12 audit was merged through PR #22 at main commit `98efe4304d2c85509c2a4810a9d1313f7da201d1`.
 
-The automated audit checks required files, dependencies, commands, manifest settings, shared layout contracts, public content sources, staging workflow boundaries, public-build artifacts, and tracked-file publication boundaries.
+Formatting, linting, types, runtime schemas, migration history, tests, static build, accessibility checks, the integrated Phase 1 audit, staging artifact validation, and artifact upload passed before merge.
 
-## External staging gate
+## External staging setup
 
-Create the Cloudflare Pages project `cryptopaymap-staging` and a GitHub environment named `staging`. Add environment values named `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, then manually run the `Deploy staging` workflow from merged `main`.
+Create:
 
-Record the deployment URL and commit SHA. Verify Home, Roadmap, Changelog, manifest, icons, response headers, keyboard focus, skip-link behavior, reduced motion, mobile viewport behavior, and the absence of private configuration in public files.
+```text
+Cloudflare Pages project: cryptopaymap-staging
+GitHub environment: staging
+Environment values:
+- CLOUDFLARE_API_TOKEN
+- CLOUDFLARE_ACCOUNT_ID
+```
+
+Then manually run `Deploy staging` from merged `main`.
+
+## Result record
+
+Complete these fields after deployment:
+
+```text
+Workflow run:
+Deployment URL:
+Deployed commit:
+Deployment time:
+```
+
+Verification:
+
+- [ ] Home loads successfully.
+- [ ] Roadmap loads and displays all public sections.
+- [ ] Changelog loads and displays the pre-release empty state.
+- [ ] Manifest and both application icons load.
+- [ ] Response security and cache headers are present.
+- [ ] Public files contain no private configuration values.
+- [ ] Skip-link and keyboard focus behavior work.
+- [ ] Reduced-motion behavior works.
+- [ ] Mobile viewport and safe-area behavior work.
 
 ## Completion rule
 
-P1-12 completes only after repository CI is green and the live staging deployment is recorded and checked. Until then, Phase 1 remains in progress and no live staging URL is claimed.
+P1-12 completes only after the result record and verification checklist are complete. Until then, Phase 1 remains in progress and no live staging URL is claimed.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -11,17 +11,15 @@ Phase 1 — Foundation
 
 `P1-12 — Phase 1 integration and quality audit`
 
-## Repository audit pull request
+## Repository audit
 
-[#22 — P1-12: Add Phase 1 integration audit](https://github.com/badjoke-lab/cryptopaymap/pull/22)
+PR #22 is merged at main commit `98efe4304d2c85509c2a4810a9d1313f7da201d1`.
 
-## Latest completed work
+## Active pull request
 
-- Phase 0 public specifications completed.
-- P1-01 through P1-05 completed through pull requests #11 through #15.
-- P1-06 through P1-11 completed through pull requests #16 through #21.
+[#23 — P1-12: Record live Cloudflare staging verification](https://github.com/badjoke-lab/cryptopaymap/pull/23)
 
-## P1-12 repository checks
+## Repository checks
 
 - integrated foundation file and dependency checks: passed
 - publication-boundary checks: passed
@@ -31,18 +29,19 @@ Phase 1 — Foundation
 
 ## Cloudflare gate
 
-Cloudflare staging should be connected now, after P1-11 and before P1-12 is closed. The live deployment result remains required for P1-12 completion.
+Cloudflare staging should be connected now. The live deployment result remains required for P1-12 completion.
 
 ## Next
 
-1. Merge the repository-side P1-12 audit.
-2. Provision and run Cloudflare staging from merged `main`.
-3. Record the live URL, commit, and verification result.
-4. Advance to Phase 2 only after both repository and live checks pass.
+1. Create the `cryptopaymap-staging` Pages project.
+2. Create the GitHub `staging` environment and configure the documented values.
+3. Run `Deploy staging` from merged `main`.
+4. Record the workflow, URL, commit, and verification results in PR #23.
+5. Merge PR #23 and advance to Phase 2.
 
 ## Blocked
 
-Repository work is not blocked. P1-12 completion awaits the external staging result.
+Repository work is complete. P1-12 awaits the external staging result.
 
 ## Verification rule
 


### PR DESCRIPTION
## Implementation item

`P1-12`

## Purpose

Record the first live Cloudflare Pages staging deployment and complete the Phase 1 external verification gate.

## Current state

- repository audit merged through PR #22
- live staging not yet provisioned
- result fields and verification checklist prepared

## Completion

Keep this pull request in draft until the deployment URL, deployed commit, workflow run, response checks, accessibility checks, and mobile checks are recorded.