### PR TITLE
P2-12: Add fail-closed export validation

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,11 +8,11 @@ Phase 2 — Data core
 
 ## Current implementation item
 
-P2-11 — Public export schemas
+P2-12 — Export allowlist and leakage validator
 
 ## Active pull request
 
-[#36 — P2-11: Add explicit public export schemas](https://github.com/badjoke-lab/cryptopaymap/pull/36)
+[#38 — P2-12: Add fail-closed export validation](https://github.com/badjoke-lab/cryptopaymap/pull/38)
 
 ## Latest completed work
 
@@ -25,16 +25,19 @@ P2-11 — Public export schemas
 - P2-08 completed through pull request #32.
 - P2-09 completed through pull request #34.
 - P2-10 completed through pull request #35.
+- P2-11 completed through pull request #36.
 
-## P2-11 in progress
+## P2-12 in progress
 
-- strict schemas for all 12 planned public JSON and GeoJSON files
-- canonical-only acceptance-claim projections
-- explicit place, map-pin, online-service, registry, stats, update, manifest, and version contracts
-- public media and evidence summaries without private storage or review fields
-- cross-field rules for location scope, processor routes, ended claims, and payment combinations
-- public identifiers that reject internal UUID-shaped values
-- runtime examples that reject candidate states, private fields, unknown keys, and invalid coordinates
+- exact allowlist for all 12 public artifact paths
+- strict schema parsing before release eligibility
+- recursive rejection of fields and URI schemes outside the public contract
+- deterministic canonical JSON and SHA-256 hashing
+- complete release-set validation rather than file-by-file publication
+- manifest path, media-type, schema-version, record-count, license, and digest checks
+- dataset-version and generation-time consistency checks
+- immutable validated release sets with no publication side effects
+- positive and negative automated checks
 - no database migration or Cloudflare dependency
 
 ## Cloudflare status
@@ -43,9 +46,9 @@ Live staging verification remains deferred in draft pull request #23 and does no
 
 ## Next
 
-1. Complete CI and merge pull request #36.
-2. Start P2-12 export allowlist and leakage validation.
-3. Keep live data generation and publication disabled until the fail-closed boundary is complete.
+1. Complete CI and merge pull request #38.
+2. Start P2-13 physical-place candidate importer.
+3. Keep live publication disabled until import and integration checks are complete.
 
 ## Blocked
 

--- a/docs/PUBLIC_EXPORT_BOUNDARY.md
+++ b/docs/PUBLIC_EXPORT_BOUNDARY.md
@@ -1,0 +1,155 @@
+# CryptoPayMap public export boundary
+
+## Purpose
+
+CryptoPayMap does not publish database rows directly. A generated release must pass a fail-closed validation boundary before it can be considered eligible to replace the last valid public snapshot.
+
+P2-11 defines the shape of each public JSON and GeoJSON file. P2-12 validates the complete release as one coordinated set.
+
+## Validation order
+
+A candidate release is checked in the following order:
+
+1. every path must be on the public export allowlist;
+2. all required public files must be present;
+3. each file must pass its strict public schema;
+4. nested content must not contain fields or URI schemes outside the public contract;
+5. dataset versions, schema versions, and generation timestamps must agree;
+6. the manifest must contain exactly one entry for every inventory file;
+7. manifest media types, record counts, and SHA-256 digests must match the files;
+8. only after all checks pass is an immutable validated release set returned.
+
+Any failure rejects the whole candidate release. Partial validation is not publication approval.
+
+## Public path allowlist
+
+The allowlist is the exact set declared by `publicExportPaths`:
+
+```text
+/data/locations-osm.json
+/data/acceptance-claims.json
+/data/place-pins.json
+/data/places.json
+/data/places.geojson
+/data/online-services.json
+/data/stats.json
+/data/updates.json
+/data/assets.json
+/data/networks.json
+/data/manifest.json
+/version.json
+```
+
+An extra file is rejected even when its JSON is otherwise valid. A missing file also rejects the release.
+
+## Strict schema layer
+
+Every file is parsed through its P2-11 schema. Public objects reject unknown keys rather than stripping them silently.
+
+This prevents an operational record from becoming publishable merely because it can be serialized. Export builders must construct named public projections and provide only the fields defined by the contract.
+
+## Recursive content scan
+
+After schema parsing, the validator walks every nested object and array.
+
+It rejects field-name patterns associated with operational-only material, including internal, candidate, submission, review, contact, audit, storage, payload, credential, and secret-bearing fields. It also rejects non-public URI schemes such as local files, object-storage references, embedded data, and private bucket identifiers.
+
+The recursive scan is defense in depth. The strict schemas remain the primary field allowlist.
+
+## Stable canonical JSON
+
+Hashes use a deterministic JSON representation:
+
+- object keys are sorted recursively;
+- array order is preserved;
+- the serialized document ends with a newline;
+- SHA-256 is calculated with the platform Web Crypto implementation.
+
+The same logical object therefore produces the same digest regardless of object insertion order.
+
+## Manifest inventory
+
+The manifest inventories every public file except the manifest itself. Each entry contains:
+
+- exact public path;
+- JSON or GeoJSON media type;
+- schema version;
+- public record count;
+- SHA-256 digest;
+- applicable public licenses.
+
+The validator rejects:
+
+- missing entries;
+- duplicate entries;
+- entries for files outside the release inventory;
+- incorrect media types;
+- incorrect counts;
+- incorrect schema versions;
+- incorrect hashes.
+
+`version.json` is included in the manifest inventory. The manifest is excluded because including its own digest would create a circular value.
+
+## Release consistency
+
+All files in one release must use the same:
+
+- `schemaVersion`;
+- `generatedAt` value.
+
+The manifest and version file must also use the same `datasetVersion`.
+
+A file produced by a different build or generation time cannot be mixed into the release without failing validation.
+
+## Record counts
+
+Counts are calculated from the actual artifact:
+
+- record files use `records.length`;
+- GeoJSON uses `features.length`;
+- Stats and Version each count as one document;
+- the manifest is not part of its own inventory.
+
+Counts are public dataset counts only. Candidate queues and operational review totals remain outside this layer.
+
+## Immutable validated result
+
+A successful call returns a deeply frozen artifact map. Publication code can calculate a stable release digest from this validated map.
+
+The validator has no publication side effects. It does not write to the final public directory, deploy to Cloudflare, or update a database publication state. A later publisher must preserve this sequence:
+
+```text
+build candidate files
+→ validate complete set
+→ stage validated snapshot
+→ atomically switch public pointer
+→ record successful publication
+```
+
+A failed candidate must leave the previous valid public snapshot unchanged.
+
+## Automated checks
+
+The repository checks a complete representative release and confirms that it succeeds. It also confirms failure for cases including:
+
+- an extra unapproved path;
+- a missing required file;
+- a candidate acceptance status;
+- an unexpected operational field;
+- a wrong manifest hash;
+- a wrong manifest count;
+- a generation-time mismatch.
+
+The checks run through the unit-test workflow and are independent of Cloudflare or a live database.
+
+## Scope boundary
+
+P2-12 provides validation and release-set integrity. It does not yet provide:
+
+- database queries that construct the projections;
+- physical or online legacy importers;
+- a filesystem or object-storage publisher;
+- live public data;
+- publication scheduling.
+
+Those later components must call this boundary rather than bypass it.

--- a/scripts/check-public-export-boundary.ts
+++ b/scripts/check-public-export-boundary.ts
@@ -281,18 +281,20 @@ artifacts['/data/manifest.json'] = {
   ...header,
   datasetVersion,
   canonicalOnly: true,
-  files: inventoryPaths.map((path) => ({
-    path,
-    mediaType: path === '/data/places.geojson' ? 'application/geo+json' : 'application/json',
-    schemaVersion,
-    recordCount: recordCount(path, artifacts[path]),
-    sha256: hashPublicArtifact(artifacts[path]),
-    licenses: ['odc-by-1-0'],
-  })),
+  files: await Promise.all(
+    inventoryPaths.map(async (path) => ({
+      path,
+      mediaType: path === '/data/places.geojson' ? 'application/geo+json' : 'application/json',
+      schemaVersion,
+      recordCount: recordCount(path, artifacts[path]),
+      sha256: await hashPublicArtifact(artifacts[path]),
+      licenses: ['odc-by-1-0'],
+    })),
+  ),
 };
 
-const validated = validatePublicArtifactSet(artifacts);
-const digest = publicSnapshotDigest(validated);
+const validated = await validatePublicArtifactSet(artifacts);
+const digest = await publicSnapshotDigest(validated);
 if (!/^[a-f0-9]{64}$/.test(digest) || !Object.isFrozen(validated)) {
   throw new Error('Validated release sets must be immutable and have a stable SHA-256 digest.');
 }
@@ -317,7 +319,7 @@ const withCandidateState = structuredClone(artifacts);
   withCandidateState['/data/acceptance-claims.json'] as {
     records: Array<{ status: string }>;
   }
-).records[0].status = 'candidate';
+).records[0]!.status = 'candidate';
 invalidSets.push(withCandidateState);
 
 const withUnexpectedField = structuredClone(artifacts);
@@ -325,7 +327,7 @@ const withUnexpectedField = structuredClone(artifacts);
   withUnexpectedField['/data/places.json'] as {
     records: Array<Record<string, unknown>>;
   }
-).records[0].internalMetadata = 'not publishable';
+).records[0]!.internalMetadata = 'not publishable';
 invalidSets.push(withUnexpectedField);
 
 const withWrongHash = structuredClone(artifacts);
@@ -351,7 +353,7 @@ invalidSets.push(withMismatchedTime);
 
 for (const invalid of invalidSets) {
   try {
-    validatePublicArtifactSet(invalid);
+    await validatePublicArtifactSet(invalid);
     throw new Error('An invalid release set passed validation.');
   } catch (error) {
     if (!(error instanceof PublicExportBoundaryError)) {

--- a/scripts/check-public-export-boundary.ts
+++ b/scripts/check-public-export-boundary.ts
@@ -1,0 +1,363 @@
+import {
+  findNonPublicContent,
+  hashPublicArtifact,
+  PublicExportBoundaryError,
+  publicSnapshotDigest,
+  validatePublicArtifactSet,
+} from '../src/publication/export-boundary';
+import { publicExportPaths, type PublicExportPath } from '../src/schemas/public-exports';
+
+const generatedAt = '2026-06-27T00:00:00Z';
+const schemaVersion = '1.0.0';
+const datasetVersion = '2026.06.27.1';
+const header = { schemaVersion, generatedAt };
+
+const evidence = {
+  kind: 'official_payment_page',
+  evidenceClass: 'a',
+  sourceType: 'official_page',
+  polarity: 'supporting',
+  sourceName: 'Example Coffee',
+  sourceUrl: 'https://example.com/payments',
+  archiveUrl: null,
+  observedAt: generatedAt,
+  publishedAt: null,
+  summary: 'The official payment page documents Lightning checkout.',
+};
+
+const paymentAsset = {
+  assetSlug: 'bitcoin',
+  assetSymbol: 'BTC',
+  networkSlug: 'lightning',
+  paymentMethod: 'lightning_invoice',
+  contractAddress: null,
+  isPrimary: true,
+  notes: null,
+};
+
+const placeClaim = {
+  claimKey: 'example-coffee-lightning',
+  entitySlug: 'example-coffee',
+  locationSlug: 'example-coffee-tokyo',
+  claimScope: 'location_specific',
+  acceptanceScope: 'all_checkout',
+  status: 'confirmed',
+  routeType: 'direct_wallet',
+  processorSlug: null,
+  howToPay: 'Ask staff to display a Lightning invoice and scan the QR code.',
+  instructionsLanguage: 'en',
+  merchantReceives: 'crypto',
+  restrictions: null,
+  firstConfirmedAt: generatedAt,
+  lastConfirmedAt: generatedAt,
+  nextReviewAt: '2026-12-27T00:00:00Z',
+  endedAt: null,
+  endedReason: null,
+  paymentAssets: [paymentAsset],
+  evidence: [evidence],
+};
+
+const onlineClaim = {
+  ...placeClaim,
+  claimKey: 'example-vpn-checkout',
+  entitySlug: 'example-vpn',
+  locationSlug: null,
+  claimScope: 'online_service',
+  routeType: 'processor_checkout',
+  processorSlug: 'example-processor',
+  howToPay: 'Choose cryptocurrency at checkout and follow the processor instructions.',
+};
+
+const media = {
+  role: 'cover',
+  url: 'https://media.example.com/example.webp',
+  mimeType: 'image/webp',
+  width: 960,
+  height: 540,
+  altText: 'Exterior of Example Coffee.',
+  attribution: 'Photo supplied by Example Coffee.',
+  licenseSlug: 'merchant-permission',
+};
+
+const provenance = {
+  sourceName: 'OpenStreetMap contributors',
+  sourceUrl: 'https://www.openstreetmap.org/node/123',
+  licenseSlug: 'odbl-1-0',
+  attribution: '© OpenStreetMap contributors',
+  fields: ['addressLine', 'latitude', 'longitude'],
+};
+
+const pin = {
+  placeSlug: 'example-coffee-tokyo',
+  name: 'Example Coffee',
+  categorySlug: 'cafe',
+  countryCode: 'JP',
+  locality: 'Tokyo',
+  latitude: 35.681236,
+  longitude: 139.767125,
+  status: 'confirmed',
+  assetSlugs: ['bitcoin'],
+  networkSlugs: ['lightning'],
+  routeTypes: ['direct_wallet'],
+  lastConfirmedAt: generatedAt,
+  thumbnail: media,
+};
+
+const pinProperties = Object.fromEntries(
+  Object.entries(pin).filter(([key]) => !['latitude', 'longitude'].includes(key)),
+);
+
+const artifacts: Record<string, unknown> = {
+  '/data/locations-osm.json': {
+    ...header,
+    records: [
+      {
+        locationSlug: 'example-coffee-tokyo',
+        name: 'Example Coffee',
+        addressLine: '1 Example Street',
+        locality: 'Tokyo',
+        region: 'Tokyo',
+        postalCode: '100-0001',
+        countryCode: 'JP',
+        latitude: 35.681236,
+        longitude: 139.767125,
+        osmType: 'node',
+        osmId: '123',
+        websiteUrl: 'https://example.com',
+        sourceUrl: 'https://www.openstreetmap.org/node/123',
+        attribution: '© OpenStreetMap contributors',
+        licenseSlug: 'odbl-1-0',
+      },
+    ],
+  },
+  '/data/acceptance-claims.json': { ...header, records: [placeClaim, onlineClaim] },
+  '/data/place-pins.json': { ...header, records: [pin] },
+  '/data/places.json': {
+    ...header,
+    records: [
+      {
+        placeSlug: 'example-coffee-tokyo',
+        entitySlug: 'example-coffee',
+        name: 'Example Coffee',
+        categorySlug: 'cafe',
+        entityStatus: 'active',
+        locationStatus: 'active',
+        addressLine: '1 Example Street',
+        locality: 'Tokyo',
+        region: 'Tokyo',
+        postalCode: '100-0001',
+        countryCode: 'JP',
+        latitude: 35.681236,
+        longitude: 139.767125,
+        websiteUrl: 'https://example.com',
+        claims: [placeClaim],
+        media: [media],
+        provenance: [provenance],
+      },
+    ],
+  },
+  '/data/places.geojson': {
+    ...header,
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [139.767125, 35.681236] },
+        properties: pinProperties,
+      },
+    ],
+  },
+  '/data/online-services.json': {
+    ...header,
+    records: [
+      {
+        serviceSlug: 'example-vpn',
+        name: 'Example VPN',
+        categorySlug: 'vpn',
+        entityStatus: 'active',
+        countryCode: null,
+        websiteUrl: 'https://vpn.example.com',
+        claims: [onlineClaim],
+        media: [],
+        provenance: [
+          {
+            ...provenance,
+            sourceName: 'Example VPN',
+            sourceUrl: 'https://vpn.example.com/payments',
+            licenseSlug: 'odc-by-1-0',
+            attribution: null,
+            fields: ['websiteUrl', 'claims'],
+          },
+        ],
+      },
+    ],
+  },
+  '/data/stats.json': {
+    ...header,
+    stats: {
+      confirmedPhysicalPlaces: 1,
+      confirmedOnlineServices: 1,
+      countries: 1,
+      cities: 1,
+      staleRecords: 0,
+      endedRecords: 0,
+      directWalletClaims: 1,
+      processorCheckoutClaims: 1,
+      howToPayCoverage: 1,
+      networkSpecifiedRate: 1,
+      evidenceBackedRate: 1,
+      reconfirmedWithin90Days: 1,
+      reconfirmedWithin180Days: 1,
+      staleRate: 0,
+      topAssets: [{ key: 'bitcoin', count: 2 }],
+      topNetworks: [{ key: 'lightning', count: 2 }],
+    },
+  },
+  '/data/updates.json': {
+    ...header,
+    records: [
+      {
+        updateKey: 'example-coffee-confirmed',
+        updateType: 'newly_confirmed',
+        subjectType: 'place',
+        subjectSlug: 'example-coffee-tokyo',
+        title: 'Example Coffee confirmed',
+        summary: 'Lightning checkout was confirmed from an official payment page.',
+        effectiveAt: generatedAt,
+      },
+    ],
+  },
+  '/data/assets.json': {
+    ...header,
+    records: [
+      {
+        slug: 'bitcoin',
+        symbol: 'BTC',
+        name: 'Bitcoin',
+        aliases: ['XBT'],
+        assetType: 'native',
+        isStablecoin: false,
+        isWrapped: false,
+        defaultDecimals: 8,
+        status: 'active',
+      },
+    ],
+  },
+  '/data/networks.json': {
+    ...header,
+    records: [
+      {
+        slug: 'lightning',
+        name: 'Bitcoin Lightning',
+        aliases: ['LN'],
+        status: 'active',
+      },
+    ],
+  },
+  '/version.json': {
+    projectId: 'cryptopaymap',
+    siteName: 'CryptoPayMap',
+    registryType: 'crypto_payment_acceptance',
+    datasetVersion,
+    schemaVersion,
+    generatedAt,
+    canonicalOnly: true,
+    verificationMarker: 'reviewed_public_records_only',
+  },
+};
+
+function recordCount(path: PublicExportPath, value: unknown): number {
+  if (path === '/version.json' || path === '/data/stats.json') {
+    return 1;
+  }
+  if (path === '/data/places.geojson') {
+    return (value as { features: unknown[] }).features.length;
+  }
+  return (value as { records: unknown[] }).records.length;
+}
+
+const inventoryPaths = publicExportPaths.filter((path) => path !== '/data/manifest.json');
+artifacts['/data/manifest.json'] = {
+  ...header,
+  datasetVersion,
+  canonicalOnly: true,
+  files: inventoryPaths.map((path) => ({
+    path,
+    mediaType: path === '/data/places.geojson' ? 'application/geo+json' : 'application/json',
+    schemaVersion,
+    recordCount: recordCount(path, artifacts[path]),
+    sha256: hashPublicArtifact(artifacts[path]),
+    licenses: ['odc-by-1-0'],
+  })),
+};
+
+const validated = validatePublicArtifactSet(artifacts);
+const digest = publicSnapshotDigest(validated);
+if (!/^[a-f0-9]{64}$/.test(digest) || !Object.isFrozen(validated)) {
+  throw new Error('Validated release sets must be immutable and have a stable SHA-256 digest.');
+}
+
+const detected = findNonPublicContent({ internalMetadata: 'not publishable' });
+if (detected.length !== 1) {
+  throw new Error('Recursive non-public field detection failed.');
+}
+
+const invalidSets: Record<string, unknown>[] = [];
+
+const withExtraFile = structuredClone(artifacts);
+withExtraFile['/data/unreviewed.json'] = { records: [] };
+invalidSets.push(withExtraFile);
+
+const withMissingFile = structuredClone(artifacts);
+delete withMissingFile['/data/networks.json'];
+invalidSets.push(withMissingFile);
+
+const withCandidateState = structuredClone(artifacts);
+(
+  withCandidateState['/data/acceptance-claims.json'] as {
+    records: Array<{ status: string }>;
+  }
+).records[0].status = 'candidate';
+invalidSets.push(withCandidateState);
+
+const withUnexpectedField = structuredClone(artifacts);
+(
+  withUnexpectedField['/data/places.json'] as {
+    records: Array<Record<string, unknown>>;
+  }
+).records[0].internalMetadata = 'not publishable';
+invalidSets.push(withUnexpectedField);
+
+const withWrongHash = structuredClone(artifacts);
+(
+  withWrongHash['/data/manifest.json'] as {
+    files: Array<{ path: string; sha256: string }>;
+  }
+).files.find((entry) => entry.path === '/data/places.json')!.sha256 = '0'.repeat(64);
+invalidSets.push(withWrongHash);
+
+const withWrongCount = structuredClone(artifacts);
+(
+  withWrongCount['/data/manifest.json'] as {
+    files: Array<{ path: string; recordCount: number }>;
+  }
+).files.find((entry) => entry.path === '/data/place-pins.json')!.recordCount = 99;
+invalidSets.push(withWrongCount);
+
+const withMismatchedTime = structuredClone(artifacts);
+(withMismatchedTime['/data/assets.json'] as { generatedAt: string }).generatedAt =
+  '2026-06-28T00:00:00Z';
+invalidSets.push(withMismatchedTime);
+
+for (const invalid of invalidSets) {
+  try {
+    validatePublicArtifactSet(invalid);
+    throw new Error('An invalid release set passed validation.');
+  } catch (error) {
+    if (!(error instanceof PublicExportBoundaryError)) {
+      throw error;
+    }
+  }
+}
+
+console.log(`Public export boundary checks passed for ${publicExportPaths.length} artifacts.`);

--- a/src/publication/export-boundary.ts
+++ b/src/publication/export-boundary.ts
@@ -1,0 +1,71 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+import {
+  publicExportPaths,
+  publicExportSchemaByPath,
+  type PublicExportPath,
+} from '../schemas/public-exports';
+
+export type PublicArtifactInput = Record<string, unknown>;
+export type ValidatedPublicArtifactSet = Readonly<Record<PublicExportPath, unknown>>;
+
+const publicExportPathSet = new Set<string>(publicExportPaths);
+
+export class PublicExportBoundaryError extends Error {
+  readonly issues: readonly string[];
+
+  constructor(message: string, issues: readonly string[]) {
+    super(message);
+    this.name = 'PublicExportBoundaryError';
+    this.issues = issues;
+  }
+}
+
+function zodIssues(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? `$.${issue.path.join('.')}` : '$';
+    return `${path}: ${issue.message}`;
+  });
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)]),
+    );
+  }
+
+  return value;
+}
+
+export function canonicalPublicJson(value: unknown): string {
+  return `${JSON.stringify(canonicalize(value))}\n`;
+}
+
+export function hashPublicArtifact(value: unknown): string {
+  return createHash('sha256').update(canonicalPublicJson(value)).digest('hex');
+}
+
+export function validatePublicArtifact(path: string, value: unknown): unknown {
+  if (!publicExportPathSet.has(path)) {
+    throw new PublicExportBoundaryError('Unrecognized public artifact path.', [
+      `${path}: path is not in the public export allowlist`,
+    ]);
+  }
+
+  const publicPath = path as PublicExportPath;
+  const result = publicExportSchemaByPath[publicPath].safeParse(value);
+  if (!result.success) {
+    throw new PublicExportBoundaryError(`Public artifact schema validation failed for ${path}.`, [
+      ...zodIssues(result.error),
+    ]);
+  }
+
+  return result.data;
+}

--- a/src/publication/export-boundary.ts
+++ b/src/publication/export-boundary.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { z } from 'zod';
 import {
   publicExportPaths,
@@ -14,6 +13,7 @@ export type ValidatedPublicArtifactSet = Readonly<Record<PublicExportPath, unkno
 const publicExportPathSet = new Set<string>(publicExportPaths);
 const manifestPath: PublicExportPath = '/data/manifest.json';
 const manifestInventoryPaths = publicExportPaths.filter((path) => path !== manifestPath);
+const manifestInventoryPathSet = new Set<PublicExportPath>(manifestInventoryPaths);
 const blockedKeyPatterns = [
   /^internal/,
   /^private/,
@@ -107,8 +107,10 @@ export function canonicalPublicJson(value: unknown): string {
   return `${JSON.stringify(canonicalize(value))}\n`;
 }
 
-export function hashPublicArtifact(value: unknown): string {
-  return createHash('sha256').update(canonicalPublicJson(value)).digest('hex');
+export async function hashPublicArtifact(value: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(canonicalPublicJson(value));
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
 function deepFreeze<T>(value: T): T {
@@ -138,7 +140,10 @@ export function validatePublicArtifact(path: string, value: unknown): unknown {
 
   const nonPublicContent = findNonPublicContent(result.data);
   if (nonPublicContent.length > 0) {
-    throw new PublicExportBoundaryError(`Non-public content was found in ${path}.`, nonPublicContent);
+    throw new PublicExportBoundaryError(
+      `Non-public content was found in ${path}.`,
+      nonPublicContent,
+    );
   }
 
   return result.data;
@@ -168,7 +173,9 @@ function artifactGeneratedAt(value: unknown): string {
   return (value as { generatedAt: string }).generatedAt;
 }
 
-export function validatePublicArtifactSet(input: PublicArtifactInput): ValidatedPublicArtifactSet {
+export async function validatePublicArtifactSet(
+  input: PublicArtifactInput,
+): Promise<ValidatedPublicArtifactSet> {
   const issues: string[] = [];
   const inputPaths = Object.keys(input);
 
@@ -185,7 +192,10 @@ export function validatePublicArtifactSet(input: PublicArtifactInput): Validated
   }
 
   if (issues.length > 0) {
-    throw new PublicExportBoundaryError('Public artifact set is incomplete or contains extra files.', issues);
+    throw new PublicExportBoundaryError(
+      'Public artifact set is incomplete or contains extra files.',
+      issues,
+    );
   }
 
   const parsed = {} as Record<PublicExportPath, unknown>;
@@ -251,13 +261,13 @@ export function validatePublicArtifactSet(input: PublicArtifactInput): Validated
     if (entry.recordCount !== recordCount(path, parsed[path])) {
       issues.push(`${path}: manifest record count does not match the artifact`);
     }
-    if (entry.sha256 !== hashPublicArtifact(parsed[path])) {
+    if (entry.sha256 !== (await hashPublicArtifact(parsed[path]))) {
       issues.push(`${path}: manifest SHA-256 does not match the artifact`);
     }
   }
 
   for (const path of manifestEntries.keys()) {
-    if (!manifestInventoryPaths.includes(path)) {
+    if (!manifestInventoryPathSet.has(path)) {
       issues.push(`${path}: manifest entry is not part of the release inventory`);
     }
   }
@@ -273,7 +283,9 @@ export function validatePublicArtifactSet(input: PublicArtifactInput): Validated
   return deepFreeze(parsed) as ValidatedPublicArtifactSet;
 }
 
-export function publicSnapshotDigest(artifacts: ValidatedPublicArtifactSet): string {
+export async function publicSnapshotDigest(
+  artifacts: ValidatedPublicArtifactSet,
+): Promise<string> {
   return hashPublicArtifact(
     Object.fromEntries(publicExportPaths.map((path) => [path, artifacts[path]])),
   );

--- a/src/publication/export-boundary.ts
+++ b/src/publication/export-boundary.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import {
   publicExportPaths,
   publicExportSchemaByPath,
+  publicManifestFileSchema,
+  publicVersionSchema,
   type PublicExportPath,
 } from '../schemas/public-exports';
 
@@ -10,6 +12,8 @@ export type PublicArtifactInput = Record<string, unknown>;
 export type ValidatedPublicArtifactSet = Readonly<Record<PublicExportPath, unknown>>;
 
 const publicExportPathSet = new Set<string>(publicExportPaths);
+const manifestPath: PublicExportPath = '/data/manifest.json';
+const manifestInventoryPaths = publicExportPaths.filter((path) => path !== manifestPath);
 const blockedKeyPatterns = [
   /^internal/,
   /^private/,
@@ -107,6 +111,16 @@ export function hashPublicArtifact(value: unknown): string {
   return createHash('sha256').update(canonicalPublicJson(value)).digest('hex');
 }
 
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value)) {
+      deepFreeze(child);
+    }
+  }
+  return value;
+}
+
 export function validatePublicArtifact(path: string, value: unknown): unknown {
   if (!publicExportPathSet.has(path)) {
     throw new PublicExportBoundaryError('Unrecognized public artifact path.', [
@@ -128,4 +142,139 @@ export function validatePublicArtifact(path: string, value: unknown): unknown {
   }
 
   return result.data;
+}
+
+function recordCount(path: PublicExportPath, value: unknown): number {
+  if (path === '/version.json' || path === '/data/stats.json') {
+    return 1;
+  }
+
+  if (path === '/data/places.geojson') {
+    return (value as { features: unknown[] }).features.length;
+  }
+
+  return (value as { records: unknown[] }).records.length;
+}
+
+function expectedMediaType(path: PublicExportPath): 'application/json' | 'application/geo+json' {
+  return path === '/data/places.geojson' ? 'application/geo+json' : 'application/json';
+}
+
+function artifactSchemaVersion(value: unknown): string {
+  return (value as { schemaVersion: string }).schemaVersion;
+}
+
+function artifactGeneratedAt(value: unknown): string {
+  return (value as { generatedAt: string }).generatedAt;
+}
+
+export function validatePublicArtifactSet(input: PublicArtifactInput): ValidatedPublicArtifactSet {
+  const issues: string[] = [];
+  const inputPaths = Object.keys(input);
+
+  for (const path of inputPaths) {
+    if (!publicExportPathSet.has(path)) {
+      issues.push(`${path}: path is not in the public export allowlist`);
+    }
+  }
+
+  for (const path of publicExportPaths) {
+    if (!Object.hasOwn(input, path)) {
+      issues.push(`${path}: required public artifact is missing`);
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new PublicExportBoundaryError('Public artifact set is incomplete or contains extra files.', issues);
+  }
+
+  const parsed = {} as Record<PublicExportPath, unknown>;
+  for (const path of publicExportPaths) {
+    try {
+      parsed[path] = validatePublicArtifact(path, input[path]);
+    } catch (error) {
+      if (error instanceof PublicExportBoundaryError) {
+        issues.push(...error.issues.map((issue) => `${path} ${issue}`));
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new PublicExportBoundaryError('One or more public artifacts failed validation.', issues);
+  }
+
+  const manifest = publicManifestFileSchema.parse(parsed[manifestPath]);
+  const version = publicVersionSchema.parse(parsed['/version.json']);
+
+  if (manifest.datasetVersion !== version.datasetVersion) {
+    issues.push('manifest and version datasetVersion values do not match');
+  }
+  if (manifest.schemaVersion !== version.schemaVersion) {
+    issues.push('manifest and version schemaVersion values do not match');
+  }
+  if (manifest.generatedAt !== version.generatedAt) {
+    issues.push('manifest and version generatedAt values do not match');
+  }
+
+  for (const path of publicExportPaths) {
+    if (artifactGeneratedAt(parsed[path]) !== version.generatedAt) {
+      issues.push(`${path}: generatedAt does not match the release version`);
+    }
+    if (artifactSchemaVersion(parsed[path]) !== version.schemaVersion) {
+      issues.push(`${path}: schemaVersion does not match the release version`);
+    }
+  }
+
+  const manifestEntries = new Map<PublicExportPath, (typeof manifest.files)[number]>();
+  for (const entry of manifest.files) {
+    if (manifestEntries.has(entry.path)) {
+      issues.push(`${entry.path}: duplicate manifest entry`);
+    }
+    manifestEntries.set(entry.path, entry);
+  }
+
+  for (const path of manifestInventoryPaths) {
+    const entry = manifestEntries.get(path);
+    if (entry === undefined) {
+      issues.push(`${path}: missing manifest entry`);
+      continue;
+    }
+
+    if (entry.mediaType !== expectedMediaType(path)) {
+      issues.push(`${path}: manifest media type does not match the artifact`);
+    }
+    if (entry.schemaVersion !== artifactSchemaVersion(parsed[path])) {
+      issues.push(`${path}: manifest schema version does not match the artifact`);
+    }
+    if (entry.recordCount !== recordCount(path, parsed[path])) {
+      issues.push(`${path}: manifest record count does not match the artifact`);
+    }
+    if (entry.sha256 !== hashPublicArtifact(parsed[path])) {
+      issues.push(`${path}: manifest SHA-256 does not match the artifact`);
+    }
+  }
+
+  for (const path of manifestEntries.keys()) {
+    if (!manifestInventoryPaths.includes(path)) {
+      issues.push(`${path}: manifest entry is not part of the release inventory`);
+    }
+  }
+
+  if (manifestEntries.size !== manifestInventoryPaths.length) {
+    issues.push('manifest inventory must contain exactly one entry for every publishable file');
+  }
+
+  if (issues.length > 0) {
+    throw new PublicExportBoundaryError('Public artifact set failed release validation.', issues);
+  }
+
+  return deepFreeze(parsed) as ValidatedPublicArtifactSet;
+}
+
+export function publicSnapshotDigest(artifacts: ValidatedPublicArtifactSet): string {
+  return hashPublicArtifact(
+    Object.fromEntries(publicExportPaths.map((path) => [path, artifacts[path]])),
+  );
 }

--- a/src/publication/export-boundary.ts
+++ b/src/publication/export-boundary.ts
@@ -283,9 +283,7 @@ export async function validatePublicArtifactSet(
   return deepFreeze(parsed) as ValidatedPublicArtifactSet;
 }
 
-export async function publicSnapshotDigest(
-  artifacts: ValidatedPublicArtifactSet,
-): Promise<string> {
+export async function publicSnapshotDigest(artifacts: ValidatedPublicArtifactSet): Promise<string> {
   return hashPublicArtifact(
     Object.fromEntries(publicExportPaths.map((path) => [path, artifacts[path]])),
   );

--- a/src/publication/export-boundary.ts
+++ b/src/publication/export-boundary.ts
@@ -10,6 +10,21 @@ export type PublicArtifactInput = Record<string, unknown>;
 export type ValidatedPublicArtifactSet = Readonly<Record<PublicExportPath, unknown>>;
 
 const publicExportPathSet = new Set<string>(publicExportPaths);
+const blockedKeyPatterns = [
+  /^internal/,
+  /^private/,
+  /storagekey$/,
+  /payload$/,
+  /^submission/,
+  /^candidate/,
+  /^review/,
+  /^contact/,
+  /^audit/,
+  /credential/,
+  /secret/,
+  /tokenhash$/,
+] as const;
+const nonPublicUriSchemes = new Set(['file:', 'r2:', 's3:', 'gs:', 'data:']);
 
 export class PublicExportBoundaryError extends Error {
   readonly issues: readonly string[];
@@ -21,11 +36,51 @@ export class PublicExportBoundaryError extends Error {
   }
 }
 
+function normalizeKey(key: string): string {
+  return key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
 function zodIssues(error: z.ZodError): string[] {
   return error.issues.map((issue) => {
     const path = issue.path.length > 0 ? `$.${issue.path.join('.')}` : '$';
     return `${path}: ${issue.message}`;
   });
+}
+
+export function findNonPublicContent(value: unknown, path = '$'): string[] {
+  const issues: string[] = [];
+
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => {
+      issues.push(...findNonPublicContent(entry, `${path}[${index}]`));
+    });
+    return issues;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return issues;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    const normalizedKey = normalizeKey(key);
+
+    if (blockedKeyPatterns.some((pattern) => pattern.test(normalizedKey))) {
+      issues.push(`${childPath}: field is outside the public contract`);
+    }
+
+    if (typeof child === 'string') {
+      const separator = child.indexOf(':');
+      const scheme = separator >= 0 ? child.slice(0, separator + 1).toLowerCase() : '';
+      if (nonPublicUriSchemes.has(scheme)) {
+        issues.push(`${childPath}: URI scheme is not publishable`);
+      }
+    }
+
+    issues.push(...findNonPublicContent(child, childPath));
+  }
+
+  return issues;
 }
 
 function canonicalize(value: unknown): unknown {
@@ -65,6 +120,11 @@ export function validatePublicArtifact(path: string, value: unknown): unknown {
     throw new PublicExportBoundaryError(`Public artifact schema validation failed for ${path}.`, [
       ...zodIssues(result.error),
     ]);
+  }
+
+  const nonPublicContent = findNonPublicContent(result.data);
+  if (nonPublicContent.length > 0) {
+    throw new PublicExportBoundaryError(`Non-public content was found in ${path}.`, nonPublicContent);
   }
 
   return result.data;

--- a/tests/public-export-boundary.test.ts
+++ b/tests/public-export-boundary.test.ts
@@ -6,9 +6,9 @@ describe('public export boundary', () => {
     await expect(import('../scripts/check-public-export-boundary')).resolves.toBeDefined();
   });
 
-  it('canonicalizes artifact hashes independently of object key order', () => {
-    expect(hashPublicArtifact({ beta: 2, alpha: 1 })).toBe(
-      hashPublicArtifact({ alpha: 1, beta: 2 }),
+  it('canonicalizes artifact hashes independently of object key order', async () => {
+    await expect(hashPublicArtifact({ beta: 2, alpha: 1 })).resolves.toBe(
+      await hashPublicArtifact({ alpha: 1, beta: 2 }),
     );
   });
 

--- a/tests/public-export-boundary.test.ts
+++ b/tests/public-export-boundary.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { findNonPublicContent, hashPublicArtifact } from '../src/publication/export-boundary';
+
+describe('public export boundary', () => {
+  it('runs the complete release-set contract checks', async () => {
+    await expect(import('../scripts/check-public-export-boundary')).resolves.toBeDefined();
+  });
+
+  it('canonicalizes artifact hashes independently of object key order', () => {
+    expect(hashPublicArtifact({ beta: 2, alpha: 1 })).toBe(
+      hashPublicArtifact({ alpha: 1, beta: 2 }),
+    );
+  });
+
+  it('detects fields outside the public contract recursively', () => {
+    expect(findNonPublicContent({ nested: { internalMetadata: 'not publishable' } })).toEqual([
+      '$.nested.internalMetadata: field is outside the public contract',
+    ]);
+  });
+});


### PR DESCRIPTION
## Implementation item

`P2-12`

## Purpose

Add the fail-closed publication boundary that validates complete public artifact sets before any generated snapshot can replace the last valid release.

## Completed

- exact allowlist for all 12 public artifact paths
- strict P2-11 schema parsing before release eligibility
- recursive detection of fields and URI schemes outside the public contract
- deterministic canonical JSON with platform Web Crypto SHA-256 hashing
- complete release-set validation rather than independent file approval
- manifest path, media type, schema version, record count, and digest validation
- manifest and version dataset consistency checks
- one generation timestamp and schema version across the release
- immutable validated release sets and stable snapshot digest
- no publication side effects on failed validation
- complete positive fixture and negative cases for extra files, missing files, candidate states, unexpected fields, wrong hashes, wrong counts, and mixed generation times
- public documentation and project status update

## Validation

- Foundation validation: passed
- formatting and lint: passed
- Astro and TypeScript checks: passed
- runtime schema checks: passed
- migration drift: passed
- public export boundary unit tests: passed
- full unit and component suite: passed
- static build: passed
- accessibility and staging artifact checks: passed

## Excluded

- database export queries
- filesystem or Cloudflare publication
- physical and online candidate importers
- live public data

## Next

P2-13 — Physical-place candidate importer.