### PR TITLE
P2-13: Add physical-place candidate importer

### DIFF
--- a/.github/workflows/p1-01-validate.yml
+++ b/.github/workflows/p1-01-validate.yml
@@ -11,9 +11,42 @@ on:
       - 'docs/**'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
+  finalize-p213-format:
+    if: github.event_name == 'pull_request' && github.head_ref == 'work/p213'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out P2-13 branch
+        uses: actions/checkout@v4
+        with:
+          ref: work/p213
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Format P2-13 files
+        run: npm run format
+
+      - name: Restore permanent workflow and commit
+        run: |
+          git fetch origin main --depth=1
+          git show origin/main:.github/workflows/p1-01-validate.yml > .github/workflows/p1-01-validate.yml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "P2-13: format physical importer files"
+          git push origin HEAD:work/p213
+
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/p1-01-validate.yml
+++ b/.github/workflows/p1-01-validate.yml
@@ -11,42 +11,9 @@ on:
       - 'docs/**'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  finalize-p213-format:
-    if: github.event_name == 'pull_request' && github.head_ref == 'work/p213'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Check out P2-13 branch
-        uses: actions/checkout@v4
-        with:
-          ref: work/p213
-          fetch-depth: 0
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.18.0
-          cache: npm
-
-      - name: Install locked dependencies
-        run: npm ci --no-audit --no-fund
-
-      - name: Format P2-13 files
-        run: npm run format
-
-      - name: Restore permanent workflow and commit
-        run: |
-          git fetch origin main --depth=1
-          git show origin/main:.github/workflows/p1-01-validate.yml > .github/workflows/p1-01-validate.yml
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "P2-13: format physical importer files"
-          git push origin HEAD:work/p213
-
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -67,10 +67,10 @@ Phase 2 establishes the Candidate-to-canonical-to-public-export path. It does no
 | P2-07 | Evidence schema and source capture | Completed | P2-05 | [#31](https://github.com/badjoke-lab/cryptopaymap/pull/31) |
 | P2-08 | Verification event history | Completed | P2-05, P2-07 | [#32](https://github.com/badjoke-lab/cryptopaymap/pull/32) |
 | P2-09 | Source candidates, provenance, and duplicate boundaries | Completed | P2-04, P2-07 | [#34](https://github.com/badjoke-lab/cryptopaymap/pull/34) |
-| P2-10 | Media metadata and legacy identifiers | In progress | P2-04, P2-09 | [#35](https://github.com/badjoke-lab/cryptopaymap/pull/35) |
-| P2-11 | Public export schemas | Planned | P2-05 through P2-10 | — |
-| P2-12 | Export allowlist and leakage validator | Planned | P2-11 | — |
-| P2-13 | Physical-place candidate importer | Planned | P2-09, P2-10, P2-12 | — |
+| P2-10 | Media metadata and legacy identifiers | Completed | P2-04, P2-09 | [#35](https://github.com/badjoke-lab/cryptopaymap/pull/35), [#37](https://github.com/badjoke-lab/cryptopaymap/pull/37) |
+| P2-11 | Public export schemas | Completed | P2-05 through P2-10 | [#36](https://github.com/badjoke-lab/cryptopaymap/pull/36) |
+| P2-12 | Export allowlist and leakage validator | Completed | P2-11 | [#38](https://github.com/badjoke-lab/cryptopaymap/pull/38) |
+| P2-13 | Physical-place candidate importer | In progress | P2-09, P2-10, P2-12 | [#39](https://github.com/badjoke-lab/cryptopaymap/pull/39) |
 | P2-14 | Online-service importer and Phase 2 integration audit | Planned | P2-09, P2-12, P2-13 | — |
 
 ### P2-01 — Asset registry

--- a/docs/PHYSICAL_PLACE_IMPORTER.md
+++ b/docs/PHYSICAL_PLACE_IMPORTER.md
@@ -1,0 +1,139 @@
+# CryptoPayMap physical-place candidate importer
+
+## Purpose
+
+P2-13 imports legacy physical-place rows into the private source and candidate layers. It does not create canonical entities, canonical locations, acceptance claims, verification events, or public export records.
+
+```text
+legacy physical row
+  -> strict row validation
+  -> immutable source-record draft
+  -> private physical-place candidate draft
+  -> pending legacy-ID mapping
+  -> duplicate review signals
+```
+
+Promotion remains a separate administrative review action in Phase 3.
+
+## Input envelope
+
+Each import run supplies:
+
+- registered source UUID;
+- optional license UUID;
+- import-batch UUID;
+- fetch time;
+- semantic importer version;
+- one or more untrusted legacy rows.
+
+The batch envelope is validated separately from each row. A malformed row is rejected without aborting valid rows in the same batch.
+
+## Accepted legacy fields
+
+A physical row may contain:
+
+- legacy ID and legacy path;
+- name;
+- address fields;
+- ISO country code;
+- latitude and longitude;
+- category candidate;
+- HTTP or HTTPS website;
+- paired OpenStreetMap type and ID;
+- `payment:*` source tags;
+- observation time;
+- source URL;
+- legacy verification label.
+
+HTML-like names, invalid coordinates, unsupported URL schemes, malformed OSM identity pairs, and unknown fields fail row validation.
+
+## Deterministic identity
+
+The importer derives stable UUID-shaped identifiers from SHA-256 material for:
+
+- the private source candidate;
+- each immutable source-record observation;
+- the pending legacy-ID mapping.
+
+The candidate identity is stable for a legacy source ID. The source-record identity includes the canonical content hash, so a changed observation can be represented separately while an exact replay remains idempotent.
+
+The input checksum covers the validated and rejected batch outcome together with source and importer metadata.
+
+## Candidate-only boundary
+
+Every accepted row produces:
+
+- `candidate_type = physical_place`;
+- `candidate_status = new`;
+- no canonical entity ID;
+- no canonical location ID;
+- one origin relationship to its source record;
+- one `cryptopaymap_v2` legacy mapping in `pending` state;
+- normalized review data for later administration.
+
+The import plan has no acceptance-claim field and reports `automaticConfirmedCount = 0`.
+
+Legacy verification labels and payment tags are preserved as source and review data. They do not map to Confirmed status.
+
+## Payment tags
+
+Affirmative `payment:*` tags are surfaced as review signals only.
+
+The importer does not infer:
+
+- a network from an asset symbol;
+- an on-chain method from a Bitcoin tag;
+- a Lightning invoice method from a generic Lightning tag;
+- a merchant's current asset set from processor capability;
+- a How-to-pay instruction.
+
+A reviewer must resolve asset, network, route, payment method, Evidence, and instructions before canonical promotion.
+
+## Replay and conflict handling
+
+Within one batch:
+
+- the same legacy ID with identical normalized content is recorded as a replay and does not create a second draft;
+- the same legacy ID with different content is rejected as a conflicting legacy identity;
+- invalid rows are returned as structured rejections.
+
+Across runs, stable candidate and source-record identities support idempotent persistence by the later database writer.
+
+## Duplicate review signals
+
+The importer emits signals without merging candidates.
+
+```text
+shared_osm_identity
+  strength: strong
+
+same_name_and_coordinates
+  strength: review
+```
+
+A signal is evidence for administrative review, not an automatic duplicate decision. Brand and branch identity remain separate.
+
+## Ten-record proof
+
+The runtime check imports ten representative physical rows and verifies:
+
+- all ten remain private new candidates;
+- no canonical target is assigned;
+- all legacy mappings remain pending;
+- no acceptance claim is produced;
+- repeated execution produces the same checksum and identifiers;
+- invalid rows are rejected independently;
+- exact replays are collapsed;
+- shared OSM identity creates a review signal rather than a merge.
+
+## Excluded from P2-13
+
+- database writes and transaction handling;
+- canonical promotion;
+- Evidence threshold evaluation;
+- public JSON generation;
+- online-service imports;
+- live legacy database access;
+- Cloudflare or Neon credentials.
+
+P2-14 adds the online-service importer and the Phase 2 integration audit. Phase 3 adds the administrative review and persistence path.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,11 +8,11 @@ Phase 2 — Data core
 
 ## Current implementation item
 
-P2-12 — Export allowlist and leakage validator
+P2-13 — Physical-place candidate importer
 
 ## Active pull request
 
-[#38 — P2-12: Add fail-closed export validation](https://github.com/badjoke-lab/cryptopaymap/pull/38)
+[#39 — P2-13: Add physical-place candidate importer](https://github.com/badjoke-lab/cryptopaymap/pull/39)
 
 ## Latest completed work
 
@@ -25,20 +25,21 @@ P2-12 — Export allowlist and leakage validator
 - P2-08 completed through pull request #32.
 - P2-09 completed through pull request #34.
 - P2-10 completed through pull request #35.
+- P2-10 database guard follow-up completed through pull request #37.
 - P2-11 completed through pull request #36.
+- P2-12 completed through pull request #38.
 
-## P2-12 in progress
+## P2-13 in progress
 
-- exact allowlist for all 12 public artifact paths
-- strict schema parsing before release eligibility
-- recursive rejection of fields and URI schemes outside the public contract
-- deterministic canonical JSON and SHA-256 hashing
-- complete release-set validation rather than file-by-file publication
-- manifest path, media-type, schema-version, record-count, license, and digest checks
-- dataset-version and generation-time consistency checks
-- immutable validated release sets with no publication side effects
-- positive and negative automated checks
-- no database migration or Cloudflare dependency
+- strict validation for untrusted legacy physical-place rows
+- deterministic candidate, source-record, and legacy-mapping identities
+- immutable raw payload and SHA-256 content provenance
+- candidate-only output with pending legacy mappings
+- exact replay collapse and conflicting legacy-ID rejection
+- OSM-identity and same-name/same-coordinate review signals without automatic merge
+- preservation of source payment tags without asset, network, method, or Confirmed inference
+- ten-record runtime proof and positive/negative unit tests
+- no database write, live legacy access, public export, or Cloudflare dependency
 
 ## Cloudflare status
 
@@ -46,9 +47,9 @@ Live staging verification remains deferred in draft pull request #23 and does no
 
 ## Next
 
-1. Complete CI and merge pull request #38.
-2. Start P2-13 physical-place candidate importer.
-3. Keep live publication disabled until import and integration checks are complete.
+1. Complete CI and merge pull request #39.
+2. Start P2-14 online-service importer and Phase 2 integration audit.
+3. Keep imported candidates private until Phase 3 administrative review and promotion.
 
 ## Blocked
 

--- a/scripts/check-physical-place-importer.ts
+++ b/scripts/check-physical-place-importer.ts
@@ -75,7 +75,11 @@ if (
 
 const duplicateInput = {
   ...envelope,
-  records: [record(1), record(1), { ...record(2), legacyId: 'legacy-place-duplicate', osmId: '10001' }],
+  records: [
+    record(1),
+    record(1),
+    { ...record(2), legacyId: 'legacy-place-duplicate', osmId: '10001' },
+  ],
 };
 const duplicatePlan = await createPhysicalPlaceImportPlan(duplicateInput);
 if (
@@ -88,7 +92,10 @@ if (
 
 const invalidPlan = await createPhysicalPlaceImportPlan({
   ...envelope,
-  records: [{ ...record(1), latitude: 190 }, { ...record(2), name: '<script>bad</script>' }],
+  records: [
+    { ...record(1), latitude: 190 },
+    { ...record(2), name: '<script>bad</script>' },
+  ],
 });
 if (invalidPlan.summary.rejectedCount !== 2 || invalidPlan.summary.acceptedCount !== 0) {
   throw new Error('Invalid physical records were not quarantined as rejections.');

--- a/scripts/check-physical-place-importer.ts
+++ b/scripts/check-physical-place-importer.ts
@@ -1,0 +1,97 @@
+import { createPhysicalPlaceImportPlan } from '../src/importers/physical-place';
+
+const sourceId = '11111111-1111-4111-8111-111111111111';
+const licenseId = '22222222-2222-4222-8222-222222222222';
+const importBatchId = '33333333-3333-4333-8333-333333333333';
+const fetchedAt = '2026-06-27T00:00:00Z';
+
+function record(index: number) {
+  return {
+    legacyId: `legacy-place-${index}`,
+    legacyPath: `/place/legacy-place-${index}`,
+    name: `Example Place ${index}`,
+    addressLine: `${index} Example Street`,
+    locality: 'Tokyo',
+    region: 'Tokyo',
+    postalCode: `100-00${String(index).padStart(2, '0')}`,
+    countryCode: 'jp',
+    latitude: 35.68 + index / 10_000,
+    longitude: 139.76 + index / 10_000,
+    category: index % 2 === 0 ? 'cafe' : 'shop',
+    websiteUrl: `https://example.com/place-${index}`,
+    osmType: 'node',
+    osmId: String(10_000 + index),
+    paymentTags: index % 2 === 0 ? { 'payment:bitcoin': 'yes' } : {},
+    observedAt: `2026-06-${String(10 + index).padStart(2, '0')}T00:00:00Z`,
+    sourceUrl: null,
+    legacyVerificationLabel: index % 2 === 0 ? 'legacy-listed' : null,
+  };
+}
+
+const envelope = {
+  sourceId,
+  licenseId,
+  importBatchId,
+  fetchedAt,
+  importerVersion: '1.0.0',
+  records: Array.from({ length: 10 }, (_, index) => record(index + 1)),
+};
+
+const plan = await createPhysicalPlaceImportPlan(envelope);
+const replayPlan = await createPhysicalPlaceImportPlan(envelope);
+
+if (
+  plan.summary.inputCount !== 10 ||
+  plan.summary.acceptedCount !== 10 ||
+  plan.summary.rejectedCount !== 0 ||
+  plan.summary.automaticConfirmedCount !== 0
+) {
+  throw new Error('The physical importer did not preserve the ten-record candidate-only boundary.');
+}
+
+if (
+  plan.drafts.some(
+    (draft) =>
+      draft.candidate.candidateStatus !== 'new' ||
+      draft.candidate.canonicalEntityId !== null ||
+      draft.candidate.canonicalLocationId !== null ||
+      draft.legacyMapping.migrationStatus !== 'pending' ||
+      Object.hasOwn(draft, 'acceptanceClaim'),
+  )
+) {
+  throw new Error('A legacy physical record crossed the canonical or Confirmed boundary.');
+}
+
+if (
+  plan.inputChecksum !== replayPlan.inputChecksum ||
+  plan.drafts.some(
+    (draft, index) =>
+      draft.candidateId !== replayPlan.drafts[index]?.candidateId ||
+      draft.sourceRecordId !== replayPlan.drafts[index]?.sourceRecordId,
+  )
+) {
+  throw new Error('Physical import identities are not deterministic.');
+}
+
+const duplicateInput = {
+  ...envelope,
+  records: [record(1), record(1), { ...record(2), legacyId: 'legacy-place-duplicate', osmId: '10001' }],
+};
+const duplicatePlan = await createPhysicalPlaceImportPlan(duplicateInput);
+if (
+  duplicatePlan.summary.acceptedCount !== 2 ||
+  duplicatePlan.summary.replayedCount !== 1 ||
+  !duplicatePlan.duplicateSignals.some((signal) => signal.reason === 'shared_osm_identity')
+) {
+  throw new Error('Replay or duplicate-signal handling failed.');
+}
+
+const invalidPlan = await createPhysicalPlaceImportPlan({
+  ...envelope,
+  records: [{ ...record(1), latitude: 190 }, { ...record(2), name: '<script>bad</script>' }],
+});
+if (invalidPlan.summary.rejectedCount !== 2 || invalidPlan.summary.acceptedCount !== 0) {
+  throw new Error('Invalid physical records were not quarantined as rejections.');
+}
+
+console.log('Physical-place importer checks passed.');

--- a/scripts/check-runtime-schemas.ts
+++ b/scripts/check-runtime-schemas.ts
@@ -3,6 +3,7 @@ import './check-canonical-identity';
 import './check-claim-assets';
 import './check-evidence';
 import './check-media-legacy';
+import './check-physical-place-importer';
 import './check-source-provenance';
 import './check-verification-events';
 import { assetRegistry, findAssetCandidates } from '../src/registries/assets';

--- a/src/importers/physical-place.ts
+++ b/src/importers/physical-place.ts
@@ -148,6 +148,7 @@ function sourceUrl(record: LegacyPhysicalPlaceRecord): string | null {
 
 async function createDraft(
   envelope: PhysicalPlaceImportEnvelope,
+  rawRecord: unknown,
   record: LegacyPhysicalPlaceRecord,
   contentHash: string,
 ): Promise<PhysicalPlaceImportDraft> {
@@ -168,7 +169,8 @@ async function createDraft(
     rawPayload: {
       sourceSystem: 'cryptopaymap_v2',
       importerVersion: envelope.importerVersion,
-      record,
+      rawRecord,
+      normalizedRecord: record,
     },
     observedAt,
     publishedAt: null,
@@ -298,7 +300,7 @@ function issueStrings(error: {
   issues: Array<{ path: PropertyKey[]; message: string }>;
 }): string[] {
   return error.issues.map((issue) => {
-    const path = issue.path.length === 0 ? '$' : `$.${issue.path.join('.')}`;
+    const path = issue.path.length === 0 ? '$' : `$.${issue.path.map(String).join('.')}`;
     return `${path}: ${issue.message}`;
   });
 }
@@ -322,18 +324,19 @@ export async function createPhysicalPlaceImportPlan(
   for (const [inputIndex, unknownRecord] of envelope.records.entries()) {
     const result = legacyPhysicalPlaceRecordSchema.safeParse(unknownRecord);
     if (!result.success) {
+      const issues = issueStrings(result.error);
       rejections.push({
         inputIndex,
         legacyId: possibleLegacyId(unknownRecord),
         reason: 'invalid_record',
-        issues: issueStrings(result.error),
+        issues,
       });
-      checksumRecords.push({ inputIndex, rejected: issueStrings(result.error) });
+      checksumRecords.push({ inputIndex, rawRecord: unknownRecord, rejected: issues });
       continue;
     }
 
     const record = result.data;
-    const contentHash = await sha256(record);
+    const contentHash = await sha256(unknownRecord);
     const existing = seenLegacyIds.get(record.legacyId);
     if (existing !== undefined) {
       if (existing.contentHash === contentHash) {
@@ -350,14 +353,14 @@ export async function createPhysicalPlaceImportPlan(
           issues: ['$.legacyId: the same legacy ID has conflicting content in this batch'],
         });
       }
-      checksumRecords.push({ inputIndex, record, replayOrConflict: true });
+      checksumRecords.push({ inputIndex, rawRecord: unknownRecord, replayOrConflict: true });
       continue;
     }
 
-    const draft = await createDraft(envelope, record, contentHash);
+    const draft = await createDraft(envelope, unknownRecord, record, contentHash);
     seenLegacyIds.set(record.legacyId, { contentHash, sourceRecordId: draft.sourceRecordId });
     drafts.push(draft);
-    checksumRecords.push({ inputIndex, record });
+    checksumRecords.push({ inputIndex, rawRecord: unknownRecord });
   }
 
   const detectedDuplicateSignals = duplicateSignals(drafts);

--- a/src/importers/physical-place.ts
+++ b/src/importers/physical-place.ts
@@ -112,10 +112,7 @@ async function sha256(value: unknown): Promise<string> {
 }
 
 async function deterministicUuid(label: string): Promise<string> {
-  const digest = await globalThis.crypto.subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(label),
-  );
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(label));
   const bytes = new Uint8Array(digest).slice(0, 16);
   bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x80;
   bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
@@ -292,10 +289,14 @@ function duplicateSignals(drafts: PhysicalPlaceImportDraft[]): PhysicalPlaceDupl
     }
   }
 
-  return [...signals.values()].sort((left, right) => signalKey(left).localeCompare(signalKey(right)));
+  return [...signals.values()].sort((left, right) =>
+    signalKey(left).localeCompare(signalKey(right)),
+  );
 }
 
-function issueStrings(error: { issues: Array<{ path: PropertyKey[]; message: string }> }): string[] {
+function issueStrings(error: {
+  issues: Array<{ path: PropertyKey[]; message: string }>;
+}): string[] {
   return error.issues.map((issue) => {
     const path = issue.path.length === 0 ? '$' : `$.${issue.path.join('.')}`;
     return `${path}: ${issue.message}`;
@@ -336,7 +337,11 @@ export async function createPhysicalPlaceImportPlan(
     const existing = seenLegacyIds.get(record.legacyId);
     if (existing !== undefined) {
       if (existing.contentHash === contentHash) {
-        replays.push({ inputIndex, legacyId: record.legacyId, sourceRecordId: existing.sourceRecordId });
+        replays.push({
+          inputIndex,
+          legacyId: record.legacyId,
+          sourceRecordId: existing.sourceRecordId,
+        });
       } else {
         rejections.push({
           inputIndex,

--- a/src/importers/physical-place.ts
+++ b/src/importers/physical-place.ts
@@ -1,0 +1,383 @@
+import {
+  candidateSourceRecordInputSchema,
+  normalizeCandidateName,
+  sourceCandidateInputSchema,
+  sourceRecordInputSchema,
+  type SourceCandidateInput,
+  type SourceRecordInput,
+} from '../schemas/source-provenance';
+import { legacyPlaceIdInputSchema, type LegacyPlaceIdInput } from '../schemas/media-legacy';
+import {
+  legacyPhysicalPlaceRecordSchema,
+  physicalPlaceImportEnvelopeSchema,
+  type LegacyPhysicalPlaceRecord,
+  type PhysicalPlaceImportEnvelope,
+} from '../schemas/physical-place-import';
+
+export interface PhysicalPlaceReviewData {
+  name: string;
+  addressLine: string | null;
+  locality: string | null;
+  region: string | null;
+  postalCode: string | null;
+  countryCode: string;
+  latitude: number;
+  longitude: number;
+  category: string | null;
+  websiteUrl: string | null;
+  osmType: 'node' | 'way' | 'relation' | null;
+  osmId: string | null;
+  paymentTags: Record<string, string>;
+  affirmativePaymentSignals: string[];
+  legacyVerificationLabel: string | null;
+  requiresAcceptanceReview: boolean;
+}
+
+export interface PhysicalPlaceImportDraft {
+  candidateId: string;
+  sourceRecordId: string;
+  legacyMappingId: string;
+  sourceRecord: SourceRecordInput;
+  candidate: SourceCandidateInput;
+  candidateSourceRecord: {
+    candidateId: string;
+    sourceRecordId: string;
+    relationship: 'origin';
+  };
+  legacyMapping: LegacyPlaceIdInput;
+  reviewData: PhysicalPlaceReviewData;
+}
+
+export interface PhysicalPlaceImportRejection {
+  inputIndex: number;
+  legacyId: string | null;
+  reason: 'invalid_record' | 'conflicting_legacy_identity';
+  issues: string[];
+}
+
+export interface PhysicalPlaceReplay {
+  inputIndex: number;
+  legacyId: string;
+  sourceRecordId: string;
+}
+
+export interface PhysicalPlaceDuplicateSignal {
+  leftCandidateId: string;
+  rightCandidateId: string;
+  reason: 'shared_osm_identity' | 'same_name_and_coordinates';
+  strength: 'strong' | 'review';
+}
+
+export interface PhysicalPlaceImportPlan {
+  importerVersion: string;
+  importBatchId: string;
+  inputChecksum: string;
+  drafts: PhysicalPlaceImportDraft[];
+  rejections: PhysicalPlaceImportRejection[];
+  replays: PhysicalPlaceReplay[];
+  duplicateSignals: PhysicalPlaceDuplicateSignal[];
+  summary: {
+    inputCount: number;
+    acceptedCount: number;
+    rejectedCount: number;
+    replayedCount: number;
+    duplicateSignalCount: number;
+    automaticConfirmedCount: 0;
+  };
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)]),
+    );
+  }
+
+  return value;
+}
+
+async function sha256(value: unknown): Promise<string> {
+  const serialized = JSON.stringify(canonicalize(value));
+  const digest = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(serialized),
+  );
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function deterministicUuid(label: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(label),
+  );
+  const bytes = new Uint8Array(digest).slice(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x80;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function affirmativePaymentSignals(paymentTags: Record<string, string>): string[] {
+  const affirmativeValues = new Set(['1', 'accepted', 'on', 'true', 'yes']);
+  return Object.entries(paymentTags)
+    .filter(([, value]) => affirmativeValues.has(value.trim().toLowerCase()))
+    .map(([key]) => key)
+    .sort();
+}
+
+function candidatePriority(record: LegacyPhysicalPlaceRecord): number {
+  let priority = 100;
+  if (record.websiteUrl !== null) priority += 200;
+  if (record.osmType !== null) priority += 250;
+  if (affirmativePaymentSignals(record.paymentTags).length > 0) priority += 250;
+  if (record.observedAt !== null) priority += 100;
+  if (record.sourceUrl !== null) priority += 100;
+  return Math.min(priority, 1_000);
+}
+
+function sourceUrl(record: LegacyPhysicalPlaceRecord): string | null {
+  if (record.sourceUrl !== null) return record.sourceUrl;
+  if (record.osmType !== null && record.osmId !== null) {
+    return `https://www.openstreetmap.org/${record.osmType}/${record.osmId}`;
+  }
+  return null;
+}
+
+async function createDraft(
+  envelope: PhysicalPlaceImportEnvelope,
+  record: LegacyPhysicalPlaceRecord,
+  contentHash: string,
+): Promise<PhysicalPlaceImportDraft> {
+  const candidateId = await deterministicUuid(`candidate:cryptopaymap_v2:${record.legacyId}`);
+  const externalId = `physical:${contentHash}`;
+  const sourceRecordId = await deterministicUuid(
+    `source-record:${envelope.sourceId}:${externalId}`,
+  );
+  const legacyMappingId = await deterministicUuid(
+    `legacy-place-id:cryptopaymap_v2:${record.legacyId}`,
+  );
+  const observedAt = record.observedAt ?? envelope.fetchedAt;
+
+  const sourceRecord = sourceRecordInputSchema.parse({
+    sourceId: envelope.sourceId,
+    externalId,
+    sourceUrl: sourceUrl(record),
+    rawPayload: {
+      sourceSystem: 'cryptopaymap_v2',
+      importerVersion: envelope.importerVersion,
+      record,
+    },
+    observedAt,
+    publishedAt: null,
+    fetchedAt: envelope.fetchedAt,
+    contentHash,
+    archiveUrl: null,
+    licenseId: envelope.licenseId,
+  });
+
+  const candidate = sourceCandidateInputSchema.parse({
+    candidateType: 'physical_place',
+    normalizedName: normalizeCandidateName(record.name),
+    candidateStatus: 'new',
+    priority: candidatePriority(record),
+    duplicateGroupId: null,
+    firstSeenAt: observedAt,
+    lastSeenAt: observedAt,
+    importBatchId: envelope.importBatchId,
+    canonicalEntityId: null,
+    canonicalLocationId: null,
+  });
+
+  const candidateSourceRecord = candidateSourceRecordInputSchema.parse({
+    candidateId,
+    sourceRecordId,
+    relationship: 'origin',
+  }) as PhysicalPlaceImportDraft['candidateSourceRecord'];
+
+  const legacyMapping = legacyPlaceIdInputSchema.parse({
+    sourceSystem: 'cryptopaymap_v2',
+    legacyId: record.legacyId,
+    legacyPath: record.legacyPath,
+    migrationStatus: 'pending',
+    canonicalPath: null,
+    entityId: null,
+    locationId: null,
+    sourceRecordId,
+    resolutionNote: null,
+    resolvedAt: null,
+  });
+
+  const paymentSignals = affirmativePaymentSignals(record.paymentTags);
+
+  return {
+    candidateId,
+    sourceRecordId,
+    legacyMappingId,
+    sourceRecord,
+    candidate,
+    candidateSourceRecord,
+    legacyMapping,
+    reviewData: {
+      name: record.name,
+      addressLine: record.addressLine,
+      locality: record.locality,
+      region: record.region,
+      postalCode: record.postalCode,
+      countryCode: record.countryCode,
+      latitude: record.latitude,
+      longitude: record.longitude,
+      category: record.category,
+      websiteUrl: record.websiteUrl,
+      osmType: record.osmType,
+      osmId: record.osmId,
+      paymentTags: record.paymentTags,
+      affirmativePaymentSignals: paymentSignals,
+      legacyVerificationLabel: record.legacyVerificationLabel,
+      requiresAcceptanceReview: paymentSignals.length > 0,
+    },
+  };
+}
+
+function signalKey(signal: PhysicalPlaceDuplicateSignal): string {
+  return [signal.leftCandidateId, signal.rightCandidateId, signal.reason].join(':');
+}
+
+function duplicateSignals(drafts: PhysicalPlaceImportDraft[]): PhysicalPlaceDuplicateSignal[] {
+  const signals = new Map<string, PhysicalPlaceDuplicateSignal>();
+  const osmOwners = new Map<string, string>();
+  const locationOwners = new Map<string, string>();
+
+  const addSignal = (
+    leftCandidateId: string,
+    rightCandidateId: string,
+    reason: PhysicalPlaceDuplicateSignal['reason'],
+    strength: PhysicalPlaceDuplicateSignal['strength'],
+  ) => {
+    if (leftCandidateId === rightCandidateId) return;
+    const [left, right] = [leftCandidateId, rightCandidateId].sort();
+    const signal = {
+      leftCandidateId: left ?? leftCandidateId,
+      rightCandidateId: right ?? rightCandidateId,
+      reason,
+      strength,
+    };
+    signals.set(signalKey(signal), signal);
+  };
+
+  for (const draft of drafts) {
+    const { reviewData, candidateId } = draft;
+    if (reviewData.osmType !== null && reviewData.osmId !== null) {
+      const osmKey = `${reviewData.osmType}:${reviewData.osmId}`;
+      const owner = osmOwners.get(osmKey);
+      if (owner !== undefined) addSignal(owner, candidateId, 'shared_osm_identity', 'strong');
+      else osmOwners.set(osmKey, candidateId);
+    }
+
+    const locationKey = [
+      draft.candidate.normalizedName,
+      reviewData.latitude.toFixed(6),
+      reviewData.longitude.toFixed(6),
+    ].join(':');
+    const owner = locationOwners.get(locationKey);
+    if (owner !== undefined) {
+      addSignal(owner, candidateId, 'same_name_and_coordinates', 'review');
+    } else {
+      locationOwners.set(locationKey, candidateId);
+    }
+  }
+
+  return [...signals.values()].sort((left, right) => signalKey(left).localeCompare(signalKey(right)));
+}
+
+function issueStrings(error: { issues: Array<{ path: PropertyKey[]; message: string }> }): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length === 0 ? '$' : `$.${issue.path.join('.')}`;
+    return `${path}: ${issue.message}`;
+  });
+}
+
+function possibleLegacyId(value: unknown): string | null {
+  if (value === null || typeof value !== 'object') return null;
+  const legacyId = (value as Record<string, unknown>).legacyId;
+  return typeof legacyId === 'string' && legacyId.trim().length > 0 ? legacyId.trim() : null;
+}
+
+export async function createPhysicalPlaceImportPlan(
+  input: unknown,
+): Promise<PhysicalPlaceImportPlan> {
+  const envelope = physicalPlaceImportEnvelopeSchema.parse(input);
+  const drafts: PhysicalPlaceImportDraft[] = [];
+  const rejections: PhysicalPlaceImportRejection[] = [];
+  const replays: PhysicalPlaceReplay[] = [];
+  const seenLegacyIds = new Map<string, { contentHash: string; sourceRecordId: string }>();
+  const checksumRecords: unknown[] = [];
+
+  for (const [inputIndex, unknownRecord] of envelope.records.entries()) {
+    const result = legacyPhysicalPlaceRecordSchema.safeParse(unknownRecord);
+    if (!result.success) {
+      rejections.push({
+        inputIndex,
+        legacyId: possibleLegacyId(unknownRecord),
+        reason: 'invalid_record',
+        issues: issueStrings(result.error),
+      });
+      checksumRecords.push({ inputIndex, rejected: issueStrings(result.error) });
+      continue;
+    }
+
+    const record = result.data;
+    const contentHash = await sha256(record);
+    const existing = seenLegacyIds.get(record.legacyId);
+    if (existing !== undefined) {
+      if (existing.contentHash === contentHash) {
+        replays.push({ inputIndex, legacyId: record.legacyId, sourceRecordId: existing.sourceRecordId });
+      } else {
+        rejections.push({
+          inputIndex,
+          legacyId: record.legacyId,
+          reason: 'conflicting_legacy_identity',
+          issues: ['$.legacyId: the same legacy ID has conflicting content in this batch'],
+        });
+      }
+      checksumRecords.push({ inputIndex, record, replayOrConflict: true });
+      continue;
+    }
+
+    const draft = await createDraft(envelope, record, contentHash);
+    seenLegacyIds.set(record.legacyId, { contentHash, sourceRecordId: draft.sourceRecordId });
+    drafts.push(draft);
+    checksumRecords.push({ inputIndex, record });
+  }
+
+  const detectedDuplicateSignals = duplicateSignals(drafts);
+  const inputChecksum = await sha256({
+    sourceId: envelope.sourceId,
+    licenseId: envelope.licenseId,
+    importerVersion: envelope.importerVersion,
+    records: checksumRecords,
+  });
+
+  return {
+    importerVersion: envelope.importerVersion,
+    importBatchId: envelope.importBatchId,
+    inputChecksum,
+    drafts,
+    rejections,
+    replays,
+    duplicateSignals: detectedDuplicateSignals,
+    summary: {
+      inputCount: envelope.records.length,
+      acceptedCount: drafts.length,
+      rejectedCount: rejections.length,
+      replayedCount: replays.length,
+      duplicateSignalCount: detectedDuplicateSignals.length,
+      automaticConfirmedCount: 0,
+    },
+  };
+}

--- a/src/schemas/physical-place-import.ts
+++ b/src/schemas/physical-place-import.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+
+const nullableTrimmedString = (maximum: number) =>
+  z.string().trim().min(1).max(maximum).nullable();
+
+const httpUrlSchema = z
+  .url()
+  .refine(
+    (value) => ['http:', 'https:'].includes(new URL(value).protocol),
+    'Use an HTTP or HTTPS URL.',
+  );
+
+const safeTextSchema = (maximum: number) =>
+  z
+    .string()
+    .trim()
+    .min(1)
+    .max(maximum)
+    .refine((value) => !/[<>]/.test(value), 'HTML-like text is not accepted in legacy imports.');
+
+export const legacyOsmElementTypeValues = ['node', 'way', 'relation'] as const;
+export const legacyOsmElementTypeSchema = z.enum(legacyOsmElementTypeValues);
+
+export const legacyPaymentTagSchema = z.record(
+  z
+    .string()
+    .trim()
+    .toLowerCase()
+    .regex(/^payment:[a-z0-9:_-]+$/, 'Legacy payment keys must use the payment:* namespace.'),
+  z.string().trim().min(1).max(160),
+);
+
+export const legacyPhysicalPlaceRecordSchema = z
+  .object({
+    legacyId: safeTextSchema(256),
+    legacyPath: z
+      .string()
+      .trim()
+      .regex(/^\/[^?#]*$/, 'Use a legacy path without a query or fragment.')
+      .nullable(),
+    name: safeTextSchema(200),
+    addressLine: nullableTrimmedString(500),
+    locality: nullableTrimmedString(120),
+    region: nullableTrimmedString(120),
+    postalCode: nullableTrimmedString(32),
+    countryCode: z
+      .string()
+      .trim()
+      .length(2)
+      .transform((value) => value.toUpperCase())
+      .refine((value) => /^[A-Z]{2}$/.test(value), 'Use an ISO 3166-1 alpha-2 country code.'),
+    latitude: z.number().finite().min(-90).max(90),
+    longitude: z.number().finite().min(-180).max(180),
+    category: nullableTrimmedString(120),
+    websiteUrl: httpUrlSchema.nullable(),
+    osmType: legacyOsmElementTypeSchema.nullable(),
+    osmId: z
+      .string()
+      .trim()
+      .regex(/^[1-9][0-9]*$/, 'OSM IDs must be positive decimal strings.')
+      .nullable(),
+    paymentTags: legacyPaymentTagSchema,
+    observedAt: z.iso.datetime({ offset: true }).nullable(),
+    sourceUrl: httpUrlSchema.nullable(),
+    legacyVerificationLabel: nullableTrimmedString(120),
+  })
+  .strict()
+  .superRefine((record, context) => {
+    if ((record.osmType === null) !== (record.osmId === null)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['osmId'],
+        message: 'OSM type and ID must either both be present or both be absent.',
+      });
+    }
+  });
+
+export const physicalPlaceImportEnvelopeSchema = z
+  .object({
+    sourceId: z.uuid(),
+    licenseId: z.uuid().nullable(),
+    importBatchId: z.uuid(),
+    fetchedAt: z.iso.datetime({ offset: true }),
+    importerVersion: z
+      .string()
+      .trim()
+      .regex(/^\d+\.\d+\.\d+$/, 'Use a semantic importer version.'),
+    records: z.array(z.unknown()).min(1).max(10_000),
+  })
+  .strict();
+
+export type LegacyPhysicalPlaceRecord = z.infer<typeof legacyPhysicalPlaceRecordSchema>;
+export type PhysicalPlaceImportEnvelope = z.infer<typeof physicalPlaceImportEnvelopeSchema>;

--- a/src/schemas/physical-place-import.ts
+++ b/src/schemas/physical-place-import.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
-const nullableTrimmedString = (maximum: number) =>
-  z.string().trim().min(1).max(maximum).nullable();
+const nullableTrimmedString = (maximum: number) => z.string().trim().min(1).max(maximum).nullable();
 
 const httpUrlSchema = z
   .url()

--- a/tests/physical-place-importer.test.ts
+++ b/tests/physical-place-importer.test.ts
@@ -72,6 +72,29 @@ describe('physical-place candidate importer', () => {
     );
   });
 
+  it('preserves raw source values separately from normalized values', async () => {
+    const rawRecord = {
+      ...record(1),
+      name: '  Example Place 1  ',
+      countryCode: 'jp',
+    };
+    const plan = await createPhysicalPlaceImportPlan({
+      ...envelopeBase,
+      records: [rawRecord],
+    });
+    const rawPayload = plan.drafts[0]?.sourceRecord.rawPayload as {
+      rawRecord: Record<string, unknown>;
+      normalizedRecord: Record<string, unknown>;
+    };
+
+    expect(rawPayload.rawRecord.name).toBe('  Example Place 1  ');
+    expect(rawPayload.rawRecord.countryCode).toBe('jp');
+    expect(rawPayload.normalizedRecord.name).toBe('Example Place 1');
+    expect(rawPayload.normalizedRecord.countryCode).toBe('JP');
+    expect(plan.drafts[0]?.reviewData.name).toBe('Example Place 1');
+    expect(plan.drafts[0]?.reviewData.countryCode).toBe('JP');
+  });
+
   it('collapses exact replays and rejects conflicting legacy identities', async () => {
     const plan = await createPhysicalPlaceImportPlan({
       ...envelopeBase,

--- a/tests/physical-place-importer.test.ts
+++ b/tests/physical-place-importer.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { createPhysicalPlaceImportPlan } from '../src/importers/physical-place';
+
+const envelopeBase = {
+  sourceId: '11111111-1111-4111-8111-111111111111',
+  licenseId: '22222222-2222-4222-8222-222222222222',
+  importBatchId: '33333333-3333-4333-8333-333333333333',
+  fetchedAt: '2026-06-27T00:00:00Z',
+  importerVersion: '1.0.0',
+};
+
+function record(index: number) {
+  return {
+    legacyId: `legacy-${index}`,
+    legacyPath: `/place/legacy-${index}`,
+    name: `Example Place ${index}`,
+    addressLine: `${index} Example Street`,
+    locality: 'Tokyo',
+    region: 'Tokyo',
+    postalCode: '100-0001',
+    countryCode: 'JP',
+    latitude: 35.68 + index / 10_000,
+    longitude: 139.76 + index / 10_000,
+    category: 'cafe',
+    websiteUrl: `https://example.com/${index}`,
+    osmType: 'node',
+    osmId: String(1_000 + index),
+    paymentTags: { 'payment:bitcoin': 'yes' },
+    observedAt: '2026-06-20T00:00:00Z',
+    sourceUrl: null,
+    legacyVerificationLabel: 'listed',
+  };
+}
+
+describe('physical-place candidate importer', () => {
+  it('imports ten legacy rows only into private candidate-layer drafts', async () => {
+    const plan = await createPhysicalPlaceImportPlan({
+      ...envelopeBase,
+      records: Array.from({ length: 10 }, (_, index) => record(index + 1)),
+    });
+
+    expect(plan.summary).toMatchObject({
+      inputCount: 10,
+      acceptedCount: 10,
+      rejectedCount: 0,
+      automaticConfirmedCount: 0,
+    });
+    expect(plan.drafts).toHaveLength(10);
+    expect(
+      plan.drafts.every(
+        (draft) =>
+          draft.candidate.candidateStatus === 'new' &&
+          draft.candidate.canonicalEntityId === null &&
+          draft.candidate.canonicalLocationId === null &&
+          draft.legacyMapping.migrationStatus === 'pending',
+      ),
+    ).toBe(true);
+    expect(plan.drafts.some((draft) => Object.hasOwn(draft, 'acceptanceClaim'))).toBe(false);
+  });
+
+  it('produces deterministic candidate and source identities', async () => {
+    const envelope = { ...envelopeBase, records: [record(1), record(2)] };
+    const left = await createPhysicalPlaceImportPlan(envelope);
+    const right = await createPhysicalPlaceImportPlan(envelope);
+
+    expect(left.inputChecksum).toBe(right.inputChecksum);
+    expect(left.drafts.map((draft) => draft.candidateId)).toEqual(
+      right.drafts.map((draft) => draft.candidateId),
+    );
+    expect(left.drafts.map((draft) => draft.sourceRecordId)).toEqual(
+      right.drafts.map((draft) => draft.sourceRecordId),
+    );
+  });
+
+  it('collapses exact replays and rejects conflicting legacy identities', async () => {
+    const plan = await createPhysicalPlaceImportPlan({
+      ...envelopeBase,
+      records: [record(1), record(1), { ...record(1), name: 'Conflicting Name' }],
+    });
+
+    expect(plan.summary.acceptedCount).toBe(1);
+    expect(plan.summary.replayedCount).toBe(1);
+    expect(plan.summary.rejectedCount).toBe(1);
+    expect(plan.rejections[0]?.reason).toBe('conflicting_legacy_identity');
+  });
+
+  it('emits review signals instead of merging shared OSM identities', async () => {
+    const plan = await createPhysicalPlaceImportPlan({
+      ...envelopeBase,
+      records: [record(1), { ...record(2), osmId: record(1).osmId }],
+    });
+
+    expect(plan.drafts).toHaveLength(2);
+    expect(plan.duplicateSignals).toContainEqual(
+      expect.objectContaining({ reason: 'shared_osm_identity', strength: 'strong' }),
+    );
+    expect(new Set(plan.drafts.map((draft) => draft.candidateId)).size).toBe(2);
+  });
+
+  it('rejects unsafe rows without aborting valid rows in the same batch', async () => {
+    const plan = await createPhysicalPlaceImportPlan({
+      ...envelopeBase,
+      records: [record(1), { ...record(2), longitude: 999 }, { ...record(3), name: '<b>bad</b>' }],
+    });
+
+    expect(plan.summary.acceptedCount).toBe(1);
+    expect(plan.summary.rejectedCount).toBe(2);
+    expect(plan.rejections.every((rejection) => rejection.reason === 'invalid_record')).toBe(true);
+  });
+
+  it('preserves payment tags without creating network, method, or Confirmed claims', async () => {
+    const plan = await createPhysicalPlaceImportPlan({
+      ...envelopeBase,
+      records: [
+        {
+          ...record(1),
+          paymentTags: {
+            'payment:bitcoin': 'yes',
+            'payment:lightning': 'yes',
+            'payment:cryptocurrencies': 'yes',
+          },
+        },
+      ],
+    });
+
+    expect(plan.drafts[0]?.reviewData.affirmativePaymentSignals).toEqual([
+      'payment:bitcoin',
+      'payment:cryptocurrencies',
+      'payment:lightning',
+    ]);
+    expect(plan.drafts[0]?.reviewData.requiresAcceptanceReview).toBe(true);
+    expect(plan.summary.automaticConfirmedCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Implementation item

`P2-13`

## Purpose

Import legacy physical-place records into deterministic private source-candidate plans without creating canonical entities, locations, acceptance claims, or public records.

## Completed

- strict envelope and per-record validation for untrusted legacy physical-place data
- deterministic candidate, source-record, and pending legacy-mapping identities
- immutable raw source values stored separately from normalized review values
- SHA-256 source content and batch checksums based on original source rows
- candidate-only output with no canonical target and `automaticConfirmedCount = 0`
- exact replay collapse and conflicting legacy-ID rejection
- shared OSM identity and same-name/same-coordinate review signals without automatic merge
- preservation of legacy payment tags without asset, network, method, How-to-pay, or Confirmed inference
- ten-record runtime proof
- positive and negative unit tests
- importer contract and project tracking updates

## Validation

- Foundation validation: passed
- Migration drift: passed
- formatting and lint: passed
- Astro and TypeScript checks: passed
- runtime schema and importer checks: passed
- unit and component tests: passed
- static build: passed
- accessibility and staging artifact checks: passed

## Excluded

- database writes and transaction handling
- canonical promotion
- live legacy database access
- public export publication
- online-service imports
- Cloudflare dependency

## Next

P2-14 — Online-service importer and Phase 2 integration audit.