### PR TITLE
P3-07A: Define canonical promotion transaction contract

### DIFF
--- a/docs/CANDIDATE_PROMOTION_CONTRACT.md
+++ b/docs/CANDIDATE_PROMOTION_CONTRACT.md
@@ -1,0 +1,148 @@
+# Candidate promotion contract
+
+**Implementation item:** P3-07  
+**Current delivery:** P3-07A — canonical promotion service contract and atomic test backend  
+**Status:** In progress
+
+## Purpose
+
+P3-07 promotes one reviewed private Candidate into hidden canonical records. Promotion is not verification and is not publication.
+
+```text
+reviewed Candidate
+  -> explicit promotion authorization
+  -> exact Candidate and provenance version checks
+  -> hidden canonical Entity and optional Location
+  -> hidden candidate Acceptance Claim
+  -> normalized Claim Asset combinations
+  -> Candidate status promoted
+  -> pending legacy mapping resolved
+```
+
+## P3-07A scope
+
+P3-07A defines and tests:
+
+- the `candidate:promote` capability;
+- request UUID, actor identity, and actor type;
+- exact Candidate type and update-time expectations;
+- physical-place and online-service promotion boundaries;
+- explicit canonical Entity, Location, Claim, and Claim Asset drafts;
+- exact source-record provenance expectations;
+- request replay and conflicting request reuse;
+- copy-on-write rollback proof;
+- hidden canonical output and candidate claim status;
+- legacy path mapping behavior.
+
+P3-07A uses an in-memory atomic backend for contract tests. It does not claim production persistence.
+
+## Supported Candidate types
+
+This delivery supports:
+
+```text
+physical_place
+online_service
+```
+
+Other Candidate types remain private and are rejected by the promotion input contract until a later reviewed extension.
+
+## Canonical boundaries
+
+Physical-place promotion requires:
+
+- Entity type `merchant`;
+- one canonical Location;
+- Claim scope `location_specific`;
+- Claim location ID matching the new Location;
+- canonical path `/place/{location-slug}`.
+
+Online-service promotion requires:
+
+- Entity type `online_service`;
+- no Location;
+- Claim scope `online_service`;
+- canonical path `/service/{entity-slug}`.
+
+## Verification and publication boundary
+
+Every newly promoted record must remain private:
+
+```text
+Entity visibility       hidden
+Location visibility     hidden
+Claim status            candidate
+Claim visibility        hidden
+```
+
+Promotion cannot assign:
+
+- Confirmed, Stale, Ended, or public status;
+- confirmation timestamps;
+- review deadlines;
+- ending timestamps or reasons;
+- Evidence decisions;
+- verification events;
+- media decisions;
+- public exports.
+
+How-to-pay text may be normalized during promotion, but it is not treated as verified until P3-08.
+
+## Asset, network, and payment method boundary
+
+Every Claim Asset draft must explicitly identify:
+
+- asset ID;
+- network ID;
+- payment method ID;
+- optional contract address;
+- one primary combination.
+
+The backend must reject unknown registry references. Asset symbols never imply networks.
+
+## Provenance
+
+The promotion request includes the exact reviewed source-record set. The backend must reject promotion if current Candidate provenance differs.
+
+P3-07A creates record-level origin provenance for:
+
+- Entity;
+- Location when present;
+- Acceptance Claim;
+- every Claim Asset.
+
+Field-level provenance editing is added with the protected editor before P3-07 is completed.
+
+## Atomicity
+
+One promotion operation must either commit all of the following or none:
+
+- canonical records;
+- provenance links;
+- Candidate status and canonical links;
+- legacy mapping resolution;
+- replay receipt.
+
+The in-memory backend proves this with copy-on-write state and injected pre-commit failure.
+
+## Replay and conflict behavior
+
+The request UUID is the idempotency identity.
+
+- exact replay returns the original result with `state = replayed`;
+- reuse with different content is a conflict;
+- stale Candidate type, status, update time, canonical links, or provenance is a conflict;
+- existing canonical IDs or slugs are conflicts;
+- unknown processor, asset, network, or payment method references are conflicts.
+
+## Deferred P3-07 work
+
+Later P3-07 deliveries add:
+
+- durable promotion audit schema and migration;
+- Drizzle and Neon atomic backend;
+- protected Candidate promotion editor;
+- existing canonical target linking;
+- field-level provenance controls;
+- endpoint, component, accessibility, and artifact tests;
+- Phase 3 handoff to Evidence review.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -80,8 +80,8 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 | P3-03 | Dashboard and operational queue summaries | Completed | P3-01, P3-02 | #43 |
 | P3-04 | Candidate queue | Completed | P3-01, P3-02 | #44 |
 | P3-05 | Candidate detail and provenance review | Completed | P3-04 | #45 |
-| P3-06 | Duplicate review and identity resolution | In progress | P3-05 | #46, #47 |
-| P3-07 | Claim editor and canonical promotion | Planned | P3-05, P3-06 | — |
+| P3-06 | Duplicate review and identity resolution | Completed | P3-05 | #46, #47 |
+| P3-07 | Claim editor and canonical promotion | In progress | P3-05, P3-06 | P3-07A branch active |
 | P3-08 | Evidence review and verification decisions | Planned | P3-07 | — |
 | P3-09 | Status transitions and reconfirmation queue | Planned | P3-07, P3-08 | — |
 | P3-10 | Media review | Planned | P3-02, P2-10 | — |
@@ -90,11 +90,16 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 
 ### Current delivery
 
-P3-06A in pull request #46 completed duplicate-signal persistence and the atomic decision foundation. P3-06B in pull request #47 adds protected group comparison, explicit reviewer controls, conflict states, route and component tests, accessibility checks, and artifact checks. Duplicate review does not promote or publish records.
+P3-07A defines the separate Candidate promotion authorization and transaction contract. It creates only hidden canonical records, preserves exact source provenance, resolves pending legacy mappings, proves replay and rollback behavior, and keeps verification and publication outside promotion.
 
-### Next delivery
+### Remaining P3-07 deliveries
 
-P3-07 will create the reviewed Candidate-to-canonical promotion workspace. It must preserve provenance, require explicit normalized values, and keep verification and publication as later decisions.
+- durable promotion audit schema and migration
+- Drizzle and Neon atomic transaction backend
+- protected promotion endpoint and editor
+- existing canonical target linking
+- field-level provenance controls
+- endpoint, component, accessibility, and staging-artifact checks
 
 ## Phase 4 — Public core / MVP-A
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,11 +8,13 @@ Phase 3 — Administration and review
 
 ## Current implementation item
 
-P3-06 — Duplicate review and identity resolution
+P3-07 — Claim editor and canonical promotion
 
-## Active pull request
+## Active work
 
-- Pull request #47 — P3-06B duplicate-group review interface and explicit decision controls.
+- P3-07A — canonical promotion service contract and atomic test backend.
+- Branch: `work/p307a`.
+- Pull request: not opened yet.
 
 ## Latest completed work
 
@@ -23,35 +25,38 @@ P3-06 — Duplicate review and identity resolution
 - P3-04 completed through pull request #44.
 - P3-05 completed through pull request #45.
 - P3-06A completed through pull request #46.
-- Importer duplicate signals are persisted with deterministic group and signal identities.
-- Duplicate decisions require the separate `candidate:resolve` capability and an explicit reviewer action.
-- Confirm-duplicate and dismiss-signal decisions are transactional, idempotent, conflict-checked, and audit-preserving.
-- Duplicate decisions do not merge Candidate rows, move source records, create canonical records, or publish data.
+- P3-06B completed through pull request #47.
+- Duplicate review now has protected group queries, explicit reviewer controls, conflict handling, bounded private responses, and complete repository CI coverage.
 
-## P3-06B in progress
+## P3-07A in progress
 
-- expose a protected, bounded duplicate-group comparison response
-- link Candidate detail pages to duplicate-group review
-- show group members, persisted signals, provenance summaries, and closed-group states
-- provide explicit confirm-duplicate and dismiss-signal controls
-- require an authorized mutation context and optimistic group-version checks
-- return bounded denial, not-found, conflict, and unavailable states without private-detail leakage
-- add route, service, component, runtime, accessibility, and staging-artifact checks
-- keep canonical promotion, Evidence decisions, media decisions, and publication outside P3-06
+- define the separate `candidate:promote` authorization boundary
+- accept explicit normalized Entity, Location, Claim, and Claim Asset drafts
+- support physical-place and online-service promotion only
+- require exact Candidate type, update time, and source provenance
+- create hidden canonical records and a hidden candidate claim
+- update Candidate canonical links and legacy mappings atomically
+- prove replay, conflict, and rollback behavior with an in-memory backend
+- prevent verification, Evidence decisions, public visibility, and export
 
-## Cloudflare status
+## Deferred within P3-07
 
-Live staging, Access browser verification, and live database results remain deferred. Repository-level access, transaction, rendering, runtime, and artifact contracts continue to be verified in CI and do not block repository-only Phase 3 work.
+- durable promotion audit schema and migration
+- Drizzle and Neon transaction backend
+- protected promotion editor and endpoint
+- existing canonical target linking
+- field-level provenance editing
+- live Cloudflare Access and live database verification
 
 ## Next
 
-1. Complete pull request #47 and close P3-06.
-2. Start P3-07 — Claim editor and canonical promotion.
-3. Keep Evidence decisions, publication, and public routes outside the first P3-07 delivery.
+1. Complete P3-07A CI and merge its contract foundation.
+2. Add durable promotion audit persistence and the Drizzle backend.
+3. Add the protected canonical promotion editor.
 
 ## Blocked
 
-No repository blocker. Only live deployment and database verification are deferred.
+No repository blocker. Live deployment and database verification remain deferred.
 
 ## Verification rule
 

--- a/src/admin/promotion/candidate-promotion.ts
+++ b/src/admin/promotion/candidate-promotion.ts
@@ -1,0 +1,274 @@
+import { z } from 'zod';
+import { acceptanceClaimInputSchema } from '../../schemas/acceptance-claims';
+import { canonicalEntitySchema, canonicalLocationSchema } from '../../schemas/canonical-identity';
+import { claimAssetInputSchema, claimAssetSetSchema } from '../../schemas/claim-assets';
+
+export const candidatePromotionCapabilityValues = ['candidate:promote'] as const;
+export const candidatePromotionCapabilitySchema = z.enum(candidatePromotionCapabilityValues);
+
+export const candidatePromotionMutationContextSchema = z
+  .object({
+    requestId: z.uuid(),
+    actorId: z.string().trim().min(1).max(200),
+    actorType: z.enum(['human', 'system']),
+    capabilities: z.array(candidatePromotionCapabilitySchema).min(1),
+  })
+  .strict();
+
+const entityDraftSchema = z
+  .object({ id: z.uuid(), value: canonicalEntitySchema })
+  .strict();
+const locationDraftSchema = z
+  .object({ id: z.uuid(), value: canonicalLocationSchema })
+  .strict();
+const claimDraftSchema = z
+  .object({ id: z.uuid(), value: acceptanceClaimInputSchema })
+  .strict();
+const claimAssetDraftSchema = z
+  .object({ id: z.uuid(), value: claimAssetInputSchema })
+  .strict();
+
+export const candidatePromotionInputSchema = z
+  .object({
+    candidateId: z.uuid(),
+    expectedCandidateType: z.enum(['physical_place', 'online_service']),
+    expectedCandidateUpdatedAt: z.iso.datetime({ offset: true }),
+    promotedAt: z.iso.datetime({ offset: true }),
+    entity: entityDraftSchema,
+    location: locationDraftSchema.nullable(),
+    claim: claimDraftSchema,
+    claimAssets: z.array(claimAssetDraftSchema).min(1).max(100),
+    sourceRecordIds: z.array(z.uuid()).min(1).max(100),
+  })
+  .strict();
+
+export type CandidatePromotionMutationContext = z.infer<
+  typeof candidatePromotionMutationContextSchema
+>;
+export type CandidatePromotionInput = z.infer<typeof candidatePromotionInputSchema>;
+
+export interface CandidatePromotionCommand {
+  requestId: string;
+  actorId: string;
+  actorType: 'human' | 'system';
+  candidateId: string;
+  expectedCandidateType: 'physical_place' | 'online_service';
+  expectedCandidateUpdatedAt: Date;
+  promotedAt: Date;
+  entity: CandidatePromotionInput['entity'];
+  location: CandidatePromotionInput['location'];
+  claim: CandidatePromotionInput['claim'];
+  claimAssets: CandidatePromotionInput['claimAssets'];
+  sourceRecordIds: string[];
+  canonicalPath: string;
+  requestFingerprint: string;
+}
+
+export interface CandidatePromotionReceipt {
+  requestId: string;
+  candidateId: string;
+  entityId: string;
+  locationId: string | null;
+  claimId: string;
+  claimAssetIds: string[];
+  canonicalPath: string;
+  claimStatus: 'candidate';
+  visibility: 'hidden';
+  promotedAt: string;
+  state: 'committed' | 'replayed';
+}
+
+export interface CandidatePromotionBackend {
+  commitPromotion(command: CandidatePromotionCommand): Promise<CandidatePromotionReceipt>;
+}
+
+export type CandidatePromotionErrorCode =
+  | 'unauthorized'
+  | 'invalid_promotion'
+  | 'not_found'
+  | 'conflict'
+  | 'backend_failure';
+
+export class CandidatePromotionError extends Error {
+  readonly code: CandidatePromotionErrorCode;
+  readonly issues: readonly string[];
+
+  constructor(
+    code: CandidatePromotionErrorCode,
+    message: string,
+    issues: readonly string[] = [],
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'CandidatePromotionError';
+    this.code = code;
+    this.issues = issues;
+  }
+}
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, stable(child)]),
+    );
+  }
+  return value;
+}
+
+function validatePromotion(input: CandidatePromotionInput): string[] {
+  const issues: string[] = [];
+  if (Date.parse(input.promotedAt) < Date.parse(input.expectedCandidateUpdatedAt)) {
+    issues.push('promotedAt cannot precede the reviewed Candidate version');
+  }
+  if (new Set(input.sourceRecordIds).size !== input.sourceRecordIds.length) {
+    issues.push('sourceRecordIds must be unique');
+  }
+  if (new Set(input.claimAssets.map((row) => row.id)).size !== input.claimAssets.length) {
+    issues.push('claim asset record IDs must be unique');
+  }
+  const claimAssetSet = claimAssetSetSchema.safeParse(input.claimAssets.map((row) => row.value));
+  if (!claimAssetSet.success) {
+    issues.push(...claimAssetSet.error.issues.map((issue) => issue.message));
+  }
+
+  const entity = input.entity.value;
+  const claim = input.claim.value;
+  if (entity.visibility !== 'hidden') issues.push('the promoted entity must remain hidden');
+  if (input.location !== null && input.location.value.visibility !== 'hidden') {
+    issues.push('the promoted location must remain hidden');
+  }
+  if (claim.claimStatus !== 'candidate' || claim.visibility !== 'hidden') {
+    issues.push('promotion must create a hidden candidate claim');
+  }
+  if (
+    claim.firstConfirmedAt !== null ||
+    claim.lastConfirmedAt !== null ||
+    claim.nextReviewAt !== null ||
+    claim.endedAt !== null ||
+    claim.endedReason !== null
+  ) {
+    issues.push('promotion cannot assign verification, review, or ending timestamps');
+  }
+  if (claim.entityId !== input.entity.id) issues.push('claim entityId must match the entity draft');
+
+  if (input.expectedCandidateType === 'physical_place') {
+    if (entity.entityType !== 'merchant') issues.push('physical Candidates require merchant entities');
+    if (input.location === null) {
+      issues.push('physical Candidates require a canonical location');
+    } else if (
+      claim.locationId !== input.location.id ||
+      claim.claimScope !== 'location_specific'
+    ) {
+      issues.push('physical Candidates require a location-specific claim');
+    }
+  } else {
+    if (entity.entityType !== 'online_service') {
+      issues.push('online Candidates require online-service entities');
+    }
+    if (input.location !== null || claim.locationId !== null || claim.claimScope !== 'online_service') {
+      issues.push('online Candidates cannot create or reference a physical location');
+    }
+    if (entity.slug === null) issues.push('online Candidates require an entity slug');
+  }
+
+  if (claim.routeType === 'direct_wallet' && claim.processorId !== null) {
+    issues.push('direct-wallet claims cannot reference a processor');
+  }
+  for (const row of input.claimAssets) {
+    if (row.value.claimId !== input.claim.id) {
+      issues.push('every claim asset must reference the promoted claim');
+    }
+  }
+  return issues;
+}
+
+function buildCommand(
+  context: CandidatePromotionMutationContext,
+  input: CandidatePromotionInput,
+): CandidatePromotionCommand {
+  const sourceRecordIds = [...input.sourceRecordIds].sort();
+  const claimAssets = [...input.claimAssets].sort((left, right) => left.id.localeCompare(right.id));
+  const canonicalPath =
+    input.expectedCandidateType === 'physical_place'
+      ? `/place/${input.location?.value.slug ?? ''}`
+      : `/service/${input.entity.value.slug ?? ''}`;
+  const requestFingerprint = JSON.stringify(
+    stable({
+      requestId: context.requestId,
+      actorId: context.actorId,
+      actorType: context.actorType,
+      ...input,
+      sourceRecordIds,
+      claimAssets,
+      canonicalPath,
+    }),
+  );
+  return {
+    requestId: context.requestId,
+    actorId: context.actorId,
+    actorType: context.actorType,
+    candidateId: input.candidateId,
+    expectedCandidateType: input.expectedCandidateType,
+    expectedCandidateUpdatedAt: new Date(input.expectedCandidateUpdatedAt),
+    promotedAt: new Date(input.promotedAt),
+    entity: input.entity,
+    location: input.location,
+    claim: input.claim,
+    claimAssets,
+    sourceRecordIds,
+    canonicalPath,
+    requestFingerprint,
+  };
+}
+
+export function createCandidatePromotionService(backend: CandidatePromotionBackend) {
+  return {
+    async promote(
+      context: CandidatePromotionMutationContext,
+      input: CandidatePromotionInput,
+    ): Promise<CandidatePromotionReceipt> {
+      const contextResult = candidatePromotionMutationContextSchema.safeParse(context);
+      if (!contextResult.success || !context.capabilities.includes('candidate:promote')) {
+        throw new CandidatePromotionError(
+          'unauthorized',
+          'The actor is not authorized to promote Candidates.',
+          contextResult.success
+            ? []
+            : contextResult.error.issues.map(
+                (issue) => `${issue.path.join('.')}: ${issue.message}`,
+              ),
+        );
+      }
+      const inputResult = candidatePromotionInputSchema.safeParse(input);
+      if (!inputResult.success) {
+        throw new CandidatePromotionError(
+          'invalid_promotion',
+          'The Candidate promotion request is invalid.',
+          inputResult.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+        );
+      }
+      const issues = validatePromotion(inputResult.data);
+      if (issues.length > 0) {
+        throw new CandidatePromotionError(
+          'invalid_promotion',
+          'The Candidate promotion violates the canonical boundary.',
+          issues,
+        );
+      }
+      try {
+        return await backend.commitPromotion(buildCommand(contextResult.data, inputResult.data));
+      } catch (error) {
+        if (error instanceof CandidatePromotionError) throw error;
+        throw new CandidatePromotionError(
+          'backend_failure',
+          'The Candidate promotion was not committed.',
+          [],
+          { cause: error },
+        );
+      }
+    },
+  };
+}

--- a/src/admin/promotion/candidate-promotion.ts
+++ b/src/admin/promotion/candidate-promotion.ts
@@ -15,18 +15,10 @@ export const candidatePromotionMutationContextSchema = z
   })
   .strict();
 
-const entityDraftSchema = z
-  .object({ id: z.uuid(), value: canonicalEntitySchema })
-  .strict();
-const locationDraftSchema = z
-  .object({ id: z.uuid(), value: canonicalLocationSchema })
-  .strict();
-const claimDraftSchema = z
-  .object({ id: z.uuid(), value: acceptanceClaimInputSchema })
-  .strict();
-const claimAssetDraftSchema = z
-  .object({ id: z.uuid(), value: claimAssetInputSchema })
-  .strict();
+const entityDraftSchema = z.object({ id: z.uuid(), value: canonicalEntitySchema }).strict();
+const locationDraftSchema = z.object({ id: z.uuid(), value: canonicalLocationSchema }).strict();
+const claimDraftSchema = z.object({ id: z.uuid(), value: acceptanceClaimInputSchema }).strict();
+const claimAssetDraftSchema = z.object({ id: z.uuid(), value: claimAssetInputSchema }).strict();
 
 export const candidatePromotionInputSchema = z
   .object({
@@ -155,20 +147,22 @@ function validatePromotion(input: CandidatePromotionInput): string[] {
   if (claim.entityId !== input.entity.id) issues.push('claim entityId must match the entity draft');
 
   if (input.expectedCandidateType === 'physical_place') {
-    if (entity.entityType !== 'merchant') issues.push('physical Candidates require merchant entities');
+    if (entity.entityType !== 'merchant')
+      issues.push('physical Candidates require merchant entities');
     if (input.location === null) {
       issues.push('physical Candidates require a canonical location');
-    } else if (
-      claim.locationId !== input.location.id ||
-      claim.claimScope !== 'location_specific'
-    ) {
+    } else if (claim.locationId !== input.location.id || claim.claimScope !== 'location_specific') {
       issues.push('physical Candidates require a location-specific claim');
     }
   } else {
     if (entity.entityType !== 'online_service') {
       issues.push('online Candidates require online-service entities');
     }
-    if (input.location !== null || claim.locationId !== null || claim.claimScope !== 'online_service') {
+    if (
+      input.location !== null ||
+      claim.locationId !== null ||
+      claim.claimScope !== 'online_service'
+    ) {
       issues.push('online Candidates cannot create or reference a physical location');
     }
     if (entity.slug === null) issues.push('online Candidates require an entity slug');

--- a/src/admin/promotion/in-memory-candidate-promotion-backend.ts
+++ b/src/admin/promotion/in-memory-candidate-promotion-backend.ts
@@ -76,9 +76,7 @@ function cloneState(state: PromotionState): PromotionState {
     legacyMappings: new Map(
       [...state.legacyMappings].map(([id, mapping]) => [id, structuredClone(mapping)]),
     ),
-    entities: new Map(
-      [...state.entities].map(([id, entity]) => [id, structuredClone(entity)]),
-    ),
+    entities: new Map([...state.entities].map(([id, entity]) => [id, structuredClone(entity)])),
     locations: new Map(
       [...state.locations].map(([id, location]) => [id, structuredClone(location)]),
     ),
@@ -88,10 +86,7 @@ function cloneState(state: PromotionState): PromotionState {
     ),
     provenance: state.provenance.map((link) => structuredClone(link)),
     promotionsByRequest: new Map(
-      [...state.promotionsByRequest].map(([id, promotion]) => [
-        id,
-        structuredClone(promotion),
-      ]),
+      [...state.promotionsByRequest].map(([id, promotion]) => [id, structuredClone(promotion)]),
     ),
   };
 }

--- a/src/admin/promotion/in-memory-candidate-promotion-backend.ts
+++ b/src/admin/promotion/in-memory-candidate-promotion-backend.ts
@@ -1,0 +1,301 @@
+import {
+  CandidatePromotionError,
+  type CandidatePromotionBackend,
+  type CandidatePromotionCommand,
+  type CandidatePromotionReceipt,
+} from './candidate-promotion';
+
+export interface InMemoryPromotionCandidateSeed {
+  id: string;
+  candidateType:
+    | 'physical_place'
+    | 'online_service'
+    | 'payment_processor'
+    | 'payment_program'
+    | 'platform';
+  candidateStatus:
+    | 'new'
+    | 'triaged'
+    | 'linked'
+    | 'promoted'
+    | 'duplicate'
+    | 'rejected'
+    | 'archived';
+  updatedAt: string;
+  canonicalEntityId: string | null;
+  canonicalLocationId: string | null;
+  sourceRecordIds: string[];
+}
+
+export interface InMemoryPromotionLegacyMappingSeed {
+  id: string;
+  sourceSystem: 'cryptopaymap_v2' | 'crypto_acceptance_registry';
+  sourceRecordId: string;
+  migrationStatus: 'pending' | 'mapped' | 'unresolved' | 'retired';
+  canonicalPath: string | null;
+  entityId: string | null;
+  locationId: string | null;
+  resolvedAt: string | null;
+}
+
+interface StoredPromotion {
+  fingerprint: string;
+  receipt: CandidatePromotionReceipt;
+}
+
+interface PromotionState {
+  candidates: Map<string, InMemoryPromotionCandidateSeed>;
+  legacyMappings: Map<string, InMemoryPromotionLegacyMappingSeed>;
+  entities: Map<string, CandidatePromotionCommand['entity']>;
+  locations: Map<string, NonNullable<CandidatePromotionCommand['location']>>;
+  claims: Map<string, CandidatePromotionCommand['claim']>;
+  claimAssets: Map<string, CandidatePromotionCommand['claimAssets'][number]>;
+  provenance: Array<{
+    subjectType: 'entity' | 'location' | 'acceptance_claim' | 'claim_asset';
+    subjectId: string;
+    sourceRecordId: string;
+  }>;
+  promotionsByRequest: Map<string, StoredPromotion>;
+}
+
+export interface InMemoryCandidatePromotionBackendOptions {
+  candidates?: InMemoryPromotionCandidateSeed[];
+  legacyMappings?: InMemoryPromotionLegacyMappingSeed[];
+  assetIds?: string[];
+  networkIds?: string[];
+  paymentMethodIds?: string[];
+  processorEntityIds?: string[];
+  failBeforeCommit?: (command: CandidatePromotionCommand) => boolean;
+}
+
+function cloneState(state: PromotionState): PromotionState {
+  return {
+    candidates: new Map(
+      [...state.candidates].map(([id, candidate]) => [id, structuredClone(candidate)]),
+    ),
+    legacyMappings: new Map(
+      [...state.legacyMappings].map(([id, mapping]) => [id, structuredClone(mapping)]),
+    ),
+    entities: new Map(
+      [...state.entities].map(([id, entity]) => [id, structuredClone(entity)]),
+    ),
+    locations: new Map(
+      [...state.locations].map(([id, location]) => [id, structuredClone(location)]),
+    ),
+    claims: new Map([...state.claims].map(([id, claim]) => [id, structuredClone(claim)])),
+    claimAssets: new Map(
+      [...state.claimAssets].map(([id, claimAsset]) => [id, structuredClone(claimAsset)]),
+    ),
+    provenance: state.provenance.map((link) => structuredClone(link)),
+    promotionsByRequest: new Map(
+      [...state.promotionsByRequest].map(([id, promotion]) => [
+        id,
+        structuredClone(promotion),
+      ]),
+    ),
+  };
+}
+
+function conflict(message: string, issues: string[] = []): never {
+  throw new CandidatePromotionError('conflict', message, issues);
+}
+
+function sorted(values: readonly string[]): string[] {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+export class InMemoryCandidatePromotionBackend implements CandidatePromotionBackend {
+  private state: PromotionState;
+  private readonly assetIds: Set<string>;
+  private readonly networkIds: Set<string>;
+  private readonly paymentMethodIds: Set<string>;
+  private readonly processorEntityIds: Set<string>;
+  private readonly options: InMemoryCandidatePromotionBackendOptions;
+
+  constructor(options: InMemoryCandidatePromotionBackendOptions = {}) {
+    this.options = options;
+    this.assetIds = new Set(options.assetIds ?? []);
+    this.networkIds = new Set(options.networkIds ?? []);
+    this.paymentMethodIds = new Set(options.paymentMethodIds ?? []);
+    this.processorEntityIds = new Set(options.processorEntityIds ?? []);
+    this.state = {
+      candidates: new Map(
+        (options.candidates ?? []).map((candidate) => [candidate.id, structuredClone(candidate)]),
+      ),
+      legacyMappings: new Map(
+        (options.legacyMappings ?? []).map((mapping) => [mapping.id, structuredClone(mapping)]),
+      ),
+      entities: new Map(),
+      locations: new Map(),
+      claims: new Map(),
+      claimAssets: new Map(),
+      provenance: [],
+      promotionsByRequest: new Map(),
+    };
+  }
+
+  async commitPromotion(command: CandidatePromotionCommand): Promise<CandidatePromotionReceipt> {
+    const existing = this.state.promotionsByRequest.get(command.requestId);
+    if (existing !== undefined) {
+      if (existing.fingerprint !== command.requestFingerprint) {
+        conflict('The promotion request ID was reused with different content.');
+      }
+      return { ...structuredClone(existing.receipt), state: 'replayed' };
+    }
+
+    const next = cloneState(this.state);
+    const candidate = next.candidates.get(command.candidateId);
+    if (candidate === undefined) {
+      throw new CandidatePromotionError('not_found', 'The source Candidate was not found.');
+    }
+    if (
+      candidate.candidateType !== command.expectedCandidateType ||
+      candidate.updatedAt !== command.expectedCandidateUpdatedAt.toISOString()
+    ) {
+      conflict('The source Candidate changed before promotion.');
+    }
+    if (!['new', 'triaged'].includes(candidate.candidateStatus)) {
+      conflict('Only new or triaged Candidates can be promoted.');
+    }
+    if (candidate.canonicalEntityId !== null || candidate.canonicalLocationId !== null) {
+      conflict('The source Candidate already references a canonical target.');
+    }
+    if (
+      JSON.stringify(sorted(candidate.sourceRecordIds)) !==
+      JSON.stringify(sorted(command.sourceRecordIds))
+    ) {
+      conflict('The Candidate source provenance changed before promotion.');
+    }
+
+    if (next.entities.has(command.entity.id)) conflict('The canonical entity ID already exists.');
+    if (command.location !== null && next.locations.has(command.location.id)) {
+      conflict('The canonical location ID already exists.');
+    }
+    if (next.claims.has(command.claim.id)) conflict('The acceptance claim ID already exists.');
+    if (command.claimAssets.some((row) => next.claimAssets.has(row.id))) {
+      conflict('A claim asset ID already exists.');
+    }
+
+    const entitySlug = command.entity.value.slug;
+    if (
+      entitySlug !== null &&
+      [...next.entities.values()].some((row) => row.value.slug === entitySlug)
+    ) {
+      conflict('The canonical entity slug already exists.');
+    }
+    if (
+      command.location !== null &&
+      [...next.locations.values()].some((row) => row.value.slug === command.location?.value.slug)
+    ) {
+      conflict('The canonical location slug already exists.');
+    }
+
+    if (
+      command.claim.value.processorId !== null &&
+      !this.processorEntityIds.has(command.claim.value.processorId)
+    ) {
+      conflict('The selected processor entity does not exist.');
+    }
+    for (const row of command.claimAssets) {
+      if (!this.assetIds.has(row.value.assetId)) conflict('A selected asset does not exist.');
+      if (!this.networkIds.has(row.value.networkId)) conflict('A selected network does not exist.');
+      if (!this.paymentMethodIds.has(row.value.paymentMethodId)) {
+        conflict('A selected payment method does not exist.');
+      }
+    }
+
+    next.entities.set(command.entity.id, structuredClone(command.entity));
+    if (command.location !== null) {
+      next.locations.set(command.location.id, structuredClone(command.location));
+    }
+    next.claims.set(command.claim.id, structuredClone(command.claim));
+    for (const row of command.claimAssets) {
+      next.claimAssets.set(row.id, structuredClone(row));
+    }
+
+    const subjects: Array<{
+      subjectType: 'entity' | 'location' | 'acceptance_claim' | 'claim_asset';
+      subjectId: string;
+    }> = [
+      { subjectType: 'entity', subjectId: command.entity.id },
+      { subjectType: 'acceptance_claim', subjectId: command.claim.id },
+      ...command.claimAssets.map((row) => ({
+        subjectType: 'claim_asset' as const,
+        subjectId: row.id,
+      })),
+    ];
+    if (command.location !== null) {
+      subjects.push({ subjectType: 'location', subjectId: command.location.id });
+    }
+    for (const subject of subjects) {
+      for (const sourceRecordId of command.sourceRecordIds) {
+        next.provenance.push({ ...subject, sourceRecordId });
+      }
+    }
+
+    for (const mapping of next.legacyMappings.values()) {
+      if (
+        mapping.migrationStatus !== 'pending' ||
+        !command.sourceRecordIds.includes(mapping.sourceRecordId)
+      ) {
+        continue;
+      }
+      mapping.migrationStatus = 'mapped';
+      mapping.canonicalPath = command.canonicalPath;
+      mapping.entityId =
+        mapping.sourceSystem === 'crypto_acceptance_registry' ? command.entity.id : null;
+      mapping.locationId =
+        mapping.sourceSystem === 'cryptopaymap_v2' ? (command.location?.id ?? null) : null;
+      mapping.resolvedAt = command.promotedAt.toISOString();
+      next.legacyMappings.set(mapping.id, mapping);
+    }
+
+    candidate.candidateStatus = 'promoted';
+    candidate.canonicalEntityId = command.entity.id;
+    candidate.canonicalLocationId = command.location?.id ?? null;
+    candidate.updatedAt = command.promotedAt.toISOString();
+    next.candidates.set(candidate.id, candidate);
+
+    const receipt: CandidatePromotionReceipt = {
+      requestId: command.requestId,
+      candidateId: command.candidateId,
+      entityId: command.entity.id,
+      locationId: command.location?.id ?? null,
+      claimId: command.claim.id,
+      claimAssetIds: command.claimAssets.map((row) => row.id),
+      canonicalPath: command.canonicalPath,
+      claimStatus: 'candidate',
+      visibility: 'hidden',
+      promotedAt: command.promotedAt.toISOString(),
+      state: 'committed',
+    };
+    next.promotionsByRequest.set(command.requestId, {
+      fingerprint: command.requestFingerprint,
+      receipt,
+    });
+
+    if (this.options.failBeforeCommit?.(command) === true) {
+      throw new Error('Injected Candidate promotion failure before atomic commit.');
+    }
+
+    this.state = next;
+    return structuredClone(receipt);
+  }
+
+  snapshot() {
+    return {
+      candidates: [...this.state.candidates.values()]
+        .map((candidate) => structuredClone(candidate))
+        .sort((left, right) => left.id.localeCompare(right.id)),
+      legacyMappings: [...this.state.legacyMappings.values()]
+        .map((mapping) => structuredClone(mapping))
+        .sort((left, right) => left.id.localeCompare(right.id)),
+      entities: [...this.state.entities.values()].map((row) => structuredClone(row)),
+      locations: [...this.state.locations.values()].map((row) => structuredClone(row)),
+      claims: [...this.state.claims.values()].map((row) => structuredClone(row)),
+      claimAssets: [...this.state.claimAssets.values()].map((row) => structuredClone(row)),
+      provenance: this.state.provenance.map((row) => structuredClone(row)),
+      promotions: this.state.promotionsByRequest.size,
+    };
+  }
+}

--- a/tests/candidate-promotion-contract.test.ts
+++ b/tests/candidate-promotion-contract.test.ts
@@ -184,7 +184,9 @@ describe('Candidate promotion contract', () => {
   it('replays identical requests and rejects changed content', async () => {
     const store = backend();
     const service = createCandidatePromotionService(store);
-    await expect(service.promote(context(), input())).resolves.toMatchObject({ state: 'committed' });
+    await expect(service.promote(context(), input())).resolves.toMatchObject({
+      state: 'committed',
+    });
     await expect(service.promote(context(), input())).resolves.toMatchObject({ state: 'replayed' });
     const changed = input();
     changed.entity.value.name = 'Changed Cafe';

--- a/tests/candidate-promotion-contract.test.ts
+++ b/tests/candidate-promotion-contract.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createCandidatePromotionService,
+  type CandidatePromotionInput,
+} from '../src/admin/promotion/candidate-promotion';
+import { InMemoryCandidatePromotionBackend } from '../src/admin/promotion/in-memory-candidate-promotion-backend';
+
+const ids = {
+  request: '10000000-0000-4000-8000-000000000001',
+  candidate: '20000000-0000-4000-8000-000000000001',
+  entity: '30000000-0000-4000-8000-000000000001',
+  location: '40000000-0000-4000-8000-000000000001',
+  claim: '50000000-0000-4000-8000-000000000001',
+  claimAsset: '60000000-0000-4000-8000-000000000001',
+  source: '70000000-0000-4000-8000-000000000001',
+  asset: '80000000-0000-4000-8000-000000000001',
+  network: '90000000-0000-4000-8000-000000000001',
+  method: 'a0000000-0000-4000-8000-000000000001',
+} as const;
+const reviewedAt = '2026-06-29T00:00:00.000Z';
+const promotedAt = '2026-06-30T00:00:00.000Z';
+
+function input(): CandidatePromotionInput {
+  return {
+    candidateId: ids.candidate,
+    expectedCandidateType: 'physical_place',
+    expectedCandidateUpdatedAt: reviewedAt,
+    promotedAt,
+    entity: {
+      id: ids.entity,
+      value: {
+        entityType: 'merchant',
+        name: 'Reviewed Cafe',
+        slug: null,
+        legalName: null,
+        websiteUrl: 'https://example.test/',
+        countryCode: 'JP',
+        entityStatus: 'active',
+        visibility: 'hidden',
+      },
+    },
+    location: {
+      id: ids.location,
+      value: {
+        name: 'Reviewed Cafe Tokyo',
+        slug: 'reviewed-cafe-tokyo',
+        addressLine: '1-1 Example',
+        locality: 'Tokyo',
+        region: 'Tokyo',
+        postalCode: null,
+        countryCode: 'JP',
+        latitude: 35.681236,
+        longitude: 139.767125,
+        locationStatus: 'active',
+        visibility: 'hidden',
+        websiteUrl: 'https://example.test/',
+        phone: null,
+        osmType: null,
+        osmId: null,
+      },
+    },
+    claim: {
+      id: ids.claim,
+      value: {
+        entityId: ids.entity,
+        locationId: ids.location,
+        claimScope: 'location_specific',
+        routeType: 'direct_wallet',
+        acceptanceScope: 'all_checkout',
+        claimStatus: 'candidate',
+        visibility: 'hidden',
+        customerPaysCrypto: true,
+        merchantExplicitlyAcceptsCrypto: true,
+        processorId: null,
+        howToPay: 'Ask staff to display the payment QR code.',
+        instructionsLanguage: 'en',
+        merchantReceives: 'not_publicly_confirmed',
+        restrictions: null,
+        firstConfirmedAt: null,
+        lastConfirmedAt: null,
+        nextReviewAt: null,
+        endedAt: null,
+        endedReason: null,
+      },
+    },
+    claimAssets: [
+      {
+        id: ids.claimAsset,
+        value: {
+          claimId: ids.claim,
+          assetId: ids.asset,
+          networkId: ids.network,
+          paymentMethodId: ids.method,
+          contractAddress: null,
+          isPrimary: true,
+          notes: null,
+        },
+      },
+    ],
+    sourceRecordIds: [ids.source],
+  };
+}
+
+function context() {
+  return {
+    requestId: ids.request,
+    actorId: 'canonical-reviewer',
+    actorType: 'human' as const,
+    capabilities: ['candidate:promote' as const],
+  };
+}
+
+function backend(failBeforeCommit = false) {
+  return new InMemoryCandidatePromotionBackend({
+    candidates: [
+      {
+        id: ids.candidate,
+        candidateType: 'physical_place',
+        candidateStatus: 'triaged',
+        updatedAt: reviewedAt,
+        canonicalEntityId: null,
+        canonicalLocationId: null,
+        sourceRecordIds: [ids.source],
+      },
+    ],
+    legacyMappings: [
+      {
+        id: 'b0000000-0000-4000-8000-000000000001',
+        sourceSystem: 'cryptopaymap_v2',
+        sourceRecordId: ids.source,
+        migrationStatus: 'pending',
+        canonicalPath: null,
+        entityId: null,
+        locationId: null,
+        resolvedAt: null,
+      },
+    ],
+    assetIds: [ids.asset],
+    networkIds: [ids.network],
+    paymentMethodIds: [ids.method],
+    failBeforeCommit: () => failBeforeCommit,
+  });
+}
+
+describe('Candidate promotion contract', () => {
+  it('creates only hidden candidate canonical records', async () => {
+    const store = backend();
+    const receipt = await createCandidatePromotionService(store).promote(context(), input());
+    expect(receipt).toMatchObject({
+      entityId: ids.entity,
+      locationId: ids.location,
+      claimStatus: 'candidate',
+      visibility: 'hidden',
+      canonicalPath: '/place/reviewed-cafe-tokyo',
+      state: 'committed',
+    });
+    const snapshot = store.snapshot();
+    expect(snapshot.candidates[0]).toMatchObject({
+      candidateStatus: 'promoted',
+      canonicalEntityId: ids.entity,
+      canonicalLocationId: ids.location,
+    });
+    expect(snapshot.provenance).toHaveLength(4);
+    expect(snapshot.legacyMappings[0]).toMatchObject({
+      migrationStatus: 'mapped',
+      locationId: ids.location,
+    });
+  });
+
+  it('rejects public or verified promotion before backend access', async () => {
+    const commitPromotion = vi.fn();
+    const unsafe = input();
+    unsafe.claim.value.claimStatus = 'confirmed';
+    unsafe.claim.value.visibility = 'public';
+    unsafe.claim.value.firstConfirmedAt = promotedAt;
+    unsafe.claim.value.lastConfirmedAt = promotedAt;
+
+    await expect(
+      createCandidatePromotionService({ commitPromotion }).promote(context(), unsafe),
+    ).rejects.toMatchObject({ code: 'invalid_promotion' });
+    expect(commitPromotion).not.toHaveBeenCalled();
+  });
+
+  it('replays identical requests and rejects changed content', async () => {
+    const store = backend();
+    const service = createCandidatePromotionService(store);
+    await expect(service.promote(context(), input())).resolves.toMatchObject({ state: 'committed' });
+    await expect(service.promote(context(), input())).resolves.toMatchObject({ state: 'replayed' });
+    const changed = input();
+    changed.entity.value.name = 'Changed Cafe';
+    await expect(service.promote(context(), changed)).rejects.toMatchObject({ code: 'conflict' });
+  });
+
+  it('rolls back all canonical changes on pre-commit failure', async () => {
+    const store = backend(true);
+    const before = store.snapshot();
+    await expect(
+      createCandidatePromotionService(store).promote(context(), input()),
+    ).rejects.toMatchObject({ code: 'backend_failure' });
+    expect(store.snapshot()).toEqual(before);
+  });
+});


### PR DESCRIPTION
## Implementation item

`P3-07A` within `P3-07`

## Purpose

Define the authorization, validation, atomicity, provenance, replay, and private-output boundary for promoting one reviewed Candidate into canonical records.

## Included

- separate `candidate:promote` capability and mutation context
- physical-place and online-service promotion contracts
- explicit Entity, Location, Acceptance Claim, and Claim Asset drafts
- exact Candidate version and source-provenance expectations
- hidden canonical records and hidden candidate claim enforcement
- asset, network, payment-method, processor, ID, and slug conflict boundaries
- Candidate canonical-link and legacy-mapping transitions
- request replay and changed-content conflict handling
- copy-on-write atomic test backend
- success, public-boundary, replay-conflict, and rollback tests
- repository implementation and current-status updates

## Explicit exclusions

- no Confirmed, Stale, Ended, or public promotion
- no Evidence or verification decision
- no media decision
- no public export or publication
- no production Drizzle backend or migration
- no administration route or editor
- no existing canonical-target linking

## Validation

Foundation validation and Migration drift must pass before merge.

## Next

Add the durable promotion audit schema, migration, and Drizzle transaction backend.