### PR TITLE
Harden export restore replay preflight

### DIFF
--- a/docs/EXPORT_RELEASE_RESTORE_WORKFLOW.md
+++ b/docs/EXPORT_RELEASE_RESTORE_WORKFLOW.md
@@ -1,52 +1,58 @@
 # Export release restore workflow
 
-**Implementation item:** P3-11L  
+**Implementation item:** P3-11L hardening  
 **Status:** Active
 
 ## Purpose
 
-This slice connects the restore pointer-switch boundary to the restore execution-record boundary.
+This workflow connects pointer switching to restore execution recording.
 
-A successful workflow now has one controlled sequence:
+The workflow sequence is:
 
 1. authorize the publication-capable actor
-2. validate the restore request and pointer inventory relationship
-3. inspect an existing request record for replay
+2. validate request and inventory relationships
+3. calculate the request fingerprint and check for replay or conflict
 4. validate target release objects and conditionally switch pointers
-5. persist the completed restore execution record with the exact switch receipts
+5. persist the completed execution record with switch receipts
 
 ## Pre-mutation validation
 
-Before any object-store mutation, the workflow verifies:
+Before object-store mutation, the workflow verifies:
 
 - `export:publish` authority
 - request input shape
 - pointer inventory shape
-- requested target snapshot equals the inventory target snapshot
-- expected active snapshot equals the inventory previous-active snapshot
+- target snapshot agreement
+- expected active snapshot agreement
+- request fingerprint agreement with any existing execution record
 
-Invalid requests fail before pointer replacement.
+The fingerprint includes actor ID, actor type, target snapshot, expected active snapshot, restore time, reason code, internal note, and inventory fingerprint.
+
+Invalid requests and request-ID conflicts fail before pointer replacement.
 
 ## Replay behavior
 
-The workflow checks the request ID before pointer switching.
+The workflow checks for an existing matching execution before pointer switching.
 
-When a matching execution record already exists, its pointer-switch receipts are passed through the existing execution-record replay validation and no pointer is switched again.
+A matching request ID and fingerprint returns the completed record directly. Target objects are not inspected and pointers are not switched again.
 
-A mismatched request using an existing request ID fails as replay validation failure.
+A reused request ID with different content fails with `replay_validation_failed` before object-store mutation.
+
+The execution service checks the record again after pointer switching to guard concurrent requests.
 
 ## Failure boundary
 
 Pointer-switch failure does not write a completed execution record.
 
-If pointer switching succeeds but durable execution-record persistence fails, the workflow raises `execution_record_failed_after_switch` and carries the validated pointer-switch receipts on the error. This makes the post-mutation persistence failure explicit for operator reconciliation instead of reporting the restore as completed.
+When pointer switching succeeds but record persistence fails, the workflow raises `execution_record_failed_after_switch` and includes validated switch receipts for reconciliation.
+
+Object storage and database persistence are separate operations. The workflow records partial-success evidence explicitly instead of reporting completion.
 
 ## Explicit exclusions
 
-P3-11L does not add:
+This hardening does not add:
 
 - a concrete Cloudflare R2 adapter
 - restore execution database tables
 - public restore controls
 - live production verification
-- the final P3-11 integration audit

--- a/src/admin/export-release/restore-execution.ts
+++ b/src/admin/export-release/restore-execution.ts
@@ -118,9 +118,11 @@ export type ExportRestoreExecutionErrorCode =
   | 'invalid_inventory'
   | 'invalid_switch_receipt'
   | 'active_mismatch'
+  | 'target_snapshot_mismatch'
   | 'switch_count_mismatch'
   | 'pointer_mismatch'
   | 'target_etag_mismatch'
+  | 'switch_time_mismatch'
   | 'request_conflict'
   | 'backend_failure';
 
@@ -139,6 +141,12 @@ export class ExportRestoreExecutionError extends Error {
     this.code = code;
     this.issues = issues;
   }
+}
+
+interface PreparedRestoreExecutionIdentity {
+  inventory: ExportRestorePointerInventory;
+  inventoryFingerprint: string;
+  requestFingerprint: string;
 }
 
 function canonicalJson(value: unknown): string {
@@ -166,10 +174,12 @@ export async function exportRestoreInventoryFingerprint(
 export async function exportRestoreRequestFingerprint(input: {
   requestId: string;
   actorId: string;
+  actorType: 'human' | 'system';
   targetSnapshotDigest: string;
   expectedActiveSnapshotDigest: string;
   restoredAt: string;
   reasonCode: string;
+  internalNote: string | null;
   inventoryFingerprint: string;
 }): Promise<string> {
   return sha256Hex(canonicalJson(input));
@@ -184,9 +194,60 @@ function assertExecutionAuthorization(context: ExportPublicationMutationContext)
   }
 }
 
+async function prepareExecutionIdentity(args: {
+  context: ExportPublicationMutationContext;
+  input: ExportRestoreExecutionInput;
+  inventory: ExportRestorePointerInventory;
+}): Promise<PreparedRestoreExecutionIdentity> {
+  assertExecutionAuthorization(args.context);
+  const inventoryResult = exportRestorePointerInventorySchema.safeParse(args.inventory);
+  if (!inventoryResult.success) {
+    throw new ExportRestoreExecutionError(
+      'invalid_inventory',
+      'The restore pointer inventory is invalid.',
+      inventoryResult.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+    );
+  }
+  if (
+    inventoryResult.data.previousActiveSnapshotDigest !== args.input.expectedActiveSnapshotDigest
+  ) {
+    throw new ExportRestoreExecutionError(
+      'active_mismatch',
+      'The restore inventory does not match the expected active snapshot.',
+      ['expectedActiveSnapshotDigest'],
+    );
+  }
+  if (inventoryResult.data.targetSnapshotDigest !== args.input.targetSnapshotDigest) {
+    throw new ExportRestoreExecutionError(
+      'target_snapshot_mismatch',
+      'The restore inventory does not match the requested target snapshot.',
+      ['targetSnapshotDigest'],
+    );
+  }
+
+  const inventoryFingerprint = await exportRestoreInventoryFingerprint(inventoryResult.data);
+  const requestFingerprint = await exportRestoreRequestFingerprint({
+    requestId: args.context.requestId,
+    actorId: args.context.actorId,
+    actorType: args.context.actorType,
+    targetSnapshotDigest: args.input.targetSnapshotDigest,
+    expectedActiveSnapshotDigest: args.input.expectedActiveSnapshotDigest,
+    restoredAt: args.input.restoredAt,
+    reasonCode: args.input.reasonCode,
+    internalNote: args.input.internalNote,
+    inventoryFingerprint,
+  });
+  return {
+    inventory: inventoryResult.data,
+    inventoryFingerprint,
+    requestFingerprint,
+  };
+}
+
 function assertSwitchesMatchInventory(
   inventory: ExportRestorePointerInventory,
   pointerSwitches: ExportRestorePointerSwitchReceipt[],
+  restoredAt: string,
 ): void {
   if (pointerSwitches.length !== inventory.items.length) {
     throw new ExportRestoreExecutionError(
@@ -212,26 +273,64 @@ function assertSwitchesMatchInventory(
         [pointerSwitch.pointerKey],
       );
     }
+    if (pointerSwitch.switchedAt !== restoredAt) {
+      throw new ExportRestoreExecutionError(
+        'switch_time_mismatch',
+        'The restore pointer switch receipt time does not match the restore operation time.',
+        [pointerSwitch.pointerKey],
+      );
+    }
   }
+}
+
+async function readExistingExecution(
+  backend: ExportRestoreExecutionBackend,
+  requestId: string,
+  requestFingerprint: string,
+): Promise<ExportRestoreExecutionRecord | null> {
+  let existing: ExportRestoreExecutionRecord | null;
+  try {
+    existing = await backend.readRestoreRecord(requestId);
+  } catch (error) {
+    throw new ExportRestoreExecutionError(
+      'backend_failure',
+      'The restore execution record could not be read.',
+      [],
+      { cause: error },
+    );
+  }
+  if (existing !== null && existing.requestFingerprint !== requestFingerprint) {
+    throw new ExportRestoreExecutionError(
+      'request_conflict',
+      'The restore request ID was reused with different content.',
+      ['requestFingerprint'],
+    );
+  }
+  return existing;
 }
 
 export function createExportRestoreExecutionService(backend: ExportRestoreExecutionBackend) {
   return {
+    async findReplay(args: {
+      context: ExportPublicationMutationContext;
+      input: ExportRestoreExecutionInput;
+      inventory: ExportRestorePointerInventory;
+    }): Promise<ExportRestoreExecutionRecord | null> {
+      const identity = await prepareExecutionIdentity(args);
+      return readExistingExecution(
+        backend,
+        args.context.requestId,
+        identity.requestFingerprint,
+      );
+    },
+
     async recordExecution(args: {
       context: ExportPublicationMutationContext;
       input: ExportRestoreExecutionInput;
       inventory: ExportRestorePointerInventory;
       pointerSwitches: ExportRestorePointerSwitchReceipt[];
     }): Promise<ExportRestoreExecutionRecord> {
-      assertExecutionAuthorization(args.context);
-      const inventoryResult = exportRestorePointerInventorySchema.safeParse(args.inventory);
-      if (!inventoryResult.success) {
-        throw new ExportRestoreExecutionError(
-          'invalid_inventory',
-          'The restore pointer inventory is invalid.',
-          inventoryResult.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
-        );
-      }
+      const identity = await prepareExecutionIdentity(args);
       const switchResult = z
         .array(exportRestorePointerSwitchReceiptSchema)
         .safeParse(args.pointerSwitches);
@@ -242,62 +341,27 @@ export function createExportRestoreExecutionService(backend: ExportRestoreExecut
           switchResult.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
         );
       }
-      if (
-        inventoryResult.data.previousActiveSnapshotDigest !==
-        args.input.expectedActiveSnapshotDigest
-      ) {
-        throw new ExportRestoreExecutionError(
-          'active_mismatch',
-          'The restore inventory does not match the expected active snapshot.',
-          ['expectedActiveSnapshotDigest'],
-        );
-      }
-      assertSwitchesMatchInventory(inventoryResult.data, switchResult.data);
+      assertSwitchesMatchInventory(identity.inventory, switchResult.data, args.input.restoredAt);
 
-      const inventoryFingerprint = await exportRestoreInventoryFingerprint(inventoryResult.data);
-      const requestFingerprint = await exportRestoreRequestFingerprint({
-        requestId: args.context.requestId,
-        actorId: args.context.actorId,
-        targetSnapshotDigest: args.input.targetSnapshotDigest,
-        expectedActiveSnapshotDigest: args.input.expectedActiveSnapshotDigest,
-        restoredAt: args.input.restoredAt,
-        reasonCode: args.input.reasonCode,
-        inventoryFingerprint,
-      });
-      let existing: ExportRestoreExecutionRecord | null;
-      try {
-        existing = await backend.readRestoreRecord(args.context.requestId);
-      } catch (error) {
-        throw new ExportRestoreExecutionError(
-          'backend_failure',
-          'The restore execution record could not be read.',
-          [],
-          { cause: error },
-        );
-      }
-      if (existing !== null) {
-        if (existing.requestFingerprint !== requestFingerprint) {
-          throw new ExportRestoreExecutionError(
-            'request_conflict',
-            'The restore request ID was reused with different content.',
-            ['requestFingerprint'],
-          );
-        }
-        return existing;
-      }
+      const existing = await readExistingExecution(
+        backend,
+        args.context.requestId,
+        identity.requestFingerprint,
+      );
+      if (existing !== null) return existing;
 
       const record = exportRestoreExecutionRecordSchema.parse({
         requestId: args.context.requestId,
         actorId: args.context.actorId,
         actorType: args.context.actorType,
-        previousActiveSnapshotDigest: inventoryResult.data.previousActiveSnapshotDigest,
-        restoredSnapshotDigest: inventoryResult.data.targetSnapshotDigest,
-        restoredDatasetVersion: inventoryResult.data.targetDatasetVersion,
+        previousActiveSnapshotDigest: identity.inventory.previousActiveSnapshotDigest,
+        restoredSnapshotDigest: identity.inventory.targetSnapshotDigest,
+        restoredDatasetVersion: identity.inventory.targetDatasetVersion,
         reasonCode: args.input.reasonCode,
         internalNote: args.input.internalNote,
         restoredAt: args.input.restoredAt,
-        inventoryFingerprint,
-        requestFingerprint,
+        inventoryFingerprint: identity.inventoryFingerprint,
+        requestFingerprint: identity.requestFingerprint,
         pointerSwitches: switchResult.data,
       });
       try {

--- a/src/admin/export-release/restore-execution.ts
+++ b/src/admin/export-release/restore-execution.ts
@@ -317,11 +317,7 @@ export function createExportRestoreExecutionService(backend: ExportRestoreExecut
       inventory: ExportRestorePointerInventory;
     }): Promise<ExportRestoreExecutionRecord | null> {
       const identity = await prepareExecutionIdentity(args);
-      return readExistingExecution(
-        backend,
-        args.context.requestId,
-        identity.requestFingerprint,
-      );
+      return readExistingExecution(backend, args.context.requestId, identity.requestFingerprint);
     },
 
     async recordExecution(args: {

--- a/src/admin/export-release/restore-workflow.ts
+++ b/src/admin/export-release/restore-workflow.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { ExportPublicationMutationContext } from './publication-contract';
 import {
   createExportRestoreExecutionService,
+  ExportRestoreExecutionError,
   exportRestorePointerInventorySchema,
   type ExportRestoreExecutionBackend,
   type ExportRestoreExecutionInput,
@@ -138,35 +139,30 @@ export function createExportRestoreWorkflow(dependencies: {
 
       let existing: ExportRestoreExecutionRecord | null;
       try {
-        existing = await dependencies.executionBackend.readRestoreRecord(args.context.requestId);
+        existing = await executionService.findReplay({
+          context: args.context,
+          input: validated.input,
+          inventory: validated.inventory,
+        });
       } catch (error) {
+        if (error instanceof ExportRestoreExecutionError && error.code === 'backend_failure') {
+          throw new ExportRestoreWorkflowError(
+            'restore_record_read_failed',
+            'The restore workflow could not inspect an existing execution record.',
+            [],
+            [],
+            { cause: error },
+          );
+        }
         throw new ExportRestoreWorkflowError(
-          'restore_record_read_failed',
-          'The restore workflow could not inspect an existing execution record.',
+          'replay_validation_failed',
+          'The restore replay request does not match the existing execution record.',
           [],
           [],
           { cause: error },
         );
       }
-
-      if (existing !== null) {
-        try {
-          return await executionService.recordExecution({
-            context: args.context,
-            input: validated.input,
-            inventory: validated.inventory,
-            pointerSwitches: existing.pointerSwitches,
-          });
-        } catch (error) {
-          throw new ExportRestoreWorkflowError(
-            'replay_validation_failed',
-            'The existing restore execution record does not match this replay request.',
-            [],
-            existing.pointerSwitches,
-            { cause: error },
-          );
-        }
-      }
+      if (existing !== null) return existing;
 
       let pointerSwitches: ExportRestorePointerSwitchReceipt[];
       try {

--- a/tests/export-release-restore-execution.test.ts
+++ b/tests/export-release-restore-execution.test.ts
@@ -93,6 +93,22 @@ describe('export restore execution record contract', () => {
     expect(state.writes).toEqual([record]);
   });
 
+  it('finds an identical completed replay before pointer switching', async () => {
+    const first = backend();
+    const record = await createExportRestoreExecutionService(first.backend).recordExecution({
+      context,
+      input,
+      inventory,
+      pointerSwitches,
+    });
+    const replay = backend(record);
+
+    await expect(
+      createExportRestoreExecutionService(replay.backend).findReplay({ context, input, inventory }),
+    ).resolves.toEqual(record);
+    expect(replay.writes).toEqual([]);
+  });
+
   it('replays an identical restore request without writing again', async () => {
     const first = backend();
     const record = await createExportRestoreExecutionService(first.backend).recordExecution({
@@ -114,7 +130,25 @@ describe('export restore execution record contract', () => {
     expect(replay.writes).toEqual([]);
   });
 
-  it('rejects request ID reuse with different content', async () => {
+  it('rejects request ID reuse when an internal note changes', async () => {
+    const first = backend();
+    const record = await createExportRestoreExecutionService(first.backend).recordExecution({
+      context,
+      input,
+      inventory,
+      pointerSwitches,
+    });
+
+    await expect(
+      createExportRestoreExecutionService(backend(record).backend).findReplay({
+        context,
+        input: { ...input, internalNote: 'Different restore note.' },
+        inventory,
+      }),
+    ).rejects.toMatchObject({ code: 'request_conflict' });
+  });
+
+  it('rejects request ID reuse with a different reason code', async () => {
     const first = backend();
     const record = await createExportRestoreExecutionService(first.backend).recordExecution({
       context,
@@ -144,6 +178,16 @@ describe('export restore execution record contract', () => {
     ).rejects.toMatchObject({ code: 'unauthorized' });
   });
 
+  it('requires the requested target snapshot to match the inventory', async () => {
+    await expect(
+      createExportRestoreExecutionService(backend().backend).findReplay({
+        context,
+        input: { ...input, targetSnapshotDigest: 'd'.repeat(64) },
+        inventory,
+      }),
+    ).rejects.toMatchObject({ code: 'target_snapshot_mismatch' });
+  });
+
   it('requires pointer switches to match the pointer inventory', async () => {
     await expect(
       createExportRestoreExecutionService(backend().backend).recordExecution({
@@ -164,6 +208,17 @@ describe('export restore execution record contract', () => {
         pointerSwitches: [{ ...pointerSwitch, newEtag: 'etag-wrong-target' }],
       }),
     ).rejects.toMatchObject({ code: 'target_etag_mismatch' });
+  });
+
+  it('requires switch receipt time to match the restore time', async () => {
+    await expect(
+      createExportRestoreExecutionService(backend().backend).recordExecution({
+        context,
+        input,
+        inventory,
+        pointerSwitches: [{ ...pointerSwitch, switchedAt: '2026-07-04T05:01:00.000Z' }],
+      }),
+    ).rejects.toMatchObject({ code: 'switch_time_mismatch' });
   });
 
   it('rejects inventory that does not match the expected active snapshot', async () => {

--- a/tests/export-release-restore-workflow.test.ts
+++ b/tests/export-release-restore-workflow.test.ts
@@ -143,6 +143,30 @@ describe('export restore workflow', () => {
     expect(replayDatabase.writes).toEqual([]);
   });
 
+  it('rejects conflicting replay content before switching pointers', async () => {
+    const firstDatabase = executionBackend();
+    const firstObjects = pointerAdapter();
+    const existing = await createExportRestoreWorkflow({
+      executionBackend: firstDatabase.backend,
+      pointerSwitchAdapter: firstObjects.adapter,
+    }).execute(workflowArgs());
+
+    const replayDatabase = executionBackend({ existing });
+    const replayObjects = pointerAdapter();
+    await expect(
+      createExportRestoreWorkflow({
+        executionBackend: replayDatabase.backend,
+        pointerSwitchAdapter: replayObjects.adapter,
+      }).execute({
+        ...workflowArgs(),
+        input: { ...input, internalNote: 'Different restore note.' },
+      }),
+    ).rejects.toMatchObject({ code: 'replay_validation_failed' });
+
+    expect(replayObjects.replacePointer).not.toHaveBeenCalled();
+    expect(replayDatabase.writes).toEqual([]);
+  });
+
   it('fails closed before object-store mutation for unauthorized actors', async () => {
     const database = executionBackend();
     const objects = pointerAdapter();


### PR DESCRIPTION
## Scope

Focused hardening patch for the merged export restore workflow.

## Included

- request fingerprint replay lookup before pointer switching
- actor type and internal note coverage in restore request fingerprints
- requested target snapshot identity guard
- switch receipt timestamp guard
- workflow conflict detection before object-store mutation
- second execution-record lookup after pointer switching as a concurrency guard
- execution and workflow regression tests
- restore workflow documentation update

## Safety properties

- completed matching replays do not inspect targets or switch pointers again
- conflicting request-ID reuse fails before pointer mutation
- pointer switch failure does not write a completion record
- post-switch persistence failure still carries validated switch receipts for reconciliation

## Validation

- Foundation validation: passed
- Migration drift: passed
- formatting: passed
- lint: passed
- Astro and TypeScript: passed
- runtime schema checks: passed
- migration history: passed
- unit and component tests: passed
- build: passed
- accessibility: passed
- Phase 1 checks: passed
- staging artifact: passed

## Explicit exclusions

- no Cloudflare R2 adapter implementation
- no restore database schema changes
- no public restore UI changes
- no production verification