### PR TITLE
P3-12C: Connect audit history to durable Phase 3 tables

### DIFF
--- a/docs/AUDIT_HISTORY_DURABLE_SOURCES.md
+++ b/docs/AUDIT_HISTORY_DURABLE_SOURCES.md
@@ -1,0 +1,45 @@
+# Audit history durable sources
+
+**Implementation item:** P3-12C  
+**Status:** Active
+
+## Purpose
+
+P3-12C connects normalized audit history aggregation to existing Phase 3 decision and event tables.
+
+No second audit write path is added. Existing source tables remain authoritative.
+
+## Connected sources
+
+The source registry includes candidate duplicate decisions, candidate promotions, Evidence review decisions, reconfirmation expirations, Media review decisions, export release decisions, and export activation records.
+
+Each source reads one extra row beyond its bounded source limit to report `hasMore`, maps records through metadata-only normalizers, and preserves deterministic source ordering.
+
+## Filter pushdown
+
+Each source pushes applicable filters into its query before applying the source limit:
+
+- actor ID
+- from and to timestamps
+- stable before timestamp and audit item ID cursor
+- source-specific primary or secondary target filters
+
+The aggregate layer repeats normalized filters as a defense boundary.
+
+## Cursor ordering
+
+Source queries order by occurrence time descending and source record ID descending. At equal timestamps, cursor comparison uses the normalized `sourceKind:sourceRecordId` identity.
+
+## Restore execution source
+
+The restore execution contract has a normalized audit mapper, but it is not registered as a Drizzle source here because there is no deployed restore execution table in the repository schema.
+
+The source registry does not claim durable database history for a record class whose table is not present.
+
+## Failure and privacy behavior
+
+Normalizers do not expose internal notes or arbitrary source payloads. Source failures propagate through the aggregate fail-closed behavior, so partial history is not presented as complete.
+
+## Explicit exclusions
+
+P3-12C does not add a restore execution table, protected audit history API route, Audit administration UI, live database verification, or final Phase 3 integration sign-off.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -86,7 +86,7 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 | P3-09 | Status transitions and reconfirmation queue | Completed | P3-07, P3-08 | #64–#67 |
 | P3-10 | Media review | Completed | P3-02, P2-10 | #69–#74 |
 | P3-11 | Export controls and release workflow | Repository completed; live verification deferred | P3-07 through P3-10 | #75–#87 |
-| P3-12 | Audit history and Phase 3 integration audit | In progress | P3-01 through P3-11 | P3-12A active |
+| P3-12 | Audit history and Phase 3 integration audit | In progress | P3-01 through P3-11 | #88, #89; P3-12C active |
 
 ### Completed P3-07 deliveries
 
@@ -114,13 +114,18 @@ P3-11I through P3-11L established restore preparation, pointer inventory and exe
 
 P3-11M aligned restore readiness with the implemented execution workflow, added readiness-to-execution runtime verification, completed the repository integration audit, documented deferred live verification, and handed off to P3-12 in pull request #87.
 
+### Completed P3-12 deliveries
+
+P3-12A defined the protected normalized audit-history read contract across candidate, Evidence, reconfirmation, Media, and export administration. It added bounded filters, stable cursor semantics, deterministic ordering, source-domain validation, target metadata, and privacy leakage boundaries in pull request #88.
+
+P3-12B added metadata-only source normalizers, bounded concurrent aggregation, source-domain validation, duplicate identity rejection, defensive filtering, deterministic cross-source ordering, and fail-closed source handling in pull request #89.
+
 ### Current P3-12 delivery
 
-P3-12A defines the protected normalized audit-history read contract across candidate, Evidence, reconfirmation, Media, and export administration. It adds bounded filters, stable cursor semantics, deterministic ordering, source-domain validation, target metadata, and privacy leakage boundaries without duplicating authoritative domain writes.
+P3-12C connects bounded audit history sources to the existing durable Phase 3 tables. It pushes actor, time-range, target, and stable cursor filters into source queries, preserves source ordering compatible with the global cursor, and excludes restore execution from the Drizzle registry until a corresponding table exists.
 
 ### Remaining P3-12 deliveries
 
-- bounded aggregation over authoritative durable Phase 3 decision and event sources
 - protected audit history API and administration surface
 - final cross-domain Phase 3 integration audit and Phase 4 handoff
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -12,8 +12,8 @@ P3-12 — Audit history and Phase 3 integration audit
 
 ## Active work
 
-- P3-12B — bounded audit history aggregation and source normalization
-- Branch: `work/audit-history-aggregation`
+- P3-12C — durable audit history source adapters
+- Branch: `work/audit-history-sources`
 - Pull request: pending
 
 ## Latest completed work
@@ -26,29 +26,26 @@ P3-12 — Audit history and Phase 3 integration audit
 - P3-10 completed through pull request #74
 - P3-11 completed through pull request #87
 - P3-12A normalized audit history read contract completed through pull request #88
+- P3-12B bounded audit history aggregation completed through pull request #89
 
-## P3-12B in progress
+## P3-12C in progress
 
-- source-specific normalizers for durable Phase 3 decision and event records
-- metadata-only normalized audit items
-- concurrent bounded source loading
-- source-domain consistency checks
-- duplicate event identity rejection
-- actor, target, time-range, and cursor defense filters
-- deterministic cross-source merge ordering
-- source failure fail-closed behavior
+- Drizzle-backed source adapters over existing durable Phase 3 tables
+- source-side actor, time-range, cursor, and target filter pushdown
+- deterministic per-source ordering compatible with the global audit cursor
+- bounded source reads with one-row pagination lookahead
+- explicit exclusion of restore execution from the database source registry until a table exists
 - runtime and unit verification
 
 ## Next
 
-1. Complete P3-12B validation and merge the pull request.
-2. Connect bounded source adapters to durable repository tables.
-3. Add protected audit history API and administration surface.
-4. Complete the final Phase 3 cross-domain integration audit and hand off to Phase 4.
+1. Complete P3-12C validation and merge the pull request.
+2. Add protected audit history API and administration surface.
+3. Complete the final Phase 3 cross-domain integration audit and hand off to Phase 4.
 
 ## Blocked
 
-No repository blocker. Live candidate generation, R2 activation, public serving, database migration, concrete restore persistence deployment, and production verification remain deferred.
+No repository blocker. Live candidate generation, R2 activation, public serving, database migration, restore persistence deployment, and production verification remain deferred.
 
 ## Verification rule
 

--- a/scripts/check-audit-history-aggregation.ts
+++ b/scripts/check-audit-history-aggregation.ts
@@ -2,7 +2,8 @@ import { createAggregatedAuditHistoryBackend } from '../src/admin/audit-history/
 import { createDrizzleAuditHistorySources } from '../src/admin/audit-history/drizzle-sources';
 import { evidenceReviewDecisionAuditItem } from '../src/admin/audit-history/normalizers';
 
-if (typeof createAggregatedAuditHistoryBackend !== 'function') throw new Error('missing aggregation');
+if (typeof createAggregatedAuditHistoryBackend !== 'function')
+  throw new Error('missing aggregation');
 if (typeof createDrizzleAuditHistorySources !== 'function') throw new Error('missing sources');
 if (typeof evidenceReviewDecisionAuditItem !== 'function') throw new Error('missing normalizer');
 

--- a/scripts/check-audit-history-aggregation.ts
+++ b/scripts/check-audit-history-aggregation.ts
@@ -1,12 +1,9 @@
 import { createAggregatedAuditHistoryBackend } from '../src/admin/audit-history/aggregation';
+import { createDrizzleAuditHistorySources } from '../src/admin/audit-history/drizzle-sources';
 import { evidenceReviewDecisionAuditItem } from '../src/admin/audit-history/normalizers';
 
-if (typeof createAggregatedAuditHistoryBackend !== 'function') {
-  throw new Error('Audit aggregation factory is missing.');
-}
-
-if (typeof evidenceReviewDecisionAuditItem !== 'function') {
-  throw new Error('Audit normalizer is missing.');
-}
+if (typeof createAggregatedAuditHistoryBackend !== 'function') throw new Error('missing aggregation');
+if (typeof createDrizzleAuditHistorySources !== 'function') throw new Error('missing sources');
+if (typeof evidenceReviewDecisionAuditItem !== 'function') throw new Error('missing normalizer');
 
 console.log('Audit history aggregation checks passed.');

--- a/src/admin/audit-history/drizzle-sources.ts
+++ b/src/admin/audit-history/drizzle-sources.ts
@@ -1,0 +1,326 @@
+import { and, desc, eq, gte, lt, lte, or, sql, type AnyColumn, type SQL } from 'drizzle-orm';
+import type { CryptoPayMapDatabase } from '../../db/client';
+import {
+  candidateDuplicateDecisions,
+  candidatePromotionDecisions,
+  evidenceReviewDecisions,
+  exportActivationRecords,
+  exportReleaseDecisions,
+  mediaReviewDecisions,
+  reconfirmationExpirations,
+} from '../../db/schema';
+import type { AuditHistoryQuery } from './contract';
+import type { AuditHistorySource } from './aggregation';
+import {
+  candidateDuplicateDecisionAuditItem,
+  candidatePromotionAuditItem,
+  evidenceReviewDecisionAuditItem,
+  exportActivationAuditItem,
+  exportReleaseDecisionAuditItem,
+  mediaReviewDecisionAuditItem,
+  reconfirmationExpirationAuditItem,
+} from './normalizers';
+
+function commonConditions(
+  query: AuditHistoryQuery,
+  occurredAt: AnyColumn,
+  actorId: AnyColumn,
+  sourceKind: string,
+  sourceId: AnyColumn,
+): SQL[] {
+  const conditions: SQL[] = [];
+  if (query.actorId !== undefined) conditions.push(eq(actorId, query.actorId));
+  if (query.from !== undefined) conditions.push(gte(occurredAt, new Date(query.from)));
+  if (query.to !== undefined) conditions.push(lte(occurredAt, new Date(query.to)));
+  if (query.before !== undefined && query.beforeId !== undefined) {
+    const before = new Date(query.before);
+    conditions.push(
+      or(
+        lt(occurredAt, before),
+        and(
+          eq(occurredAt, before),
+          sql`${sourceKind} || ':' || ${sourceId}::text < ${query.beforeId}`,
+        ),
+      ) as SQL,
+    );
+  }
+  return conditions;
+}
+
+function whereOrUndefined(conditions: SQL[]): SQL | undefined {
+  return conditions.length === 0 ? undefined : and(...conditions);
+}
+
+export function createDrizzleCandidateDuplicateAuditSource(
+  database: CryptoPayMapDatabase,
+): AuditHistorySource {
+  return {
+    domain: 'candidate',
+    async loadAuditHistorySource(query, sourceLimit) {
+      const conditions = commonConditions(
+        query,
+        candidateDuplicateDecisions.decidedAt,
+        candidateDuplicateDecisions.actorId,
+        'candidate_duplicate_decision',
+        candidateDuplicateDecisions.id,
+      );
+      if (query.targetType === 'duplicate_group') {
+        if (query.targetId !== undefined) {
+          conditions.push(eq(candidateDuplicateDecisions.duplicateGroupId, query.targetId));
+        }
+      } else if (query.targetType === 'source_candidate') {
+        if (query.targetId !== undefined) {
+          conditions.push(
+            sql`${candidateDuplicateDecisions.memberCandidateIds} @> ${JSON.stringify([query.targetId])}::jsonb`,
+          );
+        }
+      } else if (query.targetType !== undefined) {
+        return { items: [], hasMore: false };
+      }
+
+      const rows = await database
+        .select()
+        .from(candidateDuplicateDecisions)
+        .where(whereOrUndefined(conditions))
+        .orderBy(desc(candidateDuplicateDecisions.decidedAt), desc(candidateDuplicateDecisions.id))
+        .limit(sourceLimit + 1);
+      return {
+        items: rows.slice(0, sourceLimit).map(candidateDuplicateDecisionAuditItem),
+        hasMore: rows.length > sourceLimit,
+      };
+    },
+  };
+}
+
+export function createDrizzleCandidatePromotionAuditSource(
+  database: CryptoPayMapDatabase,
+): AuditHistorySource {
+  return {
+    domain: 'candidate',
+    async loadAuditHistorySource(query, sourceLimit) {
+      const conditions = commonConditions(
+        query,
+        candidatePromotionDecisions.promotedAt,
+        candidatePromotionDecisions.actorId,
+        'candidate_promotion',
+        candidatePromotionDecisions.id,
+      );
+      if (query.targetType === 'source_candidate' && query.targetId !== undefined) {
+        conditions.push(eq(candidatePromotionDecisions.candidateId, query.targetId));
+      } else if (query.targetType === 'acceptance_claim' && query.targetId !== undefined) {
+        conditions.push(eq(candidatePromotionDecisions.claimId, query.targetId));
+      } else if (query.targetType !== undefined && query.targetId !== undefined) {
+        return { items: [], hasMore: false };
+      }
+
+      const rows = await database
+        .select()
+        .from(candidatePromotionDecisions)
+        .where(whereOrUndefined(conditions))
+        .orderBy(desc(candidatePromotionDecisions.promotedAt), desc(candidatePromotionDecisions.id))
+        .limit(sourceLimit + 1);
+      return {
+        items: rows.slice(0, sourceLimit).map(candidatePromotionAuditItem),
+        hasMore: rows.length > sourceLimit,
+      };
+    },
+  };
+}
+
+export function createDrizzleEvidenceAuditSource(
+  database: CryptoPayMapDatabase,
+): AuditHistorySource {
+  return {
+    domain: 'evidence',
+    async loadAuditHistorySource(query, sourceLimit) {
+      const conditions = commonConditions(
+        query,
+        evidenceReviewDecisions.decidedAt,
+        evidenceReviewDecisions.actorId,
+        'evidence_review_decision',
+        evidenceReviewDecisions.id,
+      );
+      if (query.targetType === 'evidence' && query.targetId !== undefined) {
+        conditions.push(eq(evidenceReviewDecisions.evidenceId, query.targetId));
+      } else if (query.targetType === 'acceptance_claim' && query.targetId !== undefined) {
+        conditions.push(eq(evidenceReviewDecisions.claimId, query.targetId));
+      } else if (query.targetType !== undefined && query.targetId !== undefined) {
+        return { items: [], hasMore: false };
+      }
+
+      const rows = await database
+        .select()
+        .from(evidenceReviewDecisions)
+        .where(whereOrUndefined(conditions))
+        .orderBy(desc(evidenceReviewDecisions.decidedAt), desc(evidenceReviewDecisions.id))
+        .limit(sourceLimit + 1);
+      return {
+        items: rows.slice(0, sourceLimit).map(evidenceReviewDecisionAuditItem),
+        hasMore: rows.length > sourceLimit,
+      };
+    },
+  };
+}
+
+export function createDrizzleReconfirmationAuditSource(
+  database: CryptoPayMapDatabase,
+): AuditHistorySource {
+  return {
+    domain: 'reconfirmation',
+    async loadAuditHistorySource(query, sourceLimit) {
+      const conditions = commonConditions(
+        query,
+        reconfirmationExpirations.effectiveAt,
+        reconfirmationExpirations.actorId,
+        'reconfirmation_expiration',
+        reconfirmationExpirations.id,
+      );
+      if (query.targetType === 'acceptance_claim' && query.targetId !== undefined) {
+        conditions.push(eq(reconfirmationExpirations.claimId, query.targetId));
+      } else if (query.targetType !== undefined && query.targetId !== undefined) {
+        return { items: [], hasMore: false };
+      }
+
+      const rows = await database
+        .select()
+        .from(reconfirmationExpirations)
+        .where(whereOrUndefined(conditions))
+        .orderBy(desc(reconfirmationExpirations.effectiveAt), desc(reconfirmationExpirations.id))
+        .limit(sourceLimit + 1);
+      return {
+        items: rows.slice(0, sourceLimit).map(reconfirmationExpirationAuditItem),
+        hasMore: rows.length > sourceLimit,
+      };
+    },
+  };
+}
+
+export function createDrizzleMediaAuditSource(database: CryptoPayMapDatabase): AuditHistorySource {
+  return {
+    domain: 'media',
+    async loadAuditHistorySource(query, sourceLimit) {
+      const conditions = commonConditions(
+        query,
+        mediaReviewDecisions.decidedAt,
+        mediaReviewDecisions.actorId,
+        'media_review_decision',
+        mediaReviewDecisions.id,
+      );
+      if (query.targetType === 'media_asset' && query.targetId !== undefined) {
+        conditions.push(eq(mediaReviewDecisions.mediaAssetId, query.targetId));
+      } else if (query.targetType === 'acceptance_claim' && query.targetId !== undefined) {
+        conditions.push(
+          and(
+            eq(mediaReviewDecisions.expectedSubjectType, 'claim'),
+            eq(mediaReviewDecisions.expectedSubjectId, query.targetId),
+          ) as SQL,
+        );
+      } else if (query.targetType === 'evidence' && query.targetId !== undefined) {
+        conditions.push(
+          and(
+            eq(mediaReviewDecisions.expectedSubjectType, 'evidence'),
+            eq(mediaReviewDecisions.expectedSubjectId, query.targetId),
+          ) as SQL,
+        );
+      } else if (query.targetType !== undefined && query.targetId !== undefined) {
+        return { items: [], hasMore: false };
+      }
+
+      const rows = await database
+        .select()
+        .from(mediaReviewDecisions)
+        .where(whereOrUndefined(conditions))
+        .orderBy(desc(mediaReviewDecisions.decidedAt), desc(mediaReviewDecisions.id))
+        .limit(sourceLimit + 1);
+      return {
+        items: rows.slice(0, sourceLimit).map(mediaReviewDecisionAuditItem),
+        hasMore: rows.length > sourceLimit,
+      };
+    },
+  };
+}
+
+export function createDrizzleExportReleaseAuditSource(
+  database: CryptoPayMapDatabase,
+): AuditHistorySource {
+  return {
+    domain: 'export',
+    async loadAuditHistorySource(query, sourceLimit) {
+      const conditions = commonConditions(
+        query,
+        exportReleaseDecisions.decidedAt,
+        exportReleaseDecisions.actorId,
+        'export_release_decision',
+        exportReleaseDecisions.id,
+      );
+      if (query.targetType === 'export_snapshot' && query.targetId !== undefined) {
+        conditions.push(eq(exportReleaseDecisions.snapshotDigest, query.targetId));
+      } else if (query.targetType !== undefined && query.targetId !== undefined) {
+        return { items: [], hasMore: false };
+      }
+
+      const rows = await database
+        .select()
+        .from(exportReleaseDecisions)
+        .where(whereOrUndefined(conditions))
+        .orderBy(desc(exportReleaseDecisions.decidedAt), desc(exportReleaseDecisions.id))
+        .limit(sourceLimit + 1);
+      return {
+        items: rows.slice(0, sourceLimit).map(exportReleaseDecisionAuditItem),
+        hasMore: rows.length > sourceLimit,
+      };
+    },
+  };
+}
+
+export function createDrizzleExportActivationAuditSource(
+  database: CryptoPayMapDatabase,
+): AuditHistorySource {
+  return {
+    domain: 'export',
+    async loadAuditHistorySource(query, sourceLimit) {
+      const conditions = commonConditions(
+        query,
+        exportActivationRecords.publishedAt,
+        exportActivationRecords.actorId,
+        'export_activation',
+        exportActivationRecords.id,
+      );
+      if (query.targetType === 'export_snapshot' && query.targetId !== undefined) {
+        conditions.push(
+          or(
+            eq(exportActivationRecords.snapshotDigest, query.targetId),
+            eq(exportActivationRecords.previousSnapshotDigest, query.targetId),
+          ) as SQL,
+        );
+      } else if (query.targetType !== undefined && query.targetId !== undefined) {
+        return { items: [], hasMore: false };
+      }
+
+      const rows = await database
+        .select()
+        .from(exportActivationRecords)
+        .where(whereOrUndefined(conditions))
+        .orderBy(desc(exportActivationRecords.publishedAt), desc(exportActivationRecords.id))
+        .limit(sourceLimit + 1);
+      return {
+        items: rows.slice(0, sourceLimit).map(exportActivationAuditItem),
+        hasMore: rows.length > sourceLimit,
+      };
+    },
+  };
+}
+
+export function createDrizzleAuditHistorySources(
+  database: CryptoPayMapDatabase,
+): AuditHistorySource[] {
+  return [
+    createDrizzleCandidateDuplicateAuditSource(database),
+    createDrizzleCandidatePromotionAuditSource(database),
+    createDrizzleEvidenceAuditSource(database),
+    createDrizzleReconfirmationAuditSource(database),
+    createDrizzleMediaAuditSource(database),
+    createDrizzleExportReleaseAuditSource(database),
+    createDrizzleExportActivationAuditSource(database),
+  ];
+}

--- a/tests/audit-history-drizzle-sources.test.ts
+++ b/tests/audit-history-drizzle-sources.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDrizzleAuditHistorySources,
+  createDrizzleEvidenceAuditSource,
+} from '../src/admin/audit-history/drizzle-sources';
+import type { CryptoPayMapDatabase } from '../src/db/client';
+
+function evidenceRow(id: string, decidedAt: string) {
+  return {
+    id,
+    requestId: id,
+    evidenceId: '30000000-0000-4000-8000-000000000003',
+    claimId: '30000000-0000-4000-8000-000000000004',
+    disposition: 'accepted' as const,
+    finding: 'supports_claim' as const,
+    claimAction: 'confirm' as const,
+    actorId: 'reviewer:evidence',
+    actorType: 'human' as const,
+    reasonCode: 'evidence_supported_claim',
+    publicSummary: 'Claim confirmed from accepted Evidence.',
+    internalNote: null,
+    expectedEvidenceUpdatedAt: new Date('2026-07-04T08:00:00.000Z'),
+    expectedClaimUpdatedAt: new Date('2026-07-04T08:00:00.000Z'),
+    fromClaimStatus: 'candidate' as const,
+    toClaimStatus: 'confirmed' as const,
+    requestFingerprint: 'fingerprint',
+    decidedAt: new Date(decidedAt),
+    createdAt: new Date(decidedAt),
+  };
+}
+
+function fakeDatabase(rows: ReturnType<typeof evidenceRow>[]) {
+  const calls: string[] = [];
+  const database = {
+    select() {
+      calls.push('select');
+      return {
+        from() {
+          calls.push('from');
+          return {
+            where() {
+              calls.push('where');
+              return {
+                orderBy() {
+                  calls.push('orderBy');
+                  return {
+                    async limit(value: number) {
+                      calls.push(`limit:${value}`);
+                      return rows.slice(0, value);
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+  return { database: database as unknown as CryptoPayMapDatabase, calls };
+}
+
+describe('audit history Drizzle sources', () => {
+  it('loads one extra Evidence decision row and maps bounded source history', async () => {
+    const { database, calls } = fakeDatabase([
+      evidenceRow('10000000-0000-4000-8000-000000000001', '2026-07-04T10:00:00.000Z'),
+      evidenceRow('10000000-0000-4000-8000-000000000002', '2026-07-04T09:00:00.000Z'),
+    ]);
+
+    const result = await createDrizzleEvidenceAuditSource(database).loadAuditHistorySource(
+      { limit: 25 },
+      1,
+    );
+
+    expect(calls).toContain('limit:2');
+    expect(result.hasMore).toBe(true);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      domain: 'evidence',
+      sourceKind: 'evidence_review_decision',
+      action: 'confirm',
+      occurredAt: '2026-07-04T10:00:00.000Z',
+    });
+  });
+
+  it('registers the seven currently durable Phase 3 table sources', () => {
+    const { database } = fakeDatabase([]);
+    const sources = createDrizzleAuditHistorySources(database);
+
+    expect(sources).toHaveLength(7);
+    expect(sources.map((source) => source.domain)).toEqual([
+      'candidate',
+      'candidate',
+      'evidence',
+      'reconfirmation',
+      'media',
+      'export',
+      'export',
+    ]);
+  });
+});


### PR DESCRIPTION
## Implementation item

P3-12C within P3-12.

## Included

- Drizzle-backed audit sources over existing durable Phase 3 decision and event tables
- source-side actor, time-range, cursor, and target filter pushdown
- stable cursor compatibility with normalized audit item identities
- deterministic per-source ordering
- one-row lookahead for bounded pagination
- source registry for candidate, Evidence, reconfirmation, Media, export release, and export activation history
- explicit exclusion of restore execution from the Drizzle registry until a corresponding table exists
- runtime checks, unit tests, documentation, project status, and implementation plan updates

## Validation

CI required before merge.

## Explicit exclusions

- no restore execution table
- no protected audit history API route yet
- no Audit administration UI yet
- no live database verification
- no final Phase 3 integration sign-off

## Next

Validate and merge, then add the protected audit history API and administration surface.