### PR TITLE
P3-12E: Add Audit administration surface

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # CryptoPayMap implementation plan
 
 **Status:** Active  
-**Last updated:** 2026-07-04
+**Last updated:** 2026-07-05
 
 This file tracks repository implementation work. GitHub main, merged pull requests, and CI are authoritative when this file differs from repository reality.
 
@@ -86,7 +86,7 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 | P3-09 | Status transitions and reconfirmation queue | Completed | P3-07, P3-08 | #64–#67 |
 | P3-10 | Media review | Completed | P3-02, P2-10 | #69–#74 |
 | P3-11 | Export controls and release workflow | Repository completed; live verification deferred | P3-07 through P3-10 | #75–#87 |
-| P3-12 | Audit history and Phase 3 integration audit | In progress | P3-01 through P3-11 | #88, #89; P3-12C active |
+| P3-12 | Audit history and Phase 3 integration audit | In progress | P3-01 through P3-11 | #88, #89, #92, #93, #94 |
 
 ### Completed P3-07 deliveries
 
@@ -120,13 +120,16 @@ P3-12A defined the protected normalized audit-history read contract across candi
 
 P3-12B added metadata-only source normalizers, bounded concurrent aggregation, source-domain validation, duplicate identity rejection, defensive filtering, deterministic cross-source ordering, and fail-closed source handling in pull request #89.
 
+P3-12C connected bounded audit history sources to the existing durable Phase 3 tables in pull request #92. It pushes actor, time-range, target, and stable cursor filters into source queries, preserves source ordering compatible with the global cursor, and excludes restore execution from the Drizzle registry until a corresponding table exists.
+
+P3-12D added the protected audit history API, isolated audit read authorization, fail-closed environment handling, bounded response mapping, runtime checks, and API tests in pull request #93.
+
 ### Current P3-12 delivery
 
-P3-12C connects bounded audit history sources to the existing durable Phase 3 tables. It pushes actor, time-range, target, and stable cursor filters into source queries, preserves source ordering compatible with the global cursor, and excludes restore execution from the Drizzle registry until a corresponding table exists.
+P3-12E adds the protected `/admin/audit` administration surface, metadata-only history cards, domain, actor, target, and time filters, stable cursor loading, explicit loading and failure states, component tests, and built-artifact leakage checks in pull request #94.
 
 ### Remaining P3-12 deliveries
 
-- protected audit history API and administration surface
 - final cross-domain Phase 3 integration audit and Phase 4 handoff
 
 ## Phase 4 — Public core / MVP-A

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # CryptoPayMap project status
 
-**Last verified:** 2026-07-04
+**Last verified:** 2026-07-05
 
 ## Current phase
 
@@ -14,7 +14,7 @@ P3-12 — Audit history and Phase 3 integration audit
 
 - P3-12E — Audit administration surface
 - Branch: `work/audit-history-ui`
-- Pull request: pending
+- Pull request: #94
 
 ## Latest completed work
 
@@ -44,7 +44,7 @@ P3-12 — Audit history and Phase 3 integration audit
 
 ## Next
 
-1. Complete P3-12E validation and merge the pull request.
+1. Merge P3-12E after successful validation.
 2. Complete the final Phase 3 cross-domain integration audit.
 3. Hand off to Phase 4 public core work.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -12,8 +12,8 @@ P3-12 — Audit history and Phase 3 integration audit
 
 ## Active work
 
-- P3-12D — protected audit history API
-- Branch: `work/audit-history-api`
+- P3-12E — Audit administration surface
+- Branch: `work/audit-history-ui`
 - Pull request: pending
 
 ## Latest completed work
@@ -28,23 +28,25 @@ P3-12 — Audit history and Phase 3 integration audit
 - P3-12A normalized audit history read contract completed through pull request #88
 - P3-12B bounded audit history aggregation completed through pull request #89
 - P3-12C durable audit history source adapters completed through pull request #92
+- P3-12D protected audit history API completed through pull request #93
 - export restore replay preflight hardening completed through pull request #91
 
-## P3-12D in progress
+## P3-12E in progress
 
-- isolated audit history reader allowlist
-- `audit:read` context issuance from protected Access identity
-- fail-closed authorization configuration handling
-- database environment boundary
-- protected `GET /admin/api/audit-history` route
-- 200, 400, 403, and 503 response mapping
-- route runtime and API tests
+- `/admin/audit` protected administration page
+- read-only normalized audit history client view
+- domain, actor, target, and time-range filters
+- stable cursor load-more behavior
+- loading, denied, invalid-query, unavailable, and empty states
+- metadata-only event cards and state transitions
+- component tests
+- built artifact and private-marker checks
 
 ## Next
 
-1. Complete P3-12D validation and merge the pull request.
-2. Add the Audit administration surface.
-3. Complete the final Phase 3 cross-domain integration audit and hand off to Phase 4.
+1. Complete P3-12E validation and merge the pull request.
+2. Complete the final Phase 3 cross-domain integration audit.
+3. Hand off to Phase 4 public core work.
 
 ## Blocked
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "db:check": "npm run db:snapshot:materialize && drizzle-kit check",
     "db:migrate": "npm run db:snapshot:materialize && drizzle-kit migrate",
     "accessibility:check": "node scripts/check-accessibility-foundation.mjs",
-    "staging:check": "node scripts/check-staging-artifact.mjs && node scripts/check-candidate-promotion-artifact.mjs && node scripts/check-candidate-existing-target-artifact.mjs && node scripts/check-evidence-review-artifact.mjs && node scripts/check-media-review-artifact.mjs && node scripts/check-export-release-artifact.mjs",
+    "staging:check": "node scripts/check-staging-artifact.mjs && node scripts/check-candidate-promotion-artifact.mjs && node scripts/check-candidate-existing-target-artifact.mjs && node scripts/check-evidence-review-artifact.mjs && node scripts/check-media-review-artifact.mjs && node scripts/check-export-release-artifact.mjs && node scripts/check-audit-history-artifact.mjs",
     "pages:dev": "npm run build && npm run accessibility:check && npm run staging:check && wrangler pages dev",
     "pages:deploy:staging": "npm run build && npm run accessibility:check && npm run staging:check && wrangler pages deploy dist --project-name cryptopaymap-staging --branch staging",
     "quality": "npm run format:check && npm run lint && npm run check && npm run schema:check && npm run db:check && npm run test && npm run build && npm run accessibility:check && npm run staging:check"

--- a/scripts/check-audit-history-artifact.mjs
+++ b/scripts/check-audit-history-artifact.mjs
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const pagePath = 'admin/audit/index.html';
+const absolutePath = join('dist', pagePath);
+
+if (!existsSync(absolutePath)) {
+  throw new Error(`Missing Audit history artifact: ${pagePath}`);
+}
+
+const content = readFileSync(absolutePath, 'utf8');
+for (const fragment of [
+  'Audit history',
+  'Protected read boundary',
+  'History without private payload leakage',
+  'Cross-domain audit workspace',
+  'Read only · metadata only',
+]) {
+  if (!content.includes(fragment)) {
+    throw new Error(`Missing Audit history marker in ${pagePath}: ${fragment}`);
+  }
+}
+
+for (const forbidden of [
+  'CPM_ADMIN_AUDIT_READ_ACTOR_IDS',
+  'DATABASE_URL',
+  'requestFingerprint',
+  'internalNote',
+  'privateStorageKey',
+]) {
+  if (content.includes(forbidden)) {
+    throw new Error(`Private Audit history marker found in ${pagePath}: ${forbidden}`);
+  }
+}
+
+console.log('Audit history artifact checks passed.');

--- a/src/components/admin/AuditHistoryView.tsx
+++ b/src/components/admin/AuditHistoryView.tsx
@@ -1,0 +1,389 @@
+import { AlertTriangle, Clock3, RefreshCw, ScrollText, ShieldAlert } from 'lucide-react';
+import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from 'react';
+import {
+  auditHistoryDomainValues,
+  auditHistoryResponseSchema,
+  auditHistoryTargetTypeValues,
+  type AuditHistoryItem,
+} from '../../admin/audit-history/contract';
+import { Button } from '../ui/Button';
+
+type DomainFilter = '' | (typeof auditHistoryDomainValues)[number];
+type TargetTypeFilter = '' | (typeof auditHistoryTargetTypeValues)[number];
+
+interface Filters {
+  domain: DomainFilter;
+  actorId: string;
+  targetType: TargetTypeFilter;
+  targetId: string;
+  from: string;
+  to: string;
+}
+
+type ViewState =
+  | { status: 'loading' }
+  | {
+      status: 'ready';
+      items: AuditHistoryItem[];
+      hasMore: boolean;
+      generatedAt: string;
+    }
+  | { status: 'denied' | 'invalid_query' | 'unavailable' | 'error' };
+
+const emptyFilters: Filters = {
+  domain: '',
+  actorId: '',
+  targetType: '',
+  targetId: '',
+  from: '',
+  to: '',
+};
+
+function label(value: string): string {
+  return value
+    .split('_')
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function optionalIso(value: string): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function buildParams(
+  filters: Filters,
+  cursor?: { before: string; beforeId: string },
+): URLSearchParams {
+  const params = new URLSearchParams({ limit: '50' });
+  if (filters.domain) params.set('domain', filters.domain);
+  if (filters.actorId.trim()) params.set('actorId', filters.actorId.trim());
+  if (filters.targetType) params.set('targetType', filters.targetType);
+  if (filters.targetId.trim()) params.set('targetId', filters.targetId.trim());
+  const from = optionalIso(filters.from);
+  const to = optionalIso(filters.to);
+  if (from) params.set('from', from);
+  if (to) params.set('to', to);
+  if (cursor) {
+    params.set('before', cursor.before);
+    params.set('beforeId', cursor.beforeId);
+  }
+  return params;
+}
+
+function StatusPanel({
+  title,
+  description,
+  icon,
+  action,
+}: {
+  title: string;
+  description: string;
+  icon: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <section
+      className="rounded-card border border-border bg-surface p-6 shadow-sm"
+      aria-live="polite"
+    >
+      <div className="flex items-start gap-4">
+        <span
+          className="flex size-11 shrink-0 items-center justify-center rounded-control bg-canvas text-muted"
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+        <div>
+          <h2 className="m-0 text-xl font-semibold tracking-tight text-ink">{title}</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">{description}</p>
+          {action ? <div className="mt-5">{action}</div> : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AuditItemCard({ item }: { item: AuditHistoryItem }) {
+  return (
+    <article className="rounded-card border border-border bg-surface p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="m-0 text-xs font-semibold uppercase tracking-[0.08em] text-muted">
+            {label(item.domain)} · {label(item.sourceKind)}
+          </p>
+          <h3 className="mt-2 text-lg font-semibold text-ink">{label(item.action)}</h3>
+        </div>
+        <span className="rounded-pill border border-border bg-canvas px-3 py-1 text-xs font-semibold text-muted">
+          {item.actorType}
+        </span>
+      </div>
+
+      <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <dt className="font-semibold text-ink">Occurred</dt>
+          <dd className="mt-1 text-muted">{item.occurredAt}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-ink">Actor</dt>
+          <dd className="mt-1 break-all font-mono text-xs text-muted">{item.actorId}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-ink">Primary target</dt>
+          <dd className="mt-1 text-muted">
+            {label(item.target.type)} · <span className="break-all font-mono text-xs">{item.target.id}</span>
+          </dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-ink">Reason</dt>
+          <dd className="mt-1 text-muted">{item.reasonCode ? label(item.reasonCode) : 'Not recorded'}</dd>
+        </div>
+      </dl>
+
+      {item.transition ? (
+        <p className="mt-4 rounded-control bg-canvas px-3 py-2 text-sm text-muted">
+          State: {item.transition.fromState ?? 'none'} → {item.transition.toState ?? 'none'}
+        </p>
+      ) : null}
+
+      {item.summary ? <p className="mt-4 text-sm leading-6 text-muted">{item.summary}</p> : null}
+
+      {item.secondaryTargets.length > 0 ? (
+        <p className="mt-4 text-xs text-muted">
+          Secondary targets: {item.secondaryTargets.map((target) => `${label(target.type)} ${target.id}`).join(' · ')}
+        </p>
+      ) : null}
+    </article>
+  );
+}
+
+export function AuditHistoryView() {
+  const [draftFilters, setDraftFilters] = useState<Filters>(emptyFilters);
+  const [filters, setFilters] = useState<Filters>(emptyFilters);
+  const [state, setState] = useState<ViewState>({ status: 'loading' });
+  const [loadingOlder, setLoadingOlder] = useState(false);
+
+  const load = useCallback(
+    async (
+      activeFilters: Filters,
+      options: { append?: boolean; cursor?: { before: string; beforeId: string }; signal?: AbortSignal } = {},
+    ) => {
+      const append = options.append === true;
+      if (append) setLoadingOlder(true);
+      else setState({ status: 'loading' });
+
+      try {
+        const params = buildParams(activeFilters, options.cursor);
+        const response = await fetch(`/admin/api/audit-history?${params.toString()}`, {
+          cache: 'no-store',
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+          signal: options.signal ?? null,
+        });
+        if (response.status === 403) return setState({ status: 'denied' });
+        if (response.status === 400) return setState({ status: 'invalid_query' });
+        if (response.status === 503) return setState({ status: 'unavailable' });
+        if (!response.ok) return setState({ status: 'error' });
+
+        const parsed = auditHistoryResponseSchema.safeParse(await response.json());
+        if (!parsed.success) return setState({ status: 'error' });
+        setState((previous) => ({
+          status: 'ready',
+          items:
+            append && previous.status === 'ready'
+              ? [...previous.items, ...parsed.data.items]
+              : parsed.data.items,
+          hasMore: parsed.data.hasMore,
+          generatedAt: parsed.data.generatedAt,
+        }));
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        setState({ status: 'error' });
+      } finally {
+        if (append) setLoadingOlder(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(filters, { signal: controller.signal });
+    return () => controller.abort();
+  }, [filters, load]);
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFilters({ ...draftFilters });
+  }
+
+  function reset() {
+    setDraftFilters(emptyFilters);
+    setFilters(emptyFilters);
+  }
+
+  function loadOlder() {
+    if (state.status !== 'ready' || state.items.length === 0 || loadingOlder) return;
+    const last = state.items[state.items.length - 1];
+    if (!last) return;
+    void load(filters, {
+      append: true,
+      cursor: { before: last.occurredAt, beforeId: last.id },
+    });
+  }
+
+  return (
+    <div>
+      <form className="rounded-card border border-border bg-surface p-5 shadow-sm" onSubmit={submit}>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <label className="grid gap-2 text-sm font-semibold text-ink">
+            Domain
+            <select
+              className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
+              value={draftFilters.domain}
+              onChange={(event) =>
+                setDraftFilters((current) => ({ ...current, domain: event.target.value as DomainFilter }))
+              }
+            >
+              <option value="">All domains</option>
+              {auditHistoryDomainValues.map((domain) => (
+                <option key={domain} value={domain}>{label(domain)}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="grid gap-2 text-sm font-semibold text-ink">
+            Actor ID
+            <input
+              className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
+              value={draftFilters.actorId}
+              onChange={(event) => setDraftFilters((current) => ({ ...current, actorId: event.target.value }))}
+              placeholder="cloudflare-access:…"
+            />
+          </label>
+
+          <label className="grid gap-2 text-sm font-semibold text-ink">
+            Target type
+            <select
+              className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
+              value={draftFilters.targetType}
+              onChange={(event) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  targetType: event.target.value as TargetTypeFilter,
+                }))
+              }
+            >
+              <option value="">Any target type</option>
+              {auditHistoryTargetTypeValues.map((targetType) => (
+                <option key={targetType} value={targetType}>{label(targetType)}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="grid gap-2 text-sm font-semibold text-ink">
+            Target ID
+            <input
+              className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
+              value={draftFilters.targetId}
+              onChange={(event) => setDraftFilters((current) => ({ ...current, targetId: event.target.value }))}
+              placeholder="Exact target identifier"
+            />
+          </label>
+
+          <label className="grid gap-2 text-sm font-semibold text-ink">
+            From
+            <input
+              type="datetime-local"
+              className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
+              value={draftFilters.from}
+              onChange={(event) => setDraftFilters((current) => ({ ...current, from: event.target.value }))}
+            />
+          </label>
+
+          <label className="grid gap-2 text-sm font-semibold text-ink">
+            To
+            <input
+              type="datetime-local"
+              className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
+              value={draftFilters.to}
+              onChange={(event) => setDraftFilters((current) => ({ ...current, to: event.target.value }))}
+            />
+          </label>
+        </div>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Button type="submit">Apply filters</Button>
+          <Button type="button" variant="secondary" onClick={reset}>Reset</Button>
+        </div>
+      </form>
+
+      <div className="mt-6" aria-live="polite">
+        {state.status === 'loading' ? (
+          <StatusPanel
+            title="Loading audit history"
+            description="The protected service is loading normalized metadata from durable Phase 3 sources."
+            icon={<RefreshCw className="size-5 animate-spin motion-reduce:animate-none" />}
+          />
+        ) : null}
+        {state.status === 'denied' ? (
+          <StatusPanel
+            title="Audit history access denied"
+            description="This verified identity does not have the isolated audit read capability."
+            icon={<ShieldAlert className="size-5" />}
+          />
+        ) : null}
+        {state.status === 'invalid_query' ? (
+          <StatusPanel
+            title="Audit history filter rejected"
+            description="Check the time range, target filter, and bounded cursor inputs before retrying."
+            icon={<AlertTriangle className="size-5" />}
+            action={<Button variant="secondary" onClick={reset}>Reset filters</Button>}
+          />
+        ) : null}
+        {state.status === 'unavailable' || state.status === 'error' ? (
+          <StatusPanel
+            title="Audit history unavailable"
+            description="The protected service could not return a complete verified history response."
+            icon={<AlertTriangle className="size-5" />}
+            action={<Button variant="secondary" onClick={() => void load(filters)}>Retry history</Button>}
+          />
+        ) : null}
+        {state.status === 'ready' ? (
+          <section aria-labelledby="audit-history-results-title">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <p className="m-0 text-sm font-semibold text-brand-700">Normalized durable history</p>
+                <h2 id="audit-history-results-title" className="mt-1 text-2xl font-semibold text-ink">Audit events</h2>
+              </div>
+              <span className="rounded-pill border border-border bg-surface px-3 py-1 text-xs font-medium text-muted">
+                {state.items.length} loaded{state.hasMore ? ' · more available' : ''}
+              </span>
+            </div>
+
+            {state.items.length === 0 ? (
+              <StatusPanel
+                title="No audit events match this filter"
+                description="The UI does not fabricate missing events. Adjust the bounded filters to inspect another history slice."
+                icon={<ScrollText className="size-5" />}
+              />
+            ) : (
+              <div className="mt-4 grid gap-4">
+                {state.items.map((item) => <AuditItemCard key={item.id} item={item} />)}
+              </div>
+            )}
+
+            <div className="mt-5 flex flex-wrap items-center justify-between gap-3 text-xs text-muted">
+              <span className="inline-flex items-center gap-2"><Clock3 className="size-4" aria-hidden="true" /> Generated {state.generatedAt}</span>
+              {state.hasMore ? (
+                <Button variant="secondary" onClick={loadOlder} disabled={loadingOlder}>
+                  {loadingOlder ? 'Loading older events…' : 'Load older events'}
+                </Button>
+              ) : null}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AuditHistoryView.tsx
+++ b/src/components/admin/AuditHistoryView.tsx
@@ -132,12 +132,15 @@ function AuditItemCard({ item }: { item: AuditHistoryItem }) {
         <div>
           <dt className="font-semibold text-ink">Primary target</dt>
           <dd className="mt-1 text-muted">
-            {label(item.target.type)} · <span className="break-all font-mono text-xs">{item.target.id}</span>
+            {label(item.target.type)} ·{' '}
+            <span className="break-all font-mono text-xs">{item.target.id}</span>
           </dd>
         </div>
         <div>
           <dt className="font-semibold text-ink">Reason</dt>
-          <dd className="mt-1 text-muted">{item.reasonCode ? label(item.reasonCode) : 'Not recorded'}</dd>
+          <dd className="mt-1 text-muted">
+            {item.reasonCode ? label(item.reasonCode) : 'Not recorded'}
+          </dd>
         </div>
       </dl>
 
@@ -151,7 +154,8 @@ function AuditItemCard({ item }: { item: AuditHistoryItem }) {
 
       {item.secondaryTargets.length > 0 ? (
         <p className="mt-4 text-xs text-muted">
-          Secondary targets: {item.secondaryTargets.map((target) => `${label(target.type)} ${target.id}`).join(' · ')}
+          Secondary targets:{' '}
+          {item.secondaryTargets.map((target) => `${label(target.type)} ${target.id}`).join(' · ')}
         </p>
       ) : null}
     </article>
@@ -167,7 +171,11 @@ export function AuditHistoryView() {
   const load = useCallback(
     async (
       activeFilters: Filters,
-      options: { append?: boolean; cursor?: { before: string; beforeId: string }; signal?: AbortSignal } = {},
+      options: {
+        append?: boolean;
+        cursor?: { before: string; beforeId: string };
+        signal?: AbortSignal;
+      } = {},
     ) => {
       const append = options.append === true;
       if (append) setLoadingOlder(true);
@@ -235,7 +243,10 @@ export function AuditHistoryView() {
 
   return (
     <div>
-      <form className="rounded-card border border-border bg-surface p-5 shadow-sm" onSubmit={submit}>
+      <form
+        className="rounded-card border border-border bg-surface p-5 shadow-sm"
+        onSubmit={submit}
+      >
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           <label className="grid gap-2 text-sm font-semibold text-ink">
             Domain
@@ -243,12 +254,17 @@ export function AuditHistoryView() {
               className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
               value={draftFilters.domain}
               onChange={(event) =>
-                setDraftFilters((current) => ({ ...current, domain: event.target.value as DomainFilter }))
+                setDraftFilters((current) => ({
+                  ...current,
+                  domain: event.target.value as DomainFilter,
+                }))
               }
             >
               <option value="">All domains</option>
               {auditHistoryDomainValues.map((domain) => (
-                <option key={domain} value={domain}>{label(domain)}</option>
+                <option key={domain} value={domain}>
+                  {label(domain)}
+                </option>
               ))}
             </select>
           </label>
@@ -258,7 +274,9 @@ export function AuditHistoryView() {
             <input
               className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
               value={draftFilters.actorId}
-              onChange={(event) => setDraftFilters((current) => ({ ...current, actorId: event.target.value }))}
+              onChange={(event) =>
+                setDraftFilters((current) => ({ ...current, actorId: event.target.value }))
+              }
               placeholder="cloudflare-access:…"
             />
           </label>
@@ -277,7 +295,9 @@ export function AuditHistoryView() {
             >
               <option value="">Any target type</option>
               {auditHistoryTargetTypeValues.map((targetType) => (
-                <option key={targetType} value={targetType}>{label(targetType)}</option>
+                <option key={targetType} value={targetType}>
+                  {label(targetType)}
+                </option>
               ))}
             </select>
           </label>
@@ -287,7 +307,9 @@ export function AuditHistoryView() {
             <input
               className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
               value={draftFilters.targetId}
-              onChange={(event) => setDraftFilters((current) => ({ ...current, targetId: event.target.value }))}
+              onChange={(event) =>
+                setDraftFilters((current) => ({ ...current, targetId: event.target.value }))
+              }
               placeholder="Exact target identifier"
             />
           </label>
@@ -298,7 +320,9 @@ export function AuditHistoryView() {
               type="datetime-local"
               className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
               value={draftFilters.from}
-              onChange={(event) => setDraftFilters((current) => ({ ...current, from: event.target.value }))}
+              onChange={(event) =>
+                setDraftFilters((current) => ({ ...current, from: event.target.value }))
+              }
             />
           </label>
 
@@ -308,13 +332,17 @@ export function AuditHistoryView() {
               type="datetime-local"
               className="min-h-11 rounded-control border border-border bg-white px-3 py-2 font-normal"
               value={draftFilters.to}
-              onChange={(event) => setDraftFilters((current) => ({ ...current, to: event.target.value }))}
+              onChange={(event) =>
+                setDraftFilters((current) => ({ ...current, to: event.target.value }))
+              }
             />
           </label>
         </div>
         <div className="mt-5 flex flex-wrap gap-3">
           <Button type="submit">Apply filters</Button>
-          <Button type="button" variant="secondary" onClick={reset}>Reset</Button>
+          <Button type="button" variant="secondary" onClick={reset}>
+            Reset
+          </Button>
         </div>
       </form>
 
@@ -338,7 +366,11 @@ export function AuditHistoryView() {
             title="Audit history filter rejected"
             description="Check the time range, target filter, and bounded cursor inputs before retrying."
             icon={<AlertTriangle className="size-5" />}
-            action={<Button variant="secondary" onClick={reset}>Reset filters</Button>}
+            action={
+              <Button variant="secondary" onClick={reset}>
+                Reset filters
+              </Button>
+            }
           />
         ) : null}
         {state.status === 'unavailable' || state.status === 'error' ? (
@@ -346,15 +378,26 @@ export function AuditHistoryView() {
             title="Audit history unavailable"
             description="The protected service could not return a complete verified history response."
             icon={<AlertTriangle className="size-5" />}
-            action={<Button variant="secondary" onClick={() => void load(filters)}>Retry history</Button>}
+            action={
+              <Button variant="secondary" onClick={() => void load(filters)}>
+                Retry history
+              </Button>
+            }
           />
         ) : null}
         {state.status === 'ready' ? (
           <section aria-labelledby="audit-history-results-title">
             <div className="flex flex-wrap items-end justify-between gap-3">
               <div>
-                <p className="m-0 text-sm font-semibold text-brand-700">Normalized durable history</p>
-                <h2 id="audit-history-results-title" className="mt-1 text-2xl font-semibold text-ink">Audit events</h2>
+                <p className="m-0 text-sm font-semibold text-brand-700">
+                  Normalized durable history
+                </p>
+                <h2
+                  id="audit-history-results-title"
+                  className="mt-1 text-2xl font-semibold text-ink"
+                >
+                  Audit events
+                </h2>
               </div>
               <span className="rounded-pill border border-border bg-surface px-3 py-1 text-xs font-medium text-muted">
                 {state.items.length} loaded{state.hasMore ? ' · more available' : ''}
@@ -369,12 +412,16 @@ export function AuditHistoryView() {
               />
             ) : (
               <div className="mt-4 grid gap-4">
-                {state.items.map((item) => <AuditItemCard key={item.id} item={item} />)}
+                {state.items.map((item) => (
+                  <AuditItemCard key={item.id} item={item} />
+                ))}
               </div>
             )}
 
             <div className="mt-5 flex flex-wrap items-center justify-between gap-3 text-xs text-muted">
-              <span className="inline-flex items-center gap-2"><Clock3 className="size-4" aria-hidden="true" /> Generated {state.generatedAt}</span>
+              <span className="inline-flex items-center gap-2">
+                <Clock3 className="size-4" aria-hidden="true" /> Generated {state.generatedAt}
+              </span>
               {state.hasMore ? (
                 <Button variant="secondary" onClick={loadOlder} disabled={loadingOlder}>
                   {loadingOlder ? 'Loading older events…' : 'Load older events'}

--- a/src/pages/admin/audit.astro
+++ b/src/pages/admin/audit.astro
@@ -1,0 +1,35 @@
+---
+import { AuditHistoryView } from '../../components/admin/AuditHistoryView';
+import AdminLayout from '../../layouts/AdminLayout.astro';
+---
+
+<AdminLayout
+  title="Audit history | CryptoPayMap Admin"
+  heading="Audit history"
+  description="Inspect normalized metadata-only administrative history across candidate, Evidence, reconfirmation, Media, and export workflows."
+>
+  <section class="rounded-card border border-brand-600 bg-brand-50 p-5 sm:p-6" aria-labelledby="audit-boundary-title">
+    <p class="m-0 text-sm font-semibold text-brand-800">Protected read boundary</p>
+    <h2 id="audit-boundary-title" class="mt-1 text-xl font-semibold tracking-tight text-ink">
+      History without private payload leakage
+    </h2>
+    <p class="mt-3 max-w-3xl text-sm leading-6 text-muted">
+      This workspace reads normalized event metadata from authoritative Phase 3 decision and event tables. Internal notes, private Evidence bodies, private Media storage keys, administrator email addresses, and arbitrary source payloads are not part of the audit response.
+    </p>
+  </section>
+
+  <section class="mt-8" aria-labelledby="audit-workspace-title">
+    <div class="mb-5 flex flex-wrap items-end justify-between gap-3">
+      <div>
+        <p class="m-0 text-sm font-semibold text-brand-700">P3-12E</p>
+        <h2 id="audit-workspace-title" class="mt-1 text-2xl font-semibold tracking-tight text-ink">
+          Cross-domain audit workspace
+        </h2>
+      </div>
+      <span class="rounded-pill border border-border bg-surface px-3 py-1 text-xs font-medium text-muted">
+        Read only · metadata only
+      </span>
+    </div>
+    <AuditHistoryView client:load />
+  </section>
+</AdminLayout>

--- a/tests/audit-history-view.test.tsx
+++ b/tests/audit-history-view.test.tsx
@@ -1,0 +1,106 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AuditHistoryView } from '../src/components/admin/AuditHistoryView';
+
+const firstItem = {
+  id: 'export_activation:20000000-0000-4000-8000-000000000001',
+  occurredAt: '2026-07-04T11:00:00.000Z',
+  domain: 'export' as const,
+  sourceKind: 'export_activation' as const,
+  action: 'activate_release',
+  actorId: 'cloudflare-access:publisher',
+  actorType: 'human' as const,
+  requestId: '10000000-0000-4000-8000-000000000001',
+  target: { type: 'export_snapshot' as const, id: 'a'.repeat(64) },
+  secondaryTargets: [],
+  reasonCode: 'activate_approved_release',
+  summary: null,
+  transition: null,
+  sourceRecordId: '20000000-0000-4000-8000-000000000001',
+};
+
+const secondItem = {
+  ...firstItem,
+  id: 'export_release_decision:20000000-0000-4000-8000-000000000002',
+  occurredAt: '2026-07-04T10:00:00.000Z',
+  sourceKind: 'export_release_decision' as const,
+  action: 'approve_release',
+  sourceRecordId: '20000000-0000-4000-8000-000000000002',
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function history(items: unknown[], hasMore = false) {
+  return {
+    generatedAt: '2026-07-04T12:00:00.000Z',
+    query: { limit: 50 },
+    items,
+    hasMore,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('AuditHistoryView', () => {
+  it('loads and renders normalized audit events', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(history([firstItem]))));
+
+    render(<AuditHistoryView />);
+
+    expect(await screen.findByText('Activate Release')).toBeInTheDocument();
+    expect(screen.getByText(/Cloudflare-access:publisher/i)).toBeInTheDocument();
+    expect(screen.getByText('1 loaded')).toBeInTheDocument();
+  });
+
+  it('applies bounded domain and actor filters', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(history([])));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<AuditHistoryView />);
+    await screen.findByText('No audit events match this filter');
+
+    fireEvent.change(screen.getByLabelText('Domain'), { target: { value: 'export' } });
+    fireEvent.change(screen.getByLabelText('Actor ID'), {
+      target: { value: 'cloudflare-access:publisher' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply filters' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const requestUrl = String(fetchMock.mock.calls[1]?.[0]);
+    expect(requestUrl).toContain('domain=export');
+    expect(requestUrl).toContain('actorId=cloudflare-access%3Apublisher');
+    expect(requestUrl).toContain('limit=50');
+  });
+
+  it('loads older events with the stable audit cursor', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(history([firstItem], true)))
+      .mockResolvedValueOnce(jsonResponse(history([secondItem], false)));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<AuditHistoryView />);
+
+    await screen.findByText('Activate Release');
+    fireEvent.click(screen.getByRole('button', { name: 'Load older events' }));
+
+    expect(await screen.findByText('Approve Release')).toBeInTheDocument();
+    const requestUrl = String(fetchMock.mock.calls[1]?.[0]);
+    expect(requestUrl).toContain(`before=${encodeURIComponent(firstItem.occurredAt)}`);
+    expect(requestUrl).toContain(`beforeId=${encodeURIComponent(firstItem.id)}`);
+  });
+
+  it('shows access denied without rendering history cards', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ error: 'audit_history_denied' }, 403)));
+    render(<AuditHistoryView />);
+
+    expect(await screen.findByText('Audit history access denied')).toBeInTheDocument();
+    expect(screen.queryByText('Audit events')).not.toBeInTheDocument();
+  });
+});

--- a/tests/audit-history-view.test.tsx
+++ b/tests/audit-history-view.test.tsx
@@ -51,7 +51,10 @@ afterEach(() => {
 
 describe('AuditHistoryView', () => {
   it('loads and renders normalized audit events', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(history([firstItem]))));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(history([firstItem]))),
+    );
 
     render(<AuditHistoryView />);
 
@@ -61,7 +64,11 @@ describe('AuditHistoryView', () => {
   });
 
   it('applies bounded domain and actor filters', async () => {
-    const fetchMock = vi.fn(async () => jsonResponse(history([])));
+    const requestUrls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      requestUrls.push(String(input));
+      return jsonResponse(history([]));
+    });
     vi.stubGlobal('fetch', fetchMock);
     render(<AuditHistoryView />);
     await screen.findByText('No audit events match this filter');
@@ -73,17 +80,22 @@ describe('AuditHistoryView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Apply filters' }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    const requestUrl = String(fetchMock.mock.calls[1]?.[0]);
+    const requestUrl = requestUrls[1] ?? '';
     expect(requestUrl).toContain('domain=export');
     expect(requestUrl).toContain('actorId=cloudflare-access%3Apublisher');
     expect(requestUrl).toContain('limit=50');
   });
 
   it('loads older events with the stable audit cursor', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse(history([firstItem], true)))
-      .mockResolvedValueOnce(jsonResponse(history([secondItem], false)));
+    const requestUrls: string[] = [];
+    let requestCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      requestUrls.push(String(input));
+      requestCount += 1;
+      return requestCount === 1
+        ? jsonResponse(history([firstItem], true))
+        : jsonResponse(history([secondItem], false));
+    });
     vi.stubGlobal('fetch', fetchMock);
     render(<AuditHistoryView />);
 
@@ -91,13 +103,16 @@ describe('AuditHistoryView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Load older events' }));
 
     expect(await screen.findByText('Approve Release')).toBeInTheDocument();
-    const requestUrl = String(fetchMock.mock.calls[1]?.[0]);
+    const requestUrl = requestUrls[1] ?? '';
     expect(requestUrl).toContain(`before=${encodeURIComponent(firstItem.occurredAt)}`);
     expect(requestUrl).toContain(`beforeId=${encodeURIComponent(firstItem.id)}`);
   });
 
   it('shows access denied without rendering history cards', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ error: 'audit_history_denied' }, 403)));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ error: 'audit_history_denied' }, 403)),
+    );
     render(<AuditHistoryView />);
 
     expect(await screen.findByText('Audit history access denied')).toBeInTheDocument();


### PR DESCRIPTION
## Scope

P3-12E Audit administration surface.

## Included

- `/admin/audit` page
- read-only Audit history view
- domain, actor, target, and time filters
- stable cursor loading for older events
- loading and failure states
- metadata-only event cards
- component tests
- built artifact validation
- project status update

## Validation

In progress through Foundation validation and Migration drift.