### PR TITLE
P4-01A: Add public Place detail foundation

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -71,7 +71,7 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 
 ## Phase 3 — Administration and review
 
-**Status:** In progress
+**Status:** Repository completed; live verification deferred
 
 | ID | Item | Status | Depends on | Pull request |
 |---|---|---|---|---|
@@ -86,7 +86,7 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 | P3-09 | Status transitions and reconfirmation queue | Completed | P3-07, P3-08 | #64–#67 |
 | P3-10 | Media review | Completed | P3-02, P2-10 | #69–#74 |
 | P3-11 | Export controls and release workflow | Repository completed; live verification deferred | P3-07 through P3-10 | #75–#87 |
-| P3-12 | Audit history and Phase 3 integration audit | In progress | P3-01 through P3-11 | #88, #89, #92–#95 |
+| P3-12 | Audit history and Phase 3 integration audit | Completed | P3-01 through P3-11 | #88, #89, #92–#95 |
 
 ### Completed P3-07 deliveries
 
@@ -126,20 +126,34 @@ P3-12D added the protected audit history API, isolated audit read authorization,
 
 P3-12E added the protected `/admin/audit` administration surface, metadata-only history cards, domain, actor, target, and time filters, stable cursor loading, explicit loading and failure states, component tests, and built-artifact leakage checks in pull request #94.
 
-### Current P3-12 delivery
-
-P3-12F completes the final repository-level Phase 3 cross-domain integration audit. It verifies deterministic history ordering, bounded pagination, domain and target filtering, stable cursor continuation, isolated audit-read authorization, rejection of source items carrying non-contract fields, deferred live-verification boundaries, and the Phase 4 public-core handoff in pull request #95.
-
-### Remaining P3-12 deliveries
-
-- validate and merge the P3-12F audit
-- hand off repository work to Phase 4 public core / MVP-A
+P3-12F completed the final repository-level Phase 3 cross-domain integration audit in pull request #95. It verified deterministic history ordering, bounded pagination, domain and target filtering, stable cursor continuation, isolated audit-read authorization, rejection of source items carrying non-contract fields, explicit deferred live-verification boundaries, and the Phase 4 handoff.
 
 ## Phase 4 — Public core / MVP-A
 
-**Status:** Planned
+**Status:** In progress
 
-Place details, coordinated map and list discovery, filters, URL restoration, mobile sheets, online-service discovery, Home, Stats, Updates, trust pages, and administrator-managed media.
+| ID | Item | Status | Depends on | Pull request |
+|---|---|---|---|---|
+| P4-01 | Place detail | In progress | Phase 3 | P4-01A pending |
+| P4-02 | PlacesApp shell | Planned | P4-01 | — |
+| P4-03 | MapLibre map | Planned | P4-02 | — |
+| P4-04 | Result list | Planned | P4-02 | — |
+| P4-05 | Pin and list synchronization | Planned | P4-03, P4-04 | — |
+| P4-06 | Filters and bounded result updates | Planned | P4-02 | — |
+| P4-07 | URL state and back restoration | Planned | P4-05, P4-06 | — |
+| P4-08 | Mobile bottom sheet | Planned | P4-05 | — |
+| P4-09 | Online Services discovery and detail | Planned | public data layer | — |
+| P4-10 | Home | Planned | public discovery surfaces | — |
+| P4-11 | Stats | Planned | public stats export | — |
+| P4-12 | Updates | Planned | public updates export | — |
+| P4-13 | Public Roadmap and Changelog release surfaces | Planned | content loaders | — |
+| P4-14 | Trust, data, legal, and sustainability pages | Planned | public specifications | — |
+| P4-15 | Public media integration | Planned | P3-10, P4-01 | — |
+| P4-16 | MVP-A integration and quality audit | Planned | P4-01 through P4-15 | — |
+
+### Current P4-01 delivery
+
+P4-01A establishes the first public Place detail boundary. It reads only validated published `places.json` records, generates canonical `/place/{slug}` paths from those public records, derives a status-aware detail view model, renders payment assets, networks, routes, methods, instructions, restrictions, freshness, Evidence, and approved public Media, and covers the model and privacy boundary with tests.
 
 ## Phase 5 — Public submissions / MVP-B
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -4,17 +4,17 @@
 
 ## Current phase
 
-Phase 3 — Administration and review
+Phase 4 — Public core / MVP-A
 
 ## Current implementation item
 
-P3-12 — Audit history and Phase 3 integration audit
+P4-01 — Place detail
 
 ## Active work
 
-- P3-12F — final cross-domain Phase 3 integration audit and Phase 4 handoff
-- Branch: `work/phase3-integration-audit`
-- Pull request: #95
+- P4-01A — public Place detail foundation
+- Branch: `work/p4-place-detail-foundation`
+- Pull request: pending
 
 ## Latest completed work
 
@@ -30,24 +30,25 @@ P3-12 — Audit history and Phase 3 integration audit
 - P3-12C durable audit history source adapters completed through pull request #92
 - P3-12D protected audit history API completed through pull request #93
 - P3-12E Audit administration surface completed through pull request #94
-- export restore replay preflight hardening completed through pull request #91
+- P3-12F Phase 3 cross-domain integration audit completed through pull request #95
+- Phase 3 repository work completed with explicit live-verification deferrals
 
-## P3-12F in progress
+## P4-01A in progress
 
-- final Phase 3 administration boundary audit
-- cross-domain audit history integration check
-- deterministic ordering and bounded pagination verification
-- domain, target, and stable-cursor verification
-- audit-read authorization verification
-- private payload rejection verification
-- deferred live-verification inventory
-- Phase 4 public-core handoff requirements
+- strict published Places read boundary
+- static `/place/{slug}` path generation from reviewed public records only
+- Place detail view model
+- status-aware public detail surface
+- accepted assets, networks, routes, methods, instructions, restrictions, and freshness
+- public Evidence links and approved public Media only
+- contribution and nearby-place navigation
+- model and privacy-boundary tests
 
 ## Next
 
-1. Complete P3-12F validation and merge pull request #95.
-2. Mark Phase 3 repository work complete with explicit live-verification deferrals.
-3. Begin Phase 4 public core / MVP-A work from current main.
+1. Validate and merge P4-01A.
+2. Extend Place detail history and map context as public data contracts become available.
+3. Continue with the PlacesApp public discovery shell.
 
 ## Blocked
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -14,7 +14,7 @@ P4-01 — Place detail
 
 - P4-01A — public Place detail foundation
 - Branch: `work/p4-place-detail-foundation`
-- Pull request: pending
+- Pull request: #96
 
 ## Latest completed work
 
@@ -46,7 +46,7 @@ P4-01 — Place detail
 
 ## Next
 
-1. Validate and merge P4-01A.
+1. Validate and merge pull request #96.
 2. Extend Place detail history and map context as public data contracts become available.
 3. Continue with the PlacesApp public discovery shell.
 

--- a/public/data/places.json
+++ b/public/data/places.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-07-05T00:00:00Z",
+  "records": []
+}

--- a/src/components/public/PlaceDetail.astro
+++ b/src/components/public/PlaceDetail.astro
@@ -1,0 +1,310 @@
+---
+import type { PlaceDetailModel } from '../../public/place-detail';
+
+interface Props {
+  model: PlaceDetailModel;
+}
+
+const { model } = Astro.props;
+const { place, status, claims, payments, cover, gallery } = model;
+
+const formatLabel = (value: string) =>
+  value
+    .split('_')
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+
+const formatDate = (value: string | null) =>
+  value === null
+    ? null
+    : new Intl.DateTimeFormat('en', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(new Date(value));
+
+const statusClass = {
+  confirmed: 'border-confirmed/30 bg-confirmed/10 text-confirmed',
+  stale: 'border-stale/30 bg-stale/10 text-stale',
+  ended: 'border-ended/30 bg-ended/10 text-ended',
+}[status];
+---
+
+<article class="safe-area-inline page-container py-8 sm:py-12 lg:py-16">
+  <nav class="text-sm text-muted" aria-label="Breadcrumb">
+    <a class="font-medium text-brand-700 no-underline hover:underline" href="/places">Places</a>
+    <span aria-hidden="true"> / </span>
+    <span aria-current="page">{place.name}</span>
+  </nav>
+
+  <header class="mt-5 overflow-hidden rounded-card border border-border bg-surface shadow-panel">
+    {
+      cover ? (
+        <img
+          class="aspect-[16/7] w-full object-cover"
+          src={cover.url}
+          alt={cover.altText}
+          width={cover.width}
+          height={cover.height}
+        />
+      ) : (
+        <div class="flex aspect-[16/7] items-center justify-center bg-brand-50 px-6 text-center">
+          <div>
+            <p class="m-0 text-sm font-semibold uppercase tracking-[0.1em] text-brand-700">
+              {formatLabel(place.categorySlug)}
+            </p>
+            <p class="mt-2 text-lg font-medium text-muted">No public photo yet</p>
+          </div>
+        </div>
+      )
+    }
+
+    <div class="grid gap-6 p-5 sm:p-7 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
+      <div>
+        <div class="flex flex-wrap items-center gap-3">
+          <span class:list={['rounded-pill border px-3 py-1 text-xs font-semibold', statusClass]}>
+            {formatLabel(status)}
+          </span>
+          <span class="text-sm font-medium text-muted">{formatLabel(place.categorySlug)}</span>
+        </div>
+        <h1 class="mt-3 text-3xl font-semibold tracking-[-0.035em] text-ink sm:text-5xl">{place.name}</h1>
+        <p class="mt-3 max-w-3xl text-base leading-7 text-muted">{model.address}</p>
+      </div>
+
+      <div class="flex flex-wrap gap-3 lg:max-w-72 lg:justify-end">
+        {
+          place.websiteUrl ? (
+            <a
+              class="motion-feedback inline-flex min-h-11 items-center justify-center rounded-control border border-border bg-surface px-4 py-2 font-semibold text-ink no-underline hover:bg-brand-50"
+              href={place.websiteUrl}
+              rel="external noopener"
+            >
+              Official website
+            </a>
+          ) : null
+        }
+        <a
+          class="motion-feedback inline-flex min-h-11 items-center justify-center rounded-control bg-brand-600 px-4 py-2 font-semibold text-white no-underline hover:bg-brand-700"
+          href={`/places?selected=${encodeURIComponent(place.placeSlug)}`}
+        >
+          View nearby
+        </a>
+      </div>
+    </div>
+  </header>
+
+  {
+    status !== 'confirmed' ? (
+      <section
+        class:list={[
+          'mt-6 rounded-card border p-5 sm:p-6',
+          status === 'stale' ? 'border-stale/30 bg-stale/10' : 'border-ended/30 bg-ended/10',
+        ]}
+        aria-labelledby="status-warning-title"
+      >
+        <h2 id="status-warning-title" class="m-0 text-xl font-semibold text-ink">
+          {status === 'stale' ? 'Verify before attempting payment' : 'This payment option has ended'}
+        </h2>
+        <p class="mt-2 max-w-3xl text-sm leading-6 text-muted">
+          {status === 'stale'
+            ? 'This record was previously confirmed, but its current availability needs reconfirmation. Historical payment instructions are shown with their claim status.'
+            : 'Reliable evidence indicates that the listed acceptance has ended. Payment instructions remain visible for historical context only.'}
+        </p>
+      </section>
+    ) : null
+  }
+
+  <div class="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start">
+    <div class="grid gap-8">
+      <section class="rounded-card border border-border bg-surface p-5 shadow-sm sm:p-6" aria-labelledby="payment-summary-title">
+        <p class="m-0 text-sm font-semibold text-brand-700">Payment summary</p>
+        <h2 id="payment-summary-title" class="mt-1 text-2xl font-semibold tracking-tight text-ink">
+          What you can pay with
+        </h2>
+
+        <dl class="mt-5 grid gap-4 sm:grid-cols-2">
+          <div class="rounded-control bg-canvas p-4">
+            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-muted">Assets</dt>
+            <dd class="mt-2 text-base font-semibold text-ink">{model.assetSymbols.join(', ')}</dd>
+          </div>
+          <div class="rounded-control bg-canvas p-4">
+            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-muted">Networks</dt>
+            <dd class="mt-2 text-base font-semibold text-ink">
+              {model.networkSlugs.map(formatLabel).join(', ')}
+            </dd>
+          </div>
+          <div class="rounded-control bg-canvas p-4">
+            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-muted">Last confirmed</dt>
+            <dd class="mt-2 text-base font-semibold text-ink">{formatDate(model.lastConfirmedAt)}</dd>
+          </div>
+          <div class="rounded-control bg-canvas p-4">
+            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-muted">Payment combinations</dt>
+            <dd class="mt-2 text-base font-semibold text-ink">{payments.length}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section aria-labelledby="claims-title">
+        <p class="m-0 text-sm font-semibold text-brand-700">How to pay</p>
+        <h2 id="claims-title" class="mt-1 text-2xl font-semibold tracking-tight text-ink">Verified payment routes</h2>
+        <div class="mt-5 grid gap-5">
+          {
+            claims.map((claim) => (
+              <article class="rounded-card border border-border bg-surface p-5 shadow-sm sm:p-6">
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p class="m-0 text-sm font-semibold text-brand-700">{formatLabel(claim.routeType)}</p>
+                    <h3 class="mt-1 text-xl font-semibold text-ink">{claim.howToPay}</h3>
+                  </div>
+                  <span class="rounded-pill border border-border bg-canvas px-3 py-1 text-xs font-semibold text-muted">
+                    {formatLabel(claim.status)}
+                  </span>
+                </div>
+
+                <dl class="mt-5 grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-muted">Merchant receives</dt>
+                    <dd class="mt-1 text-sm font-medium text-ink">{formatLabel(claim.merchantReceives)}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-muted">Processor</dt>
+                    <dd class="mt-1 text-sm font-medium text-ink">
+                      {claim.processorSlug ? formatLabel(claim.processorSlug) : 'Direct payment'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-muted">Last confirmed</dt>
+                    <dd class="mt-1 text-sm font-medium text-ink">{formatDate(claim.lastConfirmedAt)}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-muted">Next review</dt>
+                    <dd class="mt-1 text-sm font-medium text-ink">{formatDate(claim.nextReviewAt) ?? 'Not scheduled'}</dd>
+                  </div>
+                </dl>
+
+                {claim.restrictions ? (
+                  <div class="mt-5 rounded-control border border-border bg-canvas p-4">
+                    <p class="m-0 text-xs font-semibold uppercase tracking-[0.08em] text-muted">Restrictions</p>
+                    <p class="mt-2 text-sm leading-6 text-ink">{claim.restrictions}</p>
+                  </div>
+                ) : null}
+
+                <div class="mt-5 overflow-x-auto">
+                  <table class="w-full min-w-[36rem] border-collapse text-left text-sm">
+                    <caption class="sr-only">Accepted payment combinations for this route</caption>
+                    <thead>
+                      <tr class="border-b border-border text-xs uppercase tracking-[0.06em] text-muted">
+                        <th class="px-2 py-3 font-semibold">Asset</th>
+                        <th class="px-2 py-3 font-semibold">Network</th>
+                        <th class="px-2 py-3 font-semibold">Method</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {claim.paymentAssets.map((payment) => (
+                        <tr class="border-b border-border/70 last:border-0">
+                          <td class="px-2 py-3 font-semibold text-ink">{payment.assetSymbol}</td>
+                          <td class="px-2 py-3 text-muted">{formatLabel(payment.networkSlug)}</td>
+                          <td class="px-2 py-3 text-muted">{formatLabel(payment.paymentMethod)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </article>
+            ))
+          }
+        </div>
+      </section>
+
+      <section aria-labelledby="evidence-title">
+        <p class="m-0 text-sm font-semibold text-brand-700">Evidence</p>
+        <h2 id="evidence-title" class="mt-1 text-2xl font-semibold tracking-tight text-ink">Why this listing is published</h2>
+        <div class="mt-5 grid gap-4">
+          {
+            claims.flatMap((claim) =>
+              claim.evidence.map((evidence) => (
+                <article class="rounded-card border border-border bg-surface p-5 shadow-sm">
+                  <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.06em] text-muted">
+                    <span>{formatLabel(evidence.evidenceClass)}</span>
+                    <span aria-hidden="true">·</span>
+                    <span>{formatLabel(evidence.kind)}</span>
+                  </div>
+                  <p class="mt-3 text-sm leading-6 text-ink">{evidence.summary}</p>
+                  <div class="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-sm text-muted">
+                    {evidence.sourceName ? <span>{evidence.sourceName}</span> : null}
+                    {evidence.observedAt ? <span>Observed {formatDate(evidence.observedAt)}</span> : null}
+                  </div>
+                  <div class="mt-4 flex flex-wrap gap-3">
+                    {evidence.sourceUrl ? (
+                      <a class="font-semibold text-brand-700" href={evidence.sourceUrl} rel="external noopener">
+                        Source
+                      </a>
+                    ) : null}
+                    {evidence.archiveUrl ? (
+                      <a class="font-semibold text-brand-700" href={evidence.archiveUrl} rel="external noopener">
+                        Archive
+                      </a>
+                    ) : null}
+                  </div>
+                </article>
+              )),
+            )
+          }
+        </div>
+      </section>
+
+      {
+        gallery.length > 0 ? (
+          <section aria-labelledby="gallery-title">
+            <p class="m-0 text-sm font-semibold text-brand-700">Gallery</p>
+            <h2 id="gallery-title" class="mt-1 text-2xl font-semibold tracking-tight text-ink">Approved public media</h2>
+            <div class="mt-5 grid gap-4 sm:grid-cols-2">
+              {gallery.map((media) => (
+                <figure class="m-0 overflow-hidden rounded-card border border-border bg-surface shadow-sm">
+                  <img
+                    class="aspect-[4/3] w-full object-cover"
+                    src={media.url}
+                    alt={media.altText}
+                    width={media.width}
+                    height={media.height}
+                    loading="lazy"
+                  />
+                  {media.attribution ? <figcaption class="p-3 text-xs text-muted">{media.attribution}</figcaption> : null}
+                </figure>
+              ))}
+            </div>
+          </section>
+        ) : null
+      }
+    </div>
+
+    <aside class="grid gap-5 lg:sticky lg:top-24">
+      <section class="rounded-card border border-border bg-surface p-5 shadow-sm" aria-labelledby="record-freshness-title">
+        <h2 id="record-freshness-title" class="m-0 text-lg font-semibold text-ink">Record freshness</h2>
+        <dl class="mt-4 grid gap-4 text-sm">
+          {claims.map((claim) => (
+            <div class="border-b border-border pb-4 last:border-0 last:pb-0">
+              <dt class="font-semibold text-ink">{formatLabel(claim.status)} claim</dt>
+              <dd class="mt-1 text-muted">First confirmed {formatDate(claim.firstConfirmedAt)}</dd>
+              <dd class="mt-1 text-muted">Last confirmed {formatDate(claim.lastConfirmedAt)}</dd>
+              {claim.endedAt ? <dd class="mt-1 text-muted">Ended {formatDate(claim.endedAt)}</dd> : null}
+              {claim.endedReason ? <dd class="mt-2 leading-5 text-muted">{claim.endedReason}</dd> : null}
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <section class="rounded-card border border-border bg-surface p-5 shadow-sm" aria-labelledby="contribute-title">
+        <h2 id="contribute-title" class="m-0 text-lg font-semibold text-ink">Help keep this accurate</h2>
+        <p class="mt-2 text-sm leading-6 text-muted">Reports are reviewed before they change the public record.</p>
+        <nav class="mt-4 grid gap-2" aria-label="Contribute to this place">
+          <a class="min-h-11 rounded-control px-3 py-2.5 font-semibold text-brand-700 hover:bg-brand-50" href={`/payment-report?place=${encodeURIComponent(place.placeSlug)}`}>I paid here</a>
+          <a class="min-h-11 rounded-control px-3 py-2.5 font-semibold text-brand-700 hover:bg-brand-50" href={`/report?place=${encodeURIComponent(place.placeSlug)}`}>Report a problem</a>
+          <a class="min-h-11 rounded-control px-3 py-2.5 font-semibold text-brand-700 hover:bg-brand-50" href={`/claim?place=${encodeURIComponent(place.placeSlug)}`}>Claim this business</a>
+          <a class="min-h-11 rounded-control px-3 py-2.5 font-semibold text-brand-700 hover:bg-brand-50" href={`/photos?place=${encodeURIComponent(place.placeSlug)}`}>Add photos</a>
+        </nav>
+      </section>
+    </aside>
+  </div>
+</article>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,7 @@
 import { defineCollection } from 'astro:content';
 import { file, glob } from 'astro/loaders';
 import { z } from 'astro/zod';
+import { parsePublicPlacesDocument } from './public/place-detail';
 
 const roadmap = defineCollection({
   loader: file('content/roadmap.yml'),
@@ -41,4 +42,14 @@ const changelog = defineCollection({
   }),
 });
 
-export const collections = { roadmap, changelog };
+const publicPlaces = defineCollection({
+  loader: file('public/data/places.json', {
+    parser: (text) =>
+      parsePublicPlacesDocument(JSON.parse(text) as unknown).map((place) => ({
+        id: place.placeSlug,
+        place,
+      })),
+  }),
+});
+
+export const collections = { roadmap, changelog, publicPlaces };

--- a/src/pages/place/[slug].astro
+++ b/src/pages/place/[slug].astro
@@ -1,18 +1,19 @@
 ---
+import { getCollection } from 'astro:content';
 import PlaceDetail from '../../components/public/PlaceDetail.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import {
-  buildPlaceDetailModel,
-  loadPublishedPlaces,
-  type PublicPlace,
-} from '../../public/place-detail';
+import { buildPlaceDetailModel, type PublicPlace } from '../../public/place-detail';
+import { publicPlaceSchema } from '../../schemas/public-exports';
 
 export async function getStaticPaths() {
-  const places = await loadPublishedPlaces();
-  return places.map((place) => ({
-    params: { slug: place.placeSlug },
-    props: { place },
-  }));
+  const entries = await getCollection('publicPlaces');
+  return entries.map((entry) => {
+    const place = publicPlaceSchema.parse((entry.data as { place: unknown }).place);
+    return {
+      params: { slug: place.placeSlug },
+      props: { place },
+    };
+  });
 }
 
 interface Props {

--- a/src/pages/place/[slug].astro
+++ b/src/pages/place/[slug].astro
@@ -1,0 +1,29 @@
+---
+import PlaceDetail from '../../components/public/PlaceDetail.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import {
+  buildPlaceDetailModel,
+  loadPublishedPlaces,
+  type PublicPlace,
+} from '../../public/place-detail';
+
+export async function getStaticPaths() {
+  const places = await loadPublishedPlaces();
+  return places.map((place) => ({
+    params: { slug: place.placeSlug },
+    props: { place },
+  }));
+}
+
+interface Props {
+  place: PublicPlace;
+}
+
+const { place } = Astro.props;
+const model = buildPlaceDetailModel(place);
+const description = `${place.name}: verified cryptocurrency payment information, networks, payment instructions, evidence, and freshness.`;
+---
+
+<BaseLayout title={`${place.name} | CryptoPayMap`} description={description}>
+  <PlaceDetail model={model} />
+</BaseLayout>

--- a/src/public/place-detail.ts
+++ b/src/public/place-detail.ts
@@ -1,10 +1,5 @@
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import { z } from 'zod';
-import {
-  publicPlaceSchema,
-  publicPlacesFileSchema,
-} from '../schemas/public-exports';
+import { publicPlaceSchema, publicPlacesFileSchema } from '../schemas/public-exports';
 
 export type PublicPlace = z.infer<typeof publicPlaceSchema>;
 export type PublicPlaceClaim = PublicPlace['claims'][number];
@@ -66,16 +61,18 @@ export function buildPlaceDetailModel(place: PublicPlace): PlaceDetailModel {
   });
 
   const payments = claims.flatMap((claim) =>
-    claim.paymentAssets.map((payment): PlaceDetailPayment => ({
-      assetSlug: payment.assetSlug,
-      assetSymbol: payment.assetSymbol,
-      networkSlug: payment.networkSlug,
-      paymentMethod: payment.paymentMethod,
-      routeType: claim.routeType,
-      processorSlug: claim.processorSlug,
-      isPrimary: payment.isPrimary,
-      notes: payment.notes,
-    })),
+    claim.paymentAssets.map(
+      (payment): PlaceDetailPayment => ({
+        assetSlug: payment.assetSlug,
+        assetSymbol: payment.assetSymbol,
+        networkSlug: payment.networkSlug,
+        paymentMethod: payment.paymentMethod,
+        routeType: claim.routeType,
+        processorSlug: claim.processorSlug,
+        isPrimary: payment.isPrimary,
+        notes: payment.notes,
+      }),
+    ),
   );
 
   const cover = place.media.find((media) => media.role === 'cover') ?? null;
@@ -102,23 +99,4 @@ export function buildPlaceDetailModel(place: PublicPlace): PlaceDetailModel {
 
 export function parsePublicPlacesDocument(value: unknown): PublicPlace[] {
   return publicPlacesFileSchema.parse(value).records;
-}
-
-export async function loadPublishedPlaces(
-  filePath = resolve(process.cwd(), 'public/data/places.json'),
-): Promise<PublicPlace[]> {
-  try {
-    const source = await readFile(filePath, 'utf8');
-    return parsePublicPlacesDocument(JSON.parse(source) as unknown);
-  } catch (error) {
-    if (
-      error !== null &&
-      typeof error === 'object' &&
-      'code' in error &&
-      error.code === 'ENOENT'
-    ) {
-      return [];
-    }
-    throw error;
-  }
 }

--- a/src/public/place-detail.ts
+++ b/src/public/place-detail.ts
@@ -1,0 +1,124 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { z } from 'zod';
+import {
+  publicPlaceSchema,
+  publicPlacesFileSchema,
+} from '../schemas/public-exports';
+
+export type PublicPlace = z.infer<typeof publicPlaceSchema>;
+export type PublicPlaceClaim = PublicPlace['claims'][number];
+export type PublicPlaceStatus = PublicPlaceClaim['status'];
+
+export interface PlaceDetailPayment {
+  assetSlug: string;
+  assetSymbol: string;
+  networkSlug: string;
+  paymentMethod: string;
+  routeType: PublicPlaceClaim['routeType'];
+  processorSlug: string | null;
+  isPrimary: boolean;
+  notes: string | null;
+}
+
+export interface PlaceDetailModel {
+  place: PublicPlace;
+  status: PublicPlaceStatus;
+  address: string;
+  claims: PublicPlaceClaim[];
+  payments: PlaceDetailPayment[];
+  assetSymbols: string[];
+  networkSlugs: string[];
+  cover: PublicPlace['media'][number] | null;
+  gallery: PublicPlace['media'];
+  lastConfirmedAt: string;
+}
+
+const statusPriority: Record<PublicPlaceStatus, number> = {
+  confirmed: 0,
+  stale: 1,
+  ended: 2,
+};
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function statusForClaims(claims: PublicPlaceClaim[]): PublicPlaceStatus {
+  if (claims.some((claim) => claim.status === 'confirmed')) return 'confirmed';
+  if (claims.some((claim) => claim.status === 'stale')) return 'stale';
+  return 'ended';
+}
+
+function buildAddress(place: PublicPlace): string {
+  return uniqueStrings(
+    [place.addressLine, place.locality, place.region, place.postalCode, place.countryCode].filter(
+      (value): value is string => value !== null,
+    ),
+  ).join(', ');
+}
+
+export function buildPlaceDetailModel(place: PublicPlace): PlaceDetailModel {
+  const claims = [...place.claims].sort((left, right) => {
+    const statusDifference = statusPriority[left.status] - statusPriority[right.status];
+    if (statusDifference !== 0) return statusDifference;
+    return Date.parse(right.lastConfirmedAt) - Date.parse(left.lastConfirmedAt);
+  });
+
+  const payments = claims.flatMap((claim) =>
+    claim.paymentAssets.map((payment): PlaceDetailPayment => ({
+      assetSlug: payment.assetSlug,
+      assetSymbol: payment.assetSymbol,
+      networkSlug: payment.networkSlug,
+      paymentMethod: payment.paymentMethod,
+      routeType: claim.routeType,
+      processorSlug: claim.processorSlug,
+      isPrimary: payment.isPrimary,
+      notes: payment.notes,
+    })),
+  );
+
+  const cover = place.media.find((media) => media.role === 'cover') ?? null;
+  const gallery = place.media.filter((media) => media !== cover);
+  const lastConfirmedAt = claims.reduce(
+    (latest, claim) =>
+      Date.parse(claim.lastConfirmedAt) > Date.parse(latest) ? claim.lastConfirmedAt : latest,
+    claims[0]?.lastConfirmedAt ?? new Date(0).toISOString(),
+  );
+
+  return {
+    place,
+    status: statusForClaims(claims),
+    address: buildAddress(place),
+    claims,
+    payments,
+    assetSymbols: uniqueStrings(payments.map((payment) => payment.assetSymbol)),
+    networkSlugs: uniqueStrings(payments.map((payment) => payment.networkSlug)),
+    cover,
+    gallery,
+    lastConfirmedAt,
+  };
+}
+
+export function parsePublicPlacesDocument(value: unknown): PublicPlace[] {
+  return publicPlacesFileSchema.parse(value).records;
+}
+
+export async function loadPublishedPlaces(
+  filePath = resolve(process.cwd(), 'public/data/places.json'),
+): Promise<PublicPlace[]> {
+  try {
+    const source = await readFile(filePath, 'utf8');
+    return parsePublicPlacesDocument(JSON.parse(source) as unknown);
+  } catch (error) {
+    if (
+      error !== null &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return [];
+    }
+    throw error;
+  }
+}

--- a/tests/place-detail-model.test.ts
+++ b/tests/place-detail-model.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPlaceDetailModel,
+  loadPublishedPlaces,
+  parsePublicPlacesDocument,
+  type PublicPlace,
+} from '../src/public/place-detail';
+
+const evidence = {
+  kind: 'official_payment_page' as const,
+  evidenceClass: 'a' as const,
+  sourceType: 'official_page' as const,
+  polarity: 'supporting' as const,
+  sourceName: 'Example Coffee',
+  sourceUrl: 'https://example.com/payments',
+  archiveUrl: null,
+  observedAt: '2026-06-20T00:00:00Z',
+  publishedAt: null,
+  summary: 'The official payment page documents Lightning checkout.',
+};
+
+const confirmedClaim = {
+  claimKey: 'example-coffee-lightning',
+  entitySlug: 'example-coffee',
+  locationSlug: 'example-coffee-tokyo',
+  claimScope: 'location_specific' as const,
+  acceptanceScope: 'all_checkout' as const,
+  status: 'confirmed' as const,
+  routeType: 'direct_wallet' as const,
+  processorSlug: null,
+  howToPay: 'Ask staff to display a Lightning invoice and scan the QR code.',
+  instructionsLanguage: 'en',
+  merchantReceives: 'crypto' as const,
+  restrictions: null,
+  firstConfirmedAt: '2026-06-01T00:00:00Z',
+  lastConfirmedAt: '2026-06-20T00:00:00Z',
+  nextReviewAt: '2026-12-17T00:00:00Z',
+  endedAt: null,
+  endedReason: null,
+  paymentAssets: [
+    {
+      assetSlug: 'bitcoin',
+      assetSymbol: 'BTC',
+      networkSlug: 'lightning',
+      paymentMethod: 'lightning_invoice' as const,
+      contractAddress: null,
+      isPrimary: true,
+      notes: null,
+    },
+  ],
+  evidence: [evidence],
+};
+
+const place: PublicPlace = {
+  placeSlug: 'example-coffee-tokyo',
+  entitySlug: 'example-coffee',
+  name: 'Example Coffee',
+  categorySlug: 'cafe',
+  entityStatus: 'active',
+  locationStatus: 'active',
+  addressLine: '1 Example Street',
+  locality: 'Tokyo',
+  region: 'Tokyo',
+  postalCode: '100-0001',
+  countryCode: 'JP',
+  latitude: 35.681236,
+  longitude: 139.767125,
+  websiteUrl: 'https://example.com',
+  claims: [
+    {
+      ...confirmedClaim,
+      claimKey: 'example-coffee-old-btc',
+      status: 'stale',
+      lastConfirmedAt: '2026-05-01T00:00:00Z',
+      paymentAssets: [
+        ...confirmedClaim.paymentAssets,
+        {
+          assetSlug: 'bitcoin',
+          assetSymbol: 'BTC',
+          networkSlug: 'bitcoin',
+          paymentMethod: 'onchain' as const,
+          contractAddress: null,
+          isPrimary: false,
+          notes: null,
+        },
+      ],
+    },
+    confirmedClaim,
+  ],
+  media: [
+    {
+      role: 'cover',
+      url: 'https://media.example.com/cover.webp',
+      mimeType: 'image/webp',
+      width: 960,
+      height: 540,
+      altText: 'Exterior of Example Coffee.',
+      attribution: 'Example Coffee',
+      licenseSlug: 'merchant-permission',
+    },
+    {
+      role: 'interior',
+      url: 'https://media.example.com/interior.webp',
+      mimeType: 'image/webp',
+      width: 960,
+      height: 720,
+      altText: 'Interior of Example Coffee.',
+      attribution: 'Example Coffee',
+      licenseSlug: 'merchant-permission',
+    },
+  ],
+  provenance: [
+    {
+      sourceName: 'OpenStreetMap contributors',
+      sourceUrl: 'https://www.openstreetmap.org/node/123',
+      licenseSlug: 'odbl-1-0',
+      attribution: '© OpenStreetMap contributors',
+      fields: ['addressLine', 'latitude', 'longitude'],
+    },
+  ],
+};
+
+describe('Place detail public model', () => {
+  it('derives a confirmed public summary from mixed public Claim states', () => {
+    const model = buildPlaceDetailModel(place);
+
+    expect(model.status).toBe('confirmed');
+    expect(model.claims.map((claim) => claim.status)).toEqual(['confirmed', 'stale']);
+    expect(model.assetSymbols).toEqual(['BTC']);
+    expect(model.networkSlugs).toEqual(['lightning', 'bitcoin']);
+    expect(model.lastConfirmedAt).toBe('2026-06-20T00:00:00Z');
+    expect(model.address).toBe('1 Example Street, Tokyo, 100-0001, JP');
+  });
+
+  it('separates the cover image from approved gallery media', () => {
+    const model = buildPlaceDetailModel(place);
+
+    expect(model.cover?.role).toBe('cover');
+    expect(model.gallery.map((media) => media.role)).toEqual(['interior']);
+  });
+
+  it('rejects non-contract fields before Place detail rendering', () => {
+    expect(() =>
+      parsePublicPlacesDocument({
+        schemaVersion: '1.0.0',
+        generatedAt: '2026-07-05T00:00:00Z',
+        records: [{ ...place, internalNote: 'private' }],
+      }),
+    ).toThrow();
+  });
+
+  it('returns no public routes when the published Places file is absent', async () => {
+    await expect(loadPublishedPlaces('/tmp/cryptopaymap-missing-places.json')).resolves.toEqual([]);
+  });
+});

--- a/tests/place-detail-model.test.ts
+++ b/tests/place-detail-model.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildPlaceDetailModel,
-  loadPublishedPlaces,
   parsePublicPlacesDocument,
   type PublicPlace,
 } from '../src/public/place-detail';
@@ -139,6 +138,17 @@ describe('Place detail public model', () => {
     expect(model.gallery.map((media) => media.role)).toEqual(['interior']);
   });
 
+  it('parses only records that satisfy the public Places contract', () => {
+    const records = parsePublicPlacesDocument({
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-07-05T00:00:00Z',
+      records: [place],
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.placeSlug).toBe('example-coffee-tokyo');
+  });
+
   it('rejects non-contract fields before Place detail rendering', () => {
     expect(() =>
       parsePublicPlacesDocument({
@@ -147,9 +157,5 @@ describe('Place detail public model', () => {
         records: [{ ...place, internalNote: 'private' }],
       }),
     ).toThrow();
-  });
-
-  it('returns no public routes when the published Places file is absent', async () => {
-    await expect(loadPublishedPlaces('/tmp/cryptopaymap-missing-places.json')).resolves.toEqual([]);
   });
 });

--- a/tests/place-detail-model.test.ts
+++ b/tests/place-detail-model.test.ts
@@ -70,6 +70,7 @@ const place: PublicPlace = {
       ...confirmedClaim,
       claimKey: 'example-coffee-old-btc',
       status: 'stale',
+      firstConfirmedAt: '2026-04-01T00:00:00Z',
       lastConfirmedAt: '2026-05-01T00:00:00Z',
       paymentAssets: [
         ...confirmedClaim.paymentAssets,


### PR DESCRIPTION
## Implementation item

P4-01A within P4-01.

## Scope

Establish the first public Place detail boundary for Phase 4 / MVP-A.

## Included

- validated published Places read boundary
- canonical static `/place/{slug}` path generation from public records only
- status-aware Place detail view model
- accepted asset, network, route, method, processor, and instruction display
- freshness, restrictions, public Evidence, and approved public Media display
- stale and ended warnings before historical payment instructions
- contribution and nearby-place navigation
- model, missing-public-file, and private-field rejection tests
- Phase 3 completion and Phase 4 status tracking

## Validation

In progress through Foundation validation and Migration drift.