### PR TITLE
P4-03A: Add map source and camera contracts

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -14,7 +14,7 @@ P4-03 — MapLibre map
 
 - P4-03A — map source and camera contract foundation
 - Branch: `work/map-geojson-foundation`
-- Pull request: pending
+- Pull request: #98
 
 ## Latest completed work
 
@@ -46,7 +46,7 @@ P4-03 — MapLibre map
 
 ## Next
 
-1. Validate and merge P4-03A.
+1. Validate and merge pull request #98.
 2. Add the MapLibre renderer against the fixed source and camera contracts.
 3. Connect renderer move events to pending viewport and Search this area behavior.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,13 +8,13 @@ Phase 4 — Public core / MVP-A
 
 ## Current implementation item
 
-P4-02 — PlacesApp shell
+P4-03 — MapLibre map
 
 ## Active work
 
-- P4-02A — coordinated PlacesApp public shell
-- Branch: `work/places-app-shell`
-- Pull request: #97
+- P4-03A — map source and camera contract foundation
+- Branch: `work/map-geojson-foundation`
+- Pull request: pending
 
 ## Latest completed work
 
@@ -33,28 +33,26 @@ P4-02 — PlacesApp shell
 - P3-12F Phase 3 cross-domain integration audit completed through pull request #95
 - Phase 3 repository work completed with explicit live-verification deferrals
 - P4-01A public Place detail foundation completed through pull request #96
+- P4-02A coordinated PlacesApp public shell completed through pull request #97
 
-## P4-02A in progress
+## P4-03A in progress
 
-- validated public Place pins collection
-- coordinated map/list application shell
-- existing Discovery URL-state restoration and canonical serialization
-- existing isolated Zustand discovery store integration
-- public search and status filtering
-- selected Place coordination and detail navigation
-- mobile map/list mode control
-- empty state without Candidate substitution
-- discovery model and component tests
+- deterministic public Place pin to point-feature conversion
+- stable feature identity by public Place slug
+- selected Place marker property
+- map camera normalization aligned with public URL limits
+- camera change detection after normalization
+- unit coverage for source and camera contracts
 
 ## Next
 
-1. Validate and merge pull request #97.
-2. Add MapLibre rendering against the coordinated shell.
-3. Add the production result-list and pin/list synchronization layers.
+1. Validate and merge P4-03A.
+2. Add the MapLibre renderer against the fixed source and camera contracts.
+3. Connect renderer move events to pending viewport and Search this area behavior.
 
 ## Blocked
 
-No repository blocker. Live candidate generation, R2 activation, public serving, database migration, restore persistence deployment, and production verification remain deferred.
+No repository blocker. MapLibre renderer dependency is not yet present in the lockfile and will be added as a separate reviewed implementation step. Live candidate generation, R2 activation, public serving, database migration, restore persistence deployment, and production verification remain deferred.
 
 ## Verification rule
 

--- a/src/components/places/map-data.ts
+++ b/src/components/places/map-data.ts
@@ -1,0 +1,1 @@
+export const placeMapDataFoundation = true;

--- a/src/components/places/map-data.ts
+++ b/src/components/places/map-data.ts
@@ -1,1 +1,75 @@
-export const placeMapDataFoundation = true;
+import type { PublicPlacePin } from '../../public/places-discovery';
+import type { DiscoveryViewport } from '../../state/discovery-url';
+
+export interface PlaceMapFeatureCollection {
+  type: 'FeatureCollection';
+  features: Array<{
+    type: 'Feature';
+    id: string;
+    geometry: {
+      type: 'Point';
+      coordinates: [number, number];
+    };
+    properties: {
+      placeSlug: string;
+      name: string;
+      status: PublicPlacePin['status'];
+      selected: boolean;
+    };
+  }>;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function round(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+export function buildPlaceMapFeatureCollection(
+  pins: readonly PublicPlacePin[],
+  selectedPlace: string | null,
+): PlaceMapFeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: pins.map((pin) => ({
+      type: 'Feature',
+      id: pin.placeSlug,
+      geometry: {
+        type: 'Point',
+        coordinates: [pin.longitude, pin.latitude],
+      },
+      properties: {
+        placeSlug: pin.placeSlug,
+        name: pin.name,
+        status: pin.status,
+        selected: pin.placeSlug === selectedPlace,
+      },
+    })),
+  };
+}
+
+export function normalizeMapViewport(viewport: DiscoveryViewport): DiscoveryViewport {
+  return {
+    latitude: round(clamp(viewport.latitude, -90, 90), 5),
+    longitude: round(clamp(viewport.longitude, -180, 180), 5),
+    zoom: round(clamp(viewport.zoom, 1, 22), 2),
+  };
+}
+
+export function mapViewportChanged(
+  current: DiscoveryViewport | null,
+  next: DiscoveryViewport,
+): boolean {
+  if (current === null) return true;
+  const previous = normalizeMapViewport(current);
+  const candidate = normalizeMapViewport(next);
+
+  return (
+    previous.latitude !== candidate.latitude ||
+    previous.longitude !== candidate.longitude ||
+    previous.zoom !== candidate.zoom
+  );
+}

--- a/tests/map-data.test.ts
+++ b/tests/map-data.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('map data', () => {
+  it('starts the contract suite', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tests/map-data.test.ts
+++ b/tests/map-data.test.ts
@@ -59,13 +59,11 @@ describe('Places map data contract', () => {
   it('compares camera state after public normalization', () => {
     expect(
       mapViewportChanged(
-        { latitude: 35.6812361, longitude: 139.7671251, zoom: 12.345 },
-        { latitude: 35.6812362, longitude: 139.7671252, zoom: 12.3449 },
+        { latitude: 35.6812361, longitude: 139.7671251, zoom: 12.3441 },
+        { latitude: 35.6812362, longitude: 139.7671252, zoom: 12.3442 },
       ),
     ).toBe(false);
 
-    expect(mapViewportChanged(null, { latitude: 35.68, longitude: 139.77, zoom: 12 })).toBe(
-      true,
-    );
+    expect(mapViewportChanged(null, { latitude: 35.68, longitude: 139.77, zoom: 12 })).toBe(true);
   });
 });

--- a/tests/map-data.test.ts
+++ b/tests/map-data.test.ts
@@ -1,7 +1,71 @@
 import { describe, expect, it } from 'vitest';
+import {
+  buildPlaceMapFeatureCollection,
+  mapViewportChanged,
+  normalizeMapViewport,
+} from '../src/components/places/map-data';
+import type { PublicPlacePin } from '../src/public/places-discovery';
 
-describe('map data', () => {
-  it('starts the contract suite', () => {
-    expect(true).toBe(true);
+const pins: PublicPlacePin[] = [
+  {
+    placeSlug: 'example-coffee-tokyo',
+    name: 'Example Coffee',
+    categorySlug: 'cafe',
+    countryCode: 'JP',
+    locality: 'Tokyo',
+    latitude: 35.681236,
+    longitude: 139.767125,
+    status: 'confirmed',
+    assetSlugs: ['bitcoin'],
+    networkSlugs: ['lightning'],
+    routeTypes: ['direct_wallet'],
+    lastConfirmedAt: '2026-06-20T00:00:00Z',
+    thumbnail: null,
+  },
+  {
+    placeSlug: 'example-market-osaka',
+    name: 'Example Market',
+    categorySlug: 'grocery',
+    countryCode: 'JP',
+    locality: 'Osaka',
+    latitude: 34.6937,
+    longitude: 135.5023,
+    status: 'stale',
+    assetSlugs: ['usdc'],
+    networkSlugs: ['base'],
+    routeTypes: ['processor_checkout'],
+    lastConfirmedAt: '2026-01-15T00:00:00Z',
+    thumbnail: null,
+  },
+];
+
+describe('Places map data contract', () => {
+  it('builds deterministic point features from public Place pins', () => {
+    const source = buildPlaceMapFeatureCollection(pins, 'example-market-osaka');
+
+    expect(source.type).toBe('FeatureCollection');
+    expect(source.features).toHaveLength(2);
+    expect(source.features[0]?.geometry.coordinates).toEqual([139.767125, 35.681236]);
+    expect(source.features[1]?.properties.selected).toBe(true);
+    expect(source.features[0]?.properties.selected).toBe(false);
+  });
+
+  it('normalizes map camera state to the public URL boundary', () => {
+    expect(
+      normalizeMapViewport({ latitude: 91.1234567, longitude: -181.1234567, zoom: 25.555 }),
+    ).toEqual({ latitude: 90, longitude: -180, zoom: 22 });
+  });
+
+  it('compares camera state after public normalization', () => {
+    expect(
+      mapViewportChanged(
+        { latitude: 35.6812361, longitude: 139.7671251, zoom: 12.345 },
+        { latitude: 35.6812362, longitude: 139.7671252, zoom: 12.3449 },
+      ),
+    ).toBe(false);
+
+    expect(mapViewportChanged(null, { latitude: 35.68, longitude: 139.77, zoom: 12 })).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
## Implementation item

P4-03A within P4-03.

## Scope

Fix the public map-data and camera-state contracts before the MapLibre renderer is added.

## Included

- deterministic public Place pin to point-feature collection conversion
- stable feature identity by public Place slug
- selected Place marker property
- map camera normalization aligned with public URL limits
- normalized camera change detection
- unit tests for map source and camera behavior
- Phase 4 status tracking update

## Non-goals

- MapLibre renderer dependency or map style loading
- viewport event wiring
- clustering
- production map controls

## Validation

In progress through Foundation validation and Migration drift.