### PR TITLE
P4-04A: Add production Place result list

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,13 +8,13 @@ Phase 4 — Public core / MVP-A
 
 ## Current implementation item
 
-P4-03 — MapLibre map
+P4-04 — Result list
 
 ## Active work
 
-- P4-03B — MapLibre renderer and PlacesApp integration
-- Branch: `work/maplibre-renderer-final`
-- Pull request: #100
+- P4-04A — production Place result list
+- Branch: `work/place-result-list`
+- Pull request: #101
 
 ## Latest completed work
 
@@ -35,24 +35,23 @@ P4-03 — MapLibre map
 - P4-01A public Place detail foundation completed through pull request #96
 - P4-02A coordinated PlacesApp public shell completed through pull request #97
 - P4-03A map source and camera contracts completed through pull request #98
+- P4-03B MapLibre renderer completed through pull request #100
 
-## P4-03B in progress
+## P4-04A in progress
 
-- MapLibre GL JS renderer dependency and generated lockfile
-- public GeoJSON source registration
-- clustered and unclustered public Place layers
-- selected, confirmed, and stale marker states
-- point selection and cluster expansion interaction
-- renderer move events to pending viewport state
-- committed viewport synchronization
-- Search this area integration
-- WebGL unsupported and map error fallbacks
-- renderer component tests
+- independent production Place result list component
+- public thumbnail or category fallback
+- Confirmed and Stale status presentation
+- asset, network, route, and freshness summaries
+- separate map-selection and detail-navigation actions
+- Candidate-free empty state
+- stable public Place slug hooks for next pin/list synchronization step
+- result-list component tests
 
 ## Next
 
-1. Validate and merge pull request #100.
-2. Complete production result-list behavior and pin/list synchronization.
+1. Validate and merge pull request #101.
+2. Implement pin/list synchronization and selected-card visibility behavior.
 3. Extend public filters and bounded result updates.
 
 ## Blocked

--- a/src/components/places/PlaceResultList.tsx
+++ b/src/components/places/PlaceResultList.tsx
@@ -1,0 +1,188 @@
+import type { PublicPlacePin } from '../../public/places-discovery';
+
+interface PlaceResultListProps {
+  pins: PublicPlacePin[];
+  selectedPlace: string | null;
+  onSelectPlace: (placeSlug: string) => void;
+  onClearFilters: () => void;
+}
+
+function formatLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+}
+
+export function PlaceResultList({
+  pins,
+  selectedPlace,
+  onSelectPlace,
+  onClearFilters,
+}: PlaceResultListProps) {
+  return (
+    <section
+      className="min-h-0 rounded-card border border-border bg-surface"
+      aria-labelledby="places-results-title"
+    >
+      <div className="border-b border-border p-4">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 id="places-results-title" className="m-0 text-lg font-semibold text-ink">
+              Public results
+            </h2>
+            <p className="mt-1 text-sm text-muted">Confirmed records are shown by default.</p>
+          </div>
+          <span className="text-xs font-semibold text-muted" aria-live="polite">
+            {pins.length} {pins.length === 1 ? 'result' : 'results'}
+          </span>
+        </div>
+      </div>
+
+      {pins.length === 0 ? (
+        <div className="p-6 text-center">
+          <h3 className="text-lg font-semibold text-ink">No public places match</h3>
+          <p className="mt-2 text-sm leading-6 text-muted">
+            Candidate records are not used as substitutes. Clear filters or suggest a place for
+            review.
+          </p>
+          <div className="mt-5 flex flex-wrap justify-center gap-3">
+            <button
+              className="motion-feedback min-h-11 rounded-control border border-border px-4 py-2 font-semibold text-ink hover:bg-brand-50"
+              type="button"
+              onClick={onClearFilters}
+            >
+              Clear filters
+            </button>
+            <a
+              className="motion-feedback inline-flex min-h-11 items-center rounded-control bg-brand-600 px-4 py-2 font-semibold text-white no-underline hover:bg-brand-700"
+              href="/suggest"
+            >
+              Suggest a place
+            </a>
+          </div>
+        </div>
+      ) : (
+        <ul className="m-0 max-h-[42rem] list-none overflow-y-auto p-3" aria-label="Place results">
+          {pins.map((pin) => {
+            const isSelected = pin.placeSlug === selectedPlace;
+            const location = [pin.locality, pin.countryCode].filter(Boolean).join(', ');
+
+            return (
+              <li key={pin.placeSlug} data-place-slug={pin.placeSlug} data-selected={isSelected}>
+                <article
+                  className={`grid gap-4 rounded-card border p-4 motion-safe:transition-[border-color,background-color,transform] motion-safe:duration-fast ${
+                    isSelected
+                      ? 'border-brand-600 bg-brand-50'
+                      : 'border-border bg-surface hover:border-brand-200'
+                  }`}
+                >
+                  <div className="flex gap-3">
+                    {pin.thumbnail ? (
+                      <img
+                        className="size-20 shrink-0 rounded-control object-cover"
+                        src={pin.thumbnail.url}
+                        alt={pin.thumbnail.altText}
+                        width={pin.thumbnail.width}
+                        height={pin.thumbnail.height}
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div
+                        className="flex size-20 shrink-0 items-center justify-center rounded-control bg-canvas px-2 text-center text-xs font-semibold text-muted"
+                        aria-hidden="true"
+                      >
+                        {formatLabel(pin.categorySlug)}
+                      </div>
+                    )}
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span
+                          className={`rounded-pill px-2.5 py-1 text-xs font-semibold ${
+                            pin.status === 'confirmed'
+                              ? 'bg-confirmed/10 text-confirmed'
+                              : 'bg-stale/10 text-stale'
+                          }`}
+                        >
+                          {formatLabel(pin.status)}
+                        </span>
+                        <span className="text-xs font-medium text-muted">
+                          {formatLabel(pin.categorySlug)}
+                        </span>
+                      </div>
+                      <h3 className="mt-2 text-base font-semibold text-ink">{pin.name}</h3>
+                      <p className="mt-1 text-sm text-muted">{location}</p>
+                    </div>
+                  </div>
+
+                  <dl className="grid gap-3 text-sm sm:grid-cols-2">
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted">
+                        Assets
+                      </dt>
+                      <dd className="mt-1 font-medium text-ink">
+                        {pin.assetSlugs.map(formatLabel).join(', ')}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted">
+                        Networks
+                      </dt>
+                      <dd className="mt-1 font-medium text-ink">
+                        {pin.networkSlugs.map(formatLabel).join(', ')}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted">
+                        Routes
+                      </dt>
+                      <dd className="mt-1 font-medium text-ink">
+                        {pin.routeTypes.map(formatLabel).join(', ')}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted">
+                        Last confirmed
+                      </dt>
+                      <dd className="mt-1 font-medium text-ink">
+                        {formatDate(pin.lastConfirmedAt)}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <div className="flex flex-wrap gap-2 border-t border-border pt-3">
+                    <button
+                      className="motion-feedback min-h-11 flex-1 rounded-control border border-border px-3 py-2 text-sm font-semibold text-ink hover:bg-brand-50"
+                      type="button"
+                      aria-pressed={isSelected}
+                      aria-label={`Select ${pin.name} on map`}
+                      onClick={() => onSelectPlace(pin.placeSlug)}
+                    >
+                      {isSelected ? 'Selected on map' : 'Show on map'}
+                    </button>
+                    <a
+                      className="motion-feedback inline-flex min-h-11 flex-1 items-center justify-center rounded-control bg-brand-600 px-3 py-2 text-sm font-semibold text-white no-underline hover:bg-brand-700"
+                      href={`/place/${pin.placeSlug}`}
+                    >
+                      Payment details
+                    </a>
+                  </div>
+                </article>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/places/PlacesApp.tsx
+++ b/src/components/places/PlacesApp.tsx
@@ -8,6 +8,7 @@ import {
   parseDiscoveryUrlState,
   serializeDiscoveryUrlState,
 } from '../../state/discovery-url';
+import { PlaceResultList } from './PlaceResultList';
 import { PlacesMap } from './PlacesMap';
 
 interface PlacesAppProps {
@@ -19,15 +20,6 @@ function formatLabel(value: string): string {
     .split('_')
     .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
     .join(' ');
-}
-
-function formatDate(value: string): string {
-  return new Intl.DateTimeFormat('en', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
-  }).format(new Date(value));
 }
 
 function createPlacesStore(): DiscoveryStoreApi {
@@ -273,82 +265,14 @@ export function PlacesApp({ pins }: PlacesAppProps) {
             ) : null}
           </section>
 
-          <section
-            className={`${urlState.view === 'map' ? 'hidden' : 'block'} min-h-0 rounded-card border border-border bg-surface lg:block`}
-            aria-labelledby="places-results-title"
-          >
-            <div className="border-b border-border p-4">
-              <h2 id="places-results-title" className="m-0 text-lg font-semibold text-ink">
-                Public results
-              </h2>
-              <p className="mt-1 text-sm text-muted">Confirmed records are shown by default.</p>
-            </div>
-
-            {results.length === 0 ? (
-              <div className="p-6 text-center">
-                <h3 className="text-lg font-semibold text-ink">No public places match</h3>
-                <p className="mt-2 text-sm leading-6 text-muted">
-                  Candidate records are not used as substitutes. Clear filters or suggest a place
-                  for review.
-                </p>
-                <div className="mt-5 flex flex-wrap justify-center gap-3">
-                  <button
-                    className="motion-feedback min-h-11 rounded-control border border-border px-4 py-2 font-semibold text-ink hover:bg-brand-50"
-                    type="button"
-                    onClick={clearFilters}
-                  >
-                    Clear filters
-                  </button>
-                  <a
-                    className="motion-feedback inline-flex min-h-11 items-center rounded-control bg-brand-600 px-4 py-2 font-semibold text-white no-underline hover:bg-brand-700"
-                    href="/suggest"
-                  >
-                    Suggest a place
-                  </a>
-                </div>
-              </div>
-            ) : (
-              <ul className="m-0 max-h-[42rem] list-none overflow-y-auto p-3">
-                {results.map((pin) => {
-                  const isSelected = pin.placeSlug === urlState.selectedPlace;
-                  return (
-                    <li key={pin.placeSlug}>
-                      <article
-                        className={`rounded-card border p-4 ${
-                          isSelected ? 'border-brand-600 bg-brand-50' : 'border-border bg-surface'
-                        }`}
-                      >
-                        <button
-                          className="w-full min-h-11 text-left"
-                          type="button"
-                          aria-pressed={isSelected}
-                          onClick={() => selectPlace(pin.placeSlug)}
-                        >
-                          <span className="block text-base font-semibold text-ink">{pin.name}</span>
-                          <span className="mt-1 block text-sm text-muted">
-                            {[pin.locality, pin.countryCode].filter(Boolean).join(', ')}
-                          </span>
-                          <span className="mt-3 flex flex-wrap gap-2">
-                            {pin.assetSlugs.map((asset) => (
-                              <span
-                                key={asset}
-                                className="rounded-pill border border-border bg-canvas px-2.5 py-1 text-xs font-semibold text-muted"
-                              >
-                                {asset.toUpperCase()}
-                              </span>
-                            ))}
-                          </span>
-                          <span className="mt-3 block text-xs text-muted">
-                            Last confirmed {formatDate(pin.lastConfirmedAt)}
-                          </span>
-                        </button>
-                      </article>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </section>
+          <div className={urlState.view === 'map' ? 'hidden lg:block' : 'block'}>
+            <PlaceResultList
+              pins={results}
+              selectedPlace={urlState.selectedPlace}
+              onSelectPlace={selectPlace}
+              onClearFilters={clearFilters}
+            />
+          </div>
         </div>
       </div>
     </section>

--- a/tests/place-result-list.test.tsx
+++ b/tests/place-result-list.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlaceResultList } from '../src/components/places/PlaceResultList';
+import type { PublicPlacePin } from '../src/public/places-discovery';
+
+const pins: PublicPlacePin[] = [
+  {
+    placeSlug: 'example-coffee-tokyo',
+    name: 'Example Coffee',
+    categorySlug: 'cafe',
+    countryCode: 'JP',
+    locality: 'Tokyo',
+    latitude: 35.681236,
+    longitude: 139.767125,
+    status: 'confirmed',
+    assetSlugs: ['bitcoin'],
+    networkSlugs: ['lightning'],
+    routeTypes: ['direct_wallet'],
+    lastConfirmedAt: '2026-06-20T00:00:00Z',
+    thumbnail: null,
+  },
+  {
+    placeSlug: 'example-market-osaka',
+    name: 'Example Market',
+    categorySlug: 'grocery',
+    countryCode: 'JP',
+    locality: 'Osaka',
+    latitude: 34.6937,
+    longitude: 135.5023,
+    status: 'stale',
+    assetSlugs: ['usdc'],
+    networkSlugs: ['base'],
+    routeTypes: ['processor_checkout'],
+    lastConfirmedAt: '2026-01-15T00:00:00Z',
+    thumbnail: null,
+  },
+];
+
+afterEach(cleanup);
+
+describe('PlaceResultList', () => {
+  it('renders public payment summary and freshness for every result', () => {
+    render(
+      <PlaceResultList
+        pins={pins}
+        selectedPlace={null}
+        onSelectPlace={vi.fn()}
+        onClearFilters={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('2 results')).toBeInTheDocument();
+    expect(screen.getByText('Example Coffee')).toBeInTheDocument();
+    expect(screen.getByText('Example Market')).toBeInTheDocument();
+    expect(screen.getByText('Bitcoin')).toBeInTheDocument();
+    expect(screen.getByText('Lightning')).toBeInTheDocument();
+    expect(screen.getByText('Direct Wallet')).toBeInTheDocument();
+    expect(screen.getByText('Jun 20, 2026')).toBeInTheDocument();
+    expect(screen.getByText('Stale')).toBeInTheDocument();
+  });
+
+  it('separates map selection from detail navigation', () => {
+    const onSelectPlace = vi.fn();
+    render(
+      <PlaceResultList
+        pins={pins}
+        selectedPlace="example-coffee-tokyo"
+        onSelectPlace={onSelectPlace}
+        onClearFilters={vi.fn()}
+      />,
+    );
+
+    const selectedButton = screen.getByRole('button', { name: 'Select Example Coffee on map' });
+    expect(selectedButton).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('link', { name: 'Payment details', exact: true })).toHaveAttribute(
+      'href',
+      '/place/example-coffee-tokyo',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select Example Market on map' }));
+    expect(onSelectPlace).toHaveBeenCalledWith('example-market-osaka');
+  });
+
+  it('preserves the Candidate-free empty state and actions', () => {
+    const onClearFilters = vi.fn();
+    render(
+      <PlaceResultList
+        pins={[]}
+        selectedPlace={null}
+        onSelectPlace={vi.fn()}
+        onClearFilters={onClearFilters}
+      />,
+    );
+
+    expect(screen.getByText('No public places match')).toBeInTheDocument();
+    expect(screen.getByText(/Candidate records are not used as substitutes/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(onClearFilters).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('link', { name: 'Suggest a place' })).toHaveAttribute(
+      'href',
+      '/suggest',
+    );
+  });
+});

--- a/tests/place-result-list.test.tsx
+++ b/tests/place-result-list.test.tsx
@@ -73,7 +73,7 @@ describe('PlaceResultList', () => {
 
     const selectedButton = screen.getByRole('button', { name: 'Select Example Coffee on map' });
     expect(selectedButton).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('link', { name: 'Payment details', exact: true })).toHaveAttribute(
+    expect(screen.getAllByRole('link', { name: 'Payment details', exact: true })[0]).toHaveAttribute(
       'href',
       '/place/example-coffee-tokyo',
     );

--- a/tests/place-result-list.test.tsx
+++ b/tests/place-result-list.test.tsx
@@ -73,7 +73,7 @@ describe('PlaceResultList', () => {
 
     const selectedButton = screen.getByRole('button', { name: 'Select Example Coffee on map' });
     expect(selectedButton).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getAllByRole('link', { name: 'Payment details', exact: true })[0]).toHaveAttribute(
+    expect(screen.getAllByRole('link', { name: 'Payment details' })[0]).toHaveAttribute(
       'href',
       '/place/example-coffee-tokyo',
     );


### PR DESCRIPTION
## Implementation item
P4-04A within P4-04.

## Scope
Replace the inline PlacesApp list with a production public Place result-list component.

## Included
- independent result-list component
- public thumbnail or category fallback
- Confirmed and Stale status presentation
- asset, network, route, and last-confirmed summaries
- separate map-selection and detail-navigation controls
- Candidate-free empty state
- public Place slug and selection hooks for next pin/list synchronization work
- result-list component tests

## Validation
In progress through Foundation validation and Migration drift.