### PR TITLE
P4-05A: Synchronize Place pins and result cards

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,13 +8,13 @@ Phase 4 — Public core / MVP-A
 
 ## Current implementation item
 
-P4-04 — Result list
+P4-05 — Pin and list synchronization
 
 ## Active work
 
-- P4-04A — production Place result list
-- Branch: `work/place-result-list`
-- Pull request: #101
+- P4-05A — shared Place selection lifecycle
+- Branch: `work/pin-list-sync`
+- Pull request: #102
 
 ## Latest completed work
 
@@ -36,23 +36,22 @@ P4-04 — Result list
 - P4-02A coordinated PlacesApp public shell completed through pull request #97
 - P4-03A map source and camera contracts completed through pull request #98
 - P4-03B MapLibre renderer completed through pull request #100
+- P4-04A production Place result list completed through pull request #101
 
-## P4-04A in progress
+## P4-05A in progress
 
-- independent production Place result list component
-- public thumbnail or category fallback
-- Confirmed and Stale status presentation
-- asset, network, route, and freshness summaries
-- separate map-selection and detail-navigation actions
-- Candidate-free empty state
-- stable public Place slug hooks for next pin/list synchronization step
-- result-list component tests
+- selected map Place scrolls the corresponding result card into view
+- reduced-motion-aware list scroll behavior
+- stable public Place slug to list-element synchronization
+- list selection updates the selected marker property in the public map source
+- existing marker click path continues to update shared Place selection
+- component coverage for both synchronization directions
 
 ## Next
 
-1. Validate and merge pull request #101.
-2. Implement pin/list synchronization and selected-card visibility behavior.
-3. Extend public filters and bounded result updates.
+1. Validate and merge pull request #102.
+2. Extend public filters and bounded result updates.
+3. Complete URL-state and browser-back restoration behavior.
 
 ## Blocked
 

--- a/src/components/places/PlaceResultList.tsx
+++ b/src/components/places/PlaceResultList.tsx
@@ -40,7 +40,10 @@ export function PlaceResultList({
 
   useEffect(() => {
     if (!selectedPlace) return;
-    itemRefs.current.get(selectedPlace)?.scrollIntoView({
+    const item = itemRefs.current.get(selectedPlace);
+    if (!item || typeof item.scrollIntoView !== 'function') return;
+
+    item.scrollIntoView({
       block: 'nearest',
       behavior: reducedMotionPreferred() ? 'auto' : 'smooth',
     });

--- a/src/components/places/PlaceResultList.tsx
+++ b/src/components/places/PlaceResultList.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import type { PublicPlacePin } from '../../public/places-discovery';
 
 interface PlaceResultListProps {
@@ -23,12 +24,28 @@ function formatDate(value: string): string {
   }).format(new Date(value));
 }
 
+function reducedMotionPreferred(): boolean {
+  return typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : true;
+}
+
 export function PlaceResultList({
   pins,
   selectedPlace,
   onSelectPlace,
   onClearFilters,
 }: PlaceResultListProps) {
+  const itemRefs = useRef(new Map<string, HTMLLIElement>());
+
+  useEffect(() => {
+    if (!selectedPlace) return;
+    itemRefs.current.get(selectedPlace)?.scrollIntoView({
+      block: 'nearest',
+      behavior: reducedMotionPreferred() ? 'auto' : 'smooth',
+    });
+  }, [selectedPlace]);
+
   return (
     <section
       className="min-h-0 rounded-card border border-border bg-surface"
@@ -78,7 +95,15 @@ export function PlaceResultList({
             const location = [pin.locality, pin.countryCode].filter(Boolean).join(', ');
 
             return (
-              <li key={pin.placeSlug} data-place-slug={pin.placeSlug} data-selected={isSelected}>
+              <li
+                key={pin.placeSlug}
+                ref={(element) => {
+                  if (element) itemRefs.current.set(pin.placeSlug, element);
+                  else itemRefs.current.delete(pin.placeSlug);
+                }}
+                data-place-slug={pin.placeSlug}
+                data-selected={isSelected}
+              >
                 <article
                   className={`grid gap-4 rounded-card border p-4 motion-safe:transition-[border-color,background-color,transform] motion-safe:duration-fast ${
                     isSelected

--- a/tests/place-result-list.test.tsx
+++ b/tests/place-result-list.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PlaceResultList } from '../src/components/places/PlaceResultList';
 import type { PublicPlacePin } from '../src/public/places-discovery';
 
@@ -36,6 +36,14 @@ const pins: PublicPlacePin[] = [
     thumbnail: null,
   },
 ];
+
+const scrollIntoView = vi.fn();
+
+beforeEach(() => {
+  scrollIntoView.mockReset();
+  HTMLElement.prototype.scrollIntoView = scrollIntoView;
+  window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+});
 
 afterEach(cleanup);
 
@@ -80,6 +88,28 @@ describe('PlaceResultList', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Select Example Market on map' }));
     expect(onSelectPlace).toHaveBeenCalledWith('example-market-osaka');
+  });
+
+  it('keeps the selected card visible when map selection changes', () => {
+    const { rerender } = render(
+      <PlaceResultList
+        pins={pins}
+        selectedPlace={null}
+        onSelectPlace={vi.fn()}
+        onClearFilters={vi.fn()}
+      />,
+    );
+
+    rerender(
+      <PlaceResultList
+        pins={pins}
+        selectedPlace="example-market-osaka"
+        onSelectPlace={vi.fn()}
+        onClearFilters={vi.fn()}
+      />,
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', behavior: 'auto' });
   });
 
   it('preserves the Candidate-free empty state and actions', () => {

--- a/tests/places-map.test.tsx
+++ b/tests/places-map.test.tsx
@@ -152,11 +152,11 @@ afterEach(() => {
 });
 
 describe('PlacesMap renderer', () => {
-  it('registers the public source and layers, selects markers, and reports moved viewport', async () => {
+  it('registers public layers, synchronizes selection, and reports moved viewport', async () => {
     const onSelectPlace = vi.fn();
     const onViewportChange = vi.fn();
 
-    render(
+    const { rerender } = render(
       <PlacesMap
         pins={pins}
         selectedPlace={null}
@@ -180,6 +180,27 @@ describe('PlacesMap renderer', () => {
       'public-place-cluster-count',
       'public-place-points',
     ]);
+
+    const source = map.sources.get('public-places');
+    if (!source) throw new Error('Public Place source was not registered.');
+
+    rerender(
+      <PlacesMap
+        pins={pins}
+        selectedPlace="example-coffee-tokyo"
+        committedViewport={null}
+        onSelectPlace={onSelectPlace}
+        onViewportChange={onViewportChange}
+        styleUrl="/test-style.json"
+      />,
+    );
+
+    await waitFor(() => {
+      const data = source.data as {
+        features: Array<{ properties: { selected: boolean } }>;
+      };
+      expect(data.features[0]?.properties.selected).toBe(true);
+    });
 
     await act(async () =>
       map.trigger(


### PR DESCRIPTION
## Implementation item
P4-05A within P4-05.

## Scope
Complete the shared public Place selection lifecycle between the MapLibre source and the production result list.

## Included
- scroll selected result card into view when map selection changes
- reduced-motion-aware scroll behavior
- stable public Place slug to list-element mapping
- verify list selection updates the selected property in the public map source
- preserve existing marker click to list selection path
- synchronization component tests

## Validation
In progress through Foundation validation and Migration drift.