### PR TITLE
P4-06A: Add public Place facet filters

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,49 +8,40 @@ Phase 4 — Public core / MVP-A
 
 ## Current implementation item
 
-P4-05 — Pin and list synchronization
+P4-06 — Filters and bounded result updates
 
 ## Active work
 
-- P4-05A — shared Place selection lifecycle
-- Branch: `work/pin-list-sync`
-- Pull request: #102
+- P4-06A — public Place facet filters
+- Branch: `work/public-place-filters`
+- Pull request: #103
 
 ## Latest completed work
 
 - Phase 2 completed through pull request #40
-- P3-01 through P3-06 completed through pull request #47
-- P3-07 completed through pull request #58
-- P3-08 completed through pull request #63
-- P3-09 completed through pull request #67
-- P3-10 completed through pull request #74
-- P3-11 completed through pull request #87
-- P3-12A normalized audit history read contract completed through pull request #88
-- P3-12B bounded audit history aggregation completed through pull request #89
-- P3-12C durable audit history source adapters completed through pull request #92
-- P3-12D protected audit history API completed through pull request #93
-- P3-12E Audit administration surface completed through pull request #94
-- P3-12F Phase 3 cross-domain integration audit completed through pull request #95
-- Phase 3 repository work completed with explicit live-verification deferrals
+- Phase 3 repository work completed through pull request #95 with explicit live-verification deferrals
 - P4-01A public Place detail foundation completed through pull request #96
 - P4-02A coordinated PlacesApp public shell completed through pull request #97
 - P4-03A map source and camera contracts completed through pull request #98
 - P4-03B MapLibre renderer completed through pull request #100
 - P4-04A production Place result list completed through pull request #101
+- P4-05A pin and list synchronization completed through pull request #102
 
-## P4-05A in progress
+## P4-06A in progress
 
-- selected map Place scrolls the corresponding result card into view
-- reduced-motion-aware list scroll behavior
-- stable public Place slug to list-element synchronization
-- list selection updates the selected marker property in the public map source
-- existing marker click path continues to update shared Place selection
-- component coverage for both synchronization directions
+- deterministic public facet derivation and counts
+- Asset, Network, Category, Payment route, and Public status groups
+- URL-owned multi-select filter state
+- selected Place clearing when filter context changes
+- Confirmed default status guard
+- active filter summary and clear action
+- PlacesApp integration
+- facet model and URL synchronization tests
 
 ## Next
 
-1. Validate and merge pull request #102.
-2. Extend public filters and bounded result updates.
+1. Validate and merge pull request #103.
+2. Implement bounded viewport result updates while preserving explicit Search this area commits.
 3. Complete URL-state and browser-back restoration behavior.
 
 ## Blocked

--- a/src/components/places/PlaceFilterPanel.tsx
+++ b/src/components/places/PlaceFilterPanel.tsx
@@ -1,1 +1,145 @@
-export const placeFilterPanelFoundation = true;
+import type {
+  PublicPlaceFilterFacet,
+  PublicPlaceFilterFacets,
+} from '../../public/places-discovery';
+import type {
+  DiscoveryRouteFilter,
+  DiscoveryStatusFilter,
+  DiscoveryUrlState,
+} from '../../state/discovery-url';
+
+interface PlaceFilterPanelProps {
+  facets: PublicPlaceFilterFacets;
+  state: DiscoveryUrlState;
+  onPatch: (patch: Partial<DiscoveryUrlState>) => void;
+  onClear: () => void;
+}
+
+interface FilterGroupProps {
+  legend: string;
+  options: PublicPlaceFilterFacet[];
+  selected: readonly string[];
+  onToggle: (value: string) => void;
+}
+
+function formatLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function toggleValue(values: readonly string[], value: string): string[] {
+  return values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
+}
+
+function FilterGroup({ legend, options, selected, onToggle }: FilterGroupProps) {
+  if (options.length === 0) return null;
+
+  return (
+    <fieldset>
+      <legend className="text-sm font-semibold text-ink">{legend}</legend>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {options.map((option) => {
+          const active = selected.includes(option.value);
+          return (
+            <button
+              key={option.value}
+              className={`motion-feedback min-h-10 rounded-pill border px-3 py-1.5 text-sm font-semibold ${
+                active
+                  ? 'border-brand-600 bg-brand-50 text-brand-800'
+                  : 'border-border bg-surface text-muted hover:border-brand-200'
+              }`}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onToggle(option.value)}
+            >
+              {formatLabel(option.value)} <span className="font-normal">({option.count})</span>
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+export function PlaceFilterPanel({ facets, state, onPatch, onClear }: PlaceFilterPanelProps) {
+  const activeCount =
+    state.assets.length +
+    state.networks.length +
+    state.categories.length +
+    state.routes.length +
+    (state.statuses.length === 1 && state.statuses[0] === 'confirmed' ? 0 : state.statuses.length);
+
+  return (
+    <section
+      className="mt-3 rounded-card border border-border bg-surface p-4 shadow-sm"
+      aria-label="Place filters"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border pb-4">
+        <div>
+          <h2 className="m-0 text-base font-semibold text-ink">Filter public places</h2>
+          <p className="mt-1 text-sm text-muted">
+            {activeCount === 0
+              ? 'Confirmed status is the default.'
+              : `${activeCount} active ${activeCount === 1 ? 'filter' : 'filters'}.`}
+          </p>
+        </div>
+        <button
+          className="motion-feedback min-h-10 rounded-control px-3 py-2 text-sm font-semibold text-brand-700 hover:bg-brand-50"
+          type="button"
+          onClick={onClear}
+        >
+          Clear filters
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-5 lg:grid-cols-2">
+        <FilterGroup
+          legend="Assets"
+          options={facets.assets}
+          selected={state.assets}
+          onToggle={(value) =>
+            onPatch({ assets: toggleValue(state.assets, value), selectedPlace: null })
+          }
+        />
+        <FilterGroup
+          legend="Networks"
+          options={facets.networks}
+          selected={state.networks}
+          onToggle={(value) =>
+            onPatch({ networks: toggleValue(state.networks, value), selectedPlace: null })
+          }
+        />
+        <FilterGroup
+          legend="Categories"
+          options={facets.categories}
+          selected={state.categories}
+          onToggle={(value) =>
+            onPatch({ categories: toggleValue(state.categories, value), selectedPlace: null })
+          }
+        />
+        <FilterGroup
+          legend="Payment routes"
+          options={facets.routes}
+          selected={state.routes}
+          onToggle={(value) =>
+            onPatch({
+              routes: toggleValue(state.routes, value) as DiscoveryRouteFilter[],
+              selectedPlace: null,
+            })
+          }
+        />
+        <FilterGroup
+          legend="Public status"
+          options={facets.statuses}
+          selected={state.statuses}
+          onToggle={(value) => {
+            const next = toggleValue(state.statuses, value) as DiscoveryStatusFilter[];
+            onPatch({ statuses: next.length > 0 ? next : ['confirmed'], selectedPlace: null });
+          }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/places/PlaceFilterPanel.tsx
+++ b/src/components/places/PlaceFilterPanel.tsx
@@ -1,0 +1,1 @@
+export const placeFilterPanelFoundation = true;

--- a/src/components/places/PlacesApp.tsx
+++ b/src/components/places/PlacesApp.tsx
@@ -1,25 +1,23 @@
 import { List, Map as MapIcon, Search, SlidersHorizontal, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useStore } from 'zustand';
-import { filterPublicPlacePins, type PublicPlacePin } from '../../public/places-discovery';
+import {
+  buildPublicPlaceFilterFacets,
+  filterPublicPlacePins,
+  type PublicPlacePin,
+} from '../../public/places-discovery';
 import { createDiscoveryStore, type DiscoveryStoreApi } from '../../state/discovery-store';
 import {
   defaultDiscoveryUrlState,
   parseDiscoveryUrlState,
   serializeDiscoveryUrlState,
 } from '../../state/discovery-url';
+import { PlaceFilterPanel } from './PlaceFilterPanel';
 import { PlaceResultList } from './PlaceResultList';
 import { PlacesMap } from './PlacesMap';
 
 interface PlacesAppProps {
   pins: PublicPlacePin[];
-}
-
-function formatLabel(value: string): string {
-  return value
-    .split('_')
-    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
-    .join(' ');
 }
 
 function createPlacesStore(): DiscoveryStoreApi {
@@ -57,6 +55,7 @@ export function PlacesApp({ pins }: PlacesAppProps) {
     window.history.replaceState(window.history.state, '', nextUrl);
   }, [urlReady, urlState]);
 
+  const facets = useMemo(() => buildPublicPlaceFilterFacets(pins), [pins]);
   const results = useMemo(() => filterPublicPlacePins(pins, urlState), [pins, urlState]);
   const selected =
     results.find((pin) => pin.placeSlug === urlState.selectedPlace) ??
@@ -117,7 +116,9 @@ export function PlacesApp({ pins }: PlacesAppProps) {
               className="min-h-12 w-full rounded-control border border-border bg-surface pl-11 pr-4 text-ink shadow-sm"
               type="search"
               value={urlState.search}
-              onChange={(event) => patchUrlState({ search: event.target.value })}
+              onChange={(event) =>
+                patchUrlState({ search: event.target.value, selectedPlace: null })
+              }
               placeholder="Search name, category, city, or country"
             />
           </label>
@@ -162,50 +163,12 @@ export function PlacesApp({ pins }: PlacesAppProps) {
         </div>
 
         {filterPanelOpen ? (
-          <section
-            className="mt-3 rounded-card border border-border bg-surface p-4 shadow-sm"
-            aria-label="Place filters"
-          >
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <p className="m-0 text-sm font-semibold text-ink">Public status</p>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {(['confirmed', 'stale'] as const).map((status) => {
-                    const active = urlState.statuses.includes(status);
-                    return (
-                      <button
-                        key={status}
-                        className={`motion-feedback min-h-10 rounded-pill border px-3 py-1.5 text-sm font-semibold ${
-                          active
-                            ? 'border-brand-600 bg-brand-50 text-brand-800'
-                            : 'border-border bg-surface text-muted'
-                        }`}
-                        type="button"
-                        aria-pressed={active}
-                        onClick={() => {
-                          const statuses = active
-                            ? urlState.statuses.filter((value) => value !== status)
-                            : [...urlState.statuses, status];
-                          patchUrlState({
-                            statuses: statuses.length > 0 ? statuses : ['confirmed'],
-                          });
-                        }}
-                      >
-                        {formatLabel(status)}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              <button
-                className="motion-feedback min-h-10 rounded-control px-3 py-2 text-sm font-semibold text-brand-700 hover:bg-brand-50"
-                type="button"
-                onClick={clearFilters}
-              >
-                Clear filters
-              </button>
-            </div>
-          </section>
+          <PlaceFilterPanel
+            facets={facets}
+            state={urlState}
+            onPatch={patchUrlState}
+            onClear={clearFilters}
+          />
         ) : null}
 
         <div className="mt-5 grid min-h-[38rem] gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(20rem,2fr)]">

--- a/src/public/places-discovery.ts
+++ b/src/public/places-discovery.ts
@@ -4,6 +4,19 @@ import type { DiscoveryUrlState } from '../state/discovery-url';
 
 export type PublicPlacePin = z.infer<typeof publicPlacePinSchema>;
 
+export interface PublicPlaceFilterFacet {
+  value: string;
+  count: number;
+}
+
+export interface PublicPlaceFilterFacets {
+  assets: PublicPlaceFilterFacet[];
+  networks: PublicPlaceFilterFacet[];
+  categories: PublicPlaceFilterFacet[];
+  routes: PublicPlaceFilterFacet[];
+  statuses: PublicPlaceFilterFacet[];
+}
+
 function includesSearch(pin: PublicPlacePin, search: string): boolean {
   if (!search) return true;
   const haystack = [pin.name, pin.categorySlug, pin.locality ?? '', pin.countryCode]
@@ -14,6 +27,27 @@ function includesSearch(pin: PublicPlacePin, search: string): boolean {
 
 function intersects(values: readonly string[], selected: readonly string[]): boolean {
   return selected.length === 0 || selected.some((value) => values.includes(value));
+}
+
+function countFacetValues(values: readonly string[]): PublicPlaceFilterFacet[] {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((left, right) => left.value.localeCompare(right.value));
+}
+
+export function buildPublicPlaceFilterFacets(
+  pins: readonly PublicPlacePin[],
+): PublicPlaceFilterFacets {
+  return {
+    assets: countFacetValues(pins.flatMap((pin) => [...new Set(pin.assetSlugs)])),
+    networks: countFacetValues(pins.flatMap((pin) => [...new Set(pin.networkSlugs)])),
+    categories: countFacetValues(pins.map((pin) => pin.categorySlug)),
+    routes: countFacetValues(pins.flatMap((pin) => [...new Set(pin.routeTypes)])),
+    statuses: countFacetValues(pins.map((pin) => pin.status)),
+  };
 }
 
 export function filterPublicPlacePins(

--- a/tests/places-app-shell.test.tsx
+++ b/tests/places-app-shell.test.tsx
@@ -20,6 +20,21 @@ const pins: PublicPlacePin[] = [
     lastConfirmedAt: '2026-06-20T00:00:00Z',
     thumbnail: null,
   },
+  {
+    placeSlug: 'example-market-osaka',
+    name: 'Example Market',
+    categorySlug: 'grocery',
+    countryCode: 'JP',
+    locality: 'Osaka',
+    latitude: 34.6937,
+    longitude: 135.5023,
+    status: 'stale',
+    assetSlugs: ['usdc'],
+    networkSlugs: ['base'],
+    routeTypes: ['processor_checkout'],
+    lastConfirmedAt: '2026-01-15T00:00:00Z',
+    thumbnail: null,
+  },
 ];
 
 beforeEach(() => {
@@ -36,7 +51,7 @@ describe('PlacesApp shell', () => {
     render(<PlacesApp pins={pins} />);
 
     expect(await screen.findByText('Example Coffee')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Example Coffee/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Select Example Coffee on map/ }));
 
     expect(screen.getByText('Selected place')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View payment details' })).toHaveAttribute(
@@ -44,6 +59,30 @@ describe('PlacesApp shell', () => {
       '/place/example-coffee-tokyo',
     );
     await waitFor(() => expect(window.location.search).toContain('place=example-coffee-tokyo'));
+  });
+
+  it('filters public results with URL-owned facets and clears hidden selection', async () => {
+    render(<PlacesApp pins={pins} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Select Example Coffee on map/ }));
+    await waitFor(() => expect(window.location.search).toContain('place=example-coffee-tokyo'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    expect(screen.getByRole('button', { name: 'Bitcoin (1)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Usdc (1)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Stale (1)' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stale (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Usdc (1)' }));
+
+    expect(await screen.findByText('Example Market')).toBeInTheDocument();
+    expect(screen.queryByText('Example Coffee')).not.toBeInTheDocument();
+    expect(screen.queryByText('Selected place')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(window.location.search).toContain('asset=usdc');
+      expect(window.location.search).toContain('status=confirmed%2Cstale');
+      expect(window.location.search).not.toContain('place=');
+    });
   });
 
   it('never substitutes private candidates when public filters return no results', async () => {

--- a/tests/places-discovery-model.test.ts
+++ b/tests/places-discovery-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildPublicPlaceFilterFacets,
   filterPublicPlacePins,
   parsePublicPlacePinsDocument,
   type PublicPlacePin,
@@ -37,12 +38,30 @@ const pins: PublicPlacePin[] = [
     lastConfirmedAt: '2026-01-15T00:00:00Z',
     thumbnail: null,
   },
+  {
+    placeSlug: 'second-bitcoin-cafe',
+    name: 'Second Bitcoin Cafe',
+    categorySlug: 'cafe',
+    countryCode: 'JP',
+    locality: 'Kyoto',
+    latitude: 35.0116,
+    longitude: 135.7681,
+    status: 'confirmed',
+    assetSlugs: ['bitcoin'],
+    networkSlugs: ['lightning'],
+    routeTypes: ['direct_wallet'],
+    lastConfirmedAt: '2026-06-25T00:00:00Z',
+    thumbnail: null,
+  },
 ];
 
 describe('Places discovery public model', () => {
   it('keeps Confirmed as the default public result set', () => {
     const results = filterPublicPlacePins(pins, defaultDiscoveryUrlState);
-    expect(results.map((pin) => pin.placeSlug)).toEqual(['example-coffee-tokyo']);
+    expect(results.map((pin) => pin.placeSlug)).toEqual([
+      'example-coffee-tokyo',
+      'second-bitcoin-cafe',
+    ]);
   });
 
   it('combines public search and facet filters', () => {
@@ -57,6 +76,26 @@ describe('Places discovery public model', () => {
     });
 
     expect(results.map((pin) => pin.placeSlug)).toEqual(['example-market-osaka']);
+  });
+
+  it('derives deterministic public facets and counts without duplicate values per Place', () => {
+    const facets = buildPublicPlaceFilterFacets([
+      pins[0] ? { ...pins[0], assetSlugs: ['bitcoin', 'bitcoin'] } : pins[0],
+      ...pins.slice(1),
+    ].filter((pin): pin is PublicPlacePin => pin !== undefined));
+
+    expect(facets.assets).toEqual([
+      { value: 'bitcoin', count: 2 },
+      { value: 'usdc', count: 1 },
+    ]);
+    expect(facets.categories).toEqual([
+      { value: 'cafe', count: 2 },
+      { value: 'grocery', count: 1 },
+    ]);
+    expect(facets.statuses).toEqual([
+      { value: 'confirmed', count: 2 },
+      { value: 'stale', count: 1 },
+    ]);
   });
 
   it('rejects private or non-contract fields in published pin input', () => {

--- a/tests/places-discovery-model.test.ts
+++ b/tests/places-discovery-model.test.ts
@@ -79,10 +79,12 @@ describe('Places discovery public model', () => {
   });
 
   it('derives deterministic public facets and counts without duplicate values per Place', () => {
-    const facets = buildPublicPlaceFilterFacets([
-      pins[0] ? { ...pins[0], assetSlugs: ['bitcoin', 'bitcoin'] } : pins[0],
-      ...pins.slice(1),
-    ].filter((pin): pin is PublicPlacePin => pin !== undefined));
+    const facets = buildPublicPlaceFilterFacets(
+      [
+        pins[0] ? { ...pins[0], assetSlugs: ['bitcoin', 'bitcoin'] } : pins[0],
+        ...pins.slice(1),
+      ].filter((pin): pin is PublicPlacePin => pin !== undefined),
+    );
 
     expect(facets.assets).toEqual([
       { value: 'bitcoin', count: 2 },


### PR DESCRIPTION
## Implementation item
P4-06A within P4-06.

## Scope
Expose the public Place pin facets already supported by URL state as an operable filter surface.

## Included
- deterministic public facet derivation and counts
- Asset, Network, Category, Payment route, and Public status groups
- URL-owned multi-select filter state
- selected Place clearing when filters hide or change the active result context
- Confirmed default status guard
- filter count summary and clear action
- PlacesApp integration
- facet model and URL synchronization tests

## Validation
In progress through Foundation validation and Migration drift.