### PR TITLE
P4-07A: Restore Places browser history

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,13 +8,13 @@ Phase 4 — Public core / MVP-A
 
 ## Current implementation item
 
-P4-06 — Filters and bounded result updates
+P4-07 — URL state and browser-back restoration
 
 ## Active work
 
-- P4-06B — bounded viewport result updates
-- Branch: `work/bounded-viewport-results`
-- Pull request: #104
+- P4-07A — Places browser history restoration
+- Branch: `work/discovery-history-restoration`
+- Pull request: #105
 
 ## Latest completed work
 
@@ -27,24 +27,25 @@ P4-06 — Filters and bounded result updates
 - P4-04A production Place result list completed through pull request #101
 - P4-05A pin and list synchronization completed through pull request #102
 - P4-06A public Place facet filters completed through pull request #103
+- P4-06B bounded viewport result updates completed through pull request #104
 
-## P4-06B in progress
+## P4-07A in progress
 
-- visible map bounds contract and normalization
-- ordinary and international-date-line bounds filtering
-- pending versus active bounds state
-- MapLibre moveend capture of pending viewport and visible bounds
-- explicit Search this area commit boundary
-- selected Place clearing when committed bounds change
-- URL center and zoom commit at the same boundary
-- optional bounds callback compatibility
-- bounds model and store lifecycle tests
+- explicit push and replace history modes
+- search typing uses replaceState without excessive history entries
+- discrete discovery changes create browser history entries
+- popstate restores URL-owned discovery state without push echo
+- validated session UI history snapshot
+- active map bounds restoration
+- bottom-sheet, filter-panel, and result-list scroll restoration state
+- result-list scroll DOM synchronization
+- history and restoration tests
 
 ## Next
 
-1. Validate and merge pull request #104.
-2. Complete URL-state and browser-back restoration behavior.
-3. Implement the mobile bottom sheet lifecycle.
+1. Validate and merge pull request #105.
+2. Implement the mobile bottom sheet lifecycle.
+3. Continue Online Services public discovery and detail work.
 
 ## Blocked
 

--- a/src/components/places/PlaceResultList.tsx
+++ b/src/components/places/PlaceResultList.tsx
@@ -4,6 +4,8 @@ import type { PublicPlacePin } from '../../public/places-discovery';
 interface PlaceResultListProps {
   pins: PublicPlacePin[];
   selectedPlace: string | null;
+  scrollOffset: number;
+  onScrollOffsetChange: (offset: number) => void;
   onSelectPlace: (placeSlug: string) => void;
   onClearFilters: () => void;
 }
@@ -33,10 +35,19 @@ function reducedMotionPreferred(): boolean {
 export function PlaceResultList({
   pins,
   selectedPlace,
+  scrollOffset,
+  onScrollOffsetChange,
   onSelectPlace,
   onClearFilters,
 }: PlaceResultListProps) {
+  const listRef = useRef<HTMLUListElement | null>(null);
   const itemRefs = useRef(new Map<string, HTMLLIElement>());
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list || Math.abs(list.scrollTop - scrollOffset) < 1) return;
+    list.scrollTop = scrollOffset;
+  }, [scrollOffset]);
 
   useEffect(() => {
     if (!selectedPlace) return;
@@ -92,7 +103,12 @@ export function PlaceResultList({
           </div>
         </div>
       ) : (
-        <ul className="m-0 max-h-[42rem] list-none overflow-y-auto p-3" aria-label="Place results">
+        <ul
+          ref={listRef}
+          className="m-0 max-h-[42rem] list-none overflow-y-auto p-3"
+          aria-label="Place results"
+          onScroll={(event) => onScrollOffsetChange(event.currentTarget.scrollTop)}
+        >
           {pins.map((pin) => {
             const isSelected = pin.placeSlug === selectedPlace;
             const location = [pin.locality, pin.countryCode].filter(Boolean).join(', ');

--- a/src/components/places/PlacesApp.tsx
+++ b/src/components/places/PlacesApp.tsx
@@ -6,11 +6,18 @@ import {
   filterPublicPlacePins,
   type PublicPlacePin,
 } from '../../public/places-discovery';
+import {
+  readDiscoveryHistoryFromWindow,
+  readDiscoveryHistorySnapshot,
+  writeDiscoveryHistory,
+  type DiscoveryHistoryMode,
+} from '../../state/discovery-history';
 import { createDiscoveryStore, type DiscoveryStoreApi } from '../../state/discovery-store';
 import {
   defaultDiscoveryUrlState,
-  parseDiscoveryUrlState,
+  mergeDiscoveryUrlState,
   serializeDiscoveryUrlState,
+  type DiscoveryUrlState,
 } from '../../state/discovery-url';
 import { filterPinsByMapBounds } from './map-data';
 import { PlaceFilterPanel } from './PlaceFilterPanel';
@@ -25,40 +32,87 @@ function createPlacesStore(): DiscoveryStoreApi {
   return createDiscoveryStore({ urlState: defaultDiscoveryUrlState });
 }
 
+function serializedState(state: DiscoveryUrlState): string {
+  return serializeDiscoveryUrlState(state).toString();
+}
+
 export function PlacesApp({ pins }: PlacesAppProps) {
   const storeRef = useRef<DiscoveryStoreApi | null>(null);
   if (storeRef.current === null) storeRef.current = createPlacesStore();
   const store = storeRef.current;
 
   const urlState = useStore(store, (state) => state.urlState);
+  const bottomSheet = useStore(store, (state) => state.bottomSheet);
+  const listScrollOffset = useStore(store, (state) => state.listScrollOffset);
   const filterPanelOpen = useStore(store, (state) => state.filterPanelOpen);
   const pendingViewport = useStore(store, (state) => state.pendingViewport);
   const pendingBounds = useStore(store, (state) => state.pendingBounds);
   const activeBounds = useStore(store, (state) => state.activeBounds);
-  const patchUrlState = useStore(store, (state) => state.patchUrlState);
   const setUrlState = useStore(store, (state) => state.setUrlState);
   const setBottomSheet = useStore(store, (state) => state.setBottomSheet);
+  const setListScrollOffset = useStore(store, (state) => state.setListScrollOffset);
   const setFilterPanelOpen = useStore(store, (state) => state.setFilterPanelOpen);
   const setPendingViewport = useStore(store, (state) => state.setPendingViewport);
   const setPendingBounds = useStore(store, (state) => state.setPendingBounds);
   const setActiveBounds = useStore(store, (state) => state.setActiveBounds);
+  const historyModeRef = useRef<DiscoveryHistoryMode>('replace');
   const [urlReady, setUrlReady] = useState(false);
 
+  function patchDiscoveryUrlState(
+    patch: Partial<DiscoveryUrlState>,
+    mode: DiscoveryHistoryMode = 'push',
+  ) {
+    const current = store.getState().urlState;
+    const next = mergeDiscoveryUrlState(current, patch);
+    if (serializedState(current) === serializedState(next)) return;
+
+    historyModeRef.current = mode;
+    setUrlState(next);
+  }
+
   useEffect(() => {
-    setUrlState(parseDiscoveryUrlState(window.location.search));
+    const initial = readDiscoveryHistoryFromWindow();
+    setUrlState(initial.urlState);
+    setBottomSheet(initial.uiState.bottomSheet);
+    setListScrollOffset(initial.uiState.listScrollOffset);
+    setFilterPanelOpen(initial.uiState.filterPanelOpen);
+    setActiveBounds(initial.uiState.activeBounds);
     setUrlReady(true);
 
-    const onPopState = () => setUrlState(parseDiscoveryUrlState(window.location.search));
+    const onPopState = (event: PopStateEvent) => {
+      const restored = readDiscoveryHistorySnapshot(window.location.search, event.state);
+      historyModeRef.current = 'replace';
+      setUrlState(restored.urlState);
+      setBottomSheet(restored.uiState.bottomSheet);
+      setListScrollOffset(restored.uiState.listScrollOffset);
+      setFilterPanelOpen(restored.uiState.filterPanelOpen);
+      setActiveBounds(restored.uiState.activeBounds);
+      setPendingViewport(null);
+      setPendingBounds(null);
+    };
+
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
-  }, [setUrlState]);
+  }, [
+    setActiveBounds,
+    setBottomSheet,
+    setFilterPanelOpen,
+    setListScrollOffset,
+    setPendingBounds,
+    setPendingViewport,
+    setUrlState,
+  ]);
 
   useEffect(() => {
     if (!urlReady) return;
-    const query = serializeDiscoveryUrlState(urlState).toString();
-    const nextUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
-    window.history.replaceState(window.history.state, '', nextUrl);
-  }, [urlReady, urlState]);
+    const mode = historyModeRef.current;
+    historyModeRef.current = 'replace';
+    writeDiscoveryHistory(
+      urlState,
+      { bottomSheet, listScrollOffset, filterPanelOpen, activeBounds },
+      mode,
+    );
+  }, [activeBounds, bottomSheet, filterPanelOpen, listScrollOffset, urlReady, urlState]);
 
   const facets = useMemo(() => buildPublicPlaceFilterFacets(pins), [pins]);
   const filteredResults = useMemo(() => filterPublicPlacePins(pins, urlState), [pins, urlState]);
@@ -69,17 +123,17 @@ export function PlacesApp({ pins }: PlacesAppProps) {
   const selected = results.find((pin) => pin.placeSlug === urlState.selectedPlace) ?? null;
 
   function selectPlace(placeSlug: string) {
-    patchUrlState({ selectedPlace: placeSlug });
+    patchDiscoveryUrlState({ selectedPlace: placeSlug });
     setBottomSheet('peek');
   }
 
   function clearSelection() {
-    patchUrlState({ selectedPlace: null });
+    patchDiscoveryUrlState({ selectedPlace: null });
     setBottomSheet('closed');
   }
 
   function clearFilters() {
-    patchUrlState({
+    patchDiscoveryUrlState({
       search: '',
       assets: [],
       networks: [],
@@ -97,7 +151,7 @@ export function PlacesApp({ pins }: PlacesAppProps) {
     if (!pendingViewport || !pendingBounds) return;
 
     setActiveBounds(pendingBounds);
-    patchUrlState({ viewport: pendingViewport, selectedPlace: null });
+    patchDiscoveryUrlState({ viewport: pendingViewport, selectedPlace: null });
     setPendingViewport(null);
     setPendingBounds(null);
     setBottomSheet('closed');
@@ -134,7 +188,10 @@ export function PlacesApp({ pins }: PlacesAppProps) {
               type="search"
               value={urlState.search}
               onChange={(event) =>
-                patchUrlState({ search: event.target.value, selectedPlace: null })
+                patchDiscoveryUrlState(
+                  { search: event.target.value, selectedPlace: null },
+                  'replace',
+                )
               }
               placeholder="Search name, category, city, or country"
             />
@@ -161,7 +218,7 @@ export function PlacesApp({ pins }: PlacesAppProps) {
                 }`}
                 type="button"
                 aria-pressed={urlState.view === 'map'}
-                onClick={() => patchUrlState({ view: 'map' })}
+                onClick={() => patchDiscoveryUrlState({ view: 'map' })}
               >
                 <MapIcon className="size-4" aria-hidden="true" /> Map
               </button>
@@ -171,7 +228,7 @@ export function PlacesApp({ pins }: PlacesAppProps) {
                 }`}
                 type="button"
                 aria-pressed={urlState.view === 'list'}
-                onClick={() => patchUrlState({ view: 'list' })}
+                onClick={() => patchDiscoveryUrlState({ view: 'list' })}
               >
                 <List className="size-4" aria-hidden="true" /> List
               </button>
@@ -183,7 +240,7 @@ export function PlacesApp({ pins }: PlacesAppProps) {
           <PlaceFilterPanel
             facets={facets}
             state={urlState}
-            onPatch={patchUrlState}
+            onPatch={(patch) => patchDiscoveryUrlState(patch)}
             onClear={clearFilters}
           />
         ) : null}
@@ -247,6 +304,8 @@ export function PlacesApp({ pins }: PlacesAppProps) {
             <PlaceResultList
               pins={results}
               selectedPlace={urlState.selectedPlace}
+              scrollOffset={listScrollOffset}
+              onScrollOffsetChange={setListScrollOffset}
               onSelectPlace={selectPlace}
               onClearFilters={clearFilters}
             />

--- a/src/state/discovery-history.ts
+++ b/src/state/discovery-history.ts
@@ -1,4 +1,7 @@
-import type { BottomSheetState } from './discovery-store';
+import type {
+  BottomSheetState,
+  DiscoveryMapBounds,
+} from './discovery-store';
 import {
   parseDiscoveryUrlState,
   serializeDiscoveryUrlState,
@@ -9,6 +12,7 @@ export interface DiscoveryHistoryUiState {
   bottomSheet: BottomSheetState;
   listScrollOffset: number;
   filterPanelOpen: boolean;
+  activeBounds: DiscoveryMapBounds | null;
 }
 
 export interface DiscoveryHistorySnapshot {
@@ -22,12 +26,30 @@ const defaultHistoryUiState: DiscoveryHistoryUiState = {
   bottomSheet: 'closed',
   listScrollOffset: 0,
   filterPanelOpen: false,
+  activeBounds: null,
 };
 
 const bottomSheetStates = new Set<BottomSheetState>(['closed', 'peek', 'expanded']);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function parseBounds(value: unknown): DiscoveryMapBounds | null {
+  if (value === null) return null;
+  if (!isRecord(value)) return null;
+
+  const west = finiteNumber(value.west);
+  const south = finiteNumber(value.south);
+  const east = finiteNumber(value.east);
+  const north = finiteNumber(value.north);
+  if (west === null || south === null || east === null || north === null) return null;
+
+  return { west, south, east, north };
 }
 
 function parseHistoryUiState(value: unknown): DiscoveryHistoryUiState {
@@ -45,7 +67,12 @@ function parseHistoryUiState(value: unknown): DiscoveryHistoryUiState {
       ? value.filterPanelOpen
       : defaultHistoryUiState.filterPanelOpen;
 
-  return { bottomSheet, listScrollOffset, filterPanelOpen };
+  return {
+    bottomSheet,
+    listScrollOffset,
+    filterPanelOpen,
+    activeBounds: parseBounds(value.activeBounds),
+  };
 }
 
 function readExistingHistoryState(value: unknown): Record<string, unknown> {
@@ -89,6 +116,7 @@ export function writeDiscoveryHistory(
       bottomSheet: uiState.bottomSheet,
       listScrollOffset: Math.max(0, uiState.listScrollOffset),
       filterPanelOpen: uiState.filterPanelOpen,
+      activeBounds: uiState.activeBounds ? { ...uiState.activeBounds } : null,
     },
   };
 

--- a/src/state/discovery-history.ts
+++ b/src/state/discovery-history.ts
@@ -1,7 +1,4 @@
-import type {
-  BottomSheetState,
-  DiscoveryMapBounds,
-} from './discovery-store';
+import type { BottomSheetState, DiscoveryMapBounds } from './discovery-store';
 import {
   parseDiscoveryUrlState,
   serializeDiscoveryUrlState,

--- a/src/state/useDiscoveryHistorySync.ts
+++ b/src/state/useDiscoveryHistorySync.ts
@@ -25,7 +25,9 @@ export function useDiscoveryHistorySync(): DiscoveryHistoryControls {
       actions.setBottomSheet(snapshot.uiState.bottomSheet);
       actions.setListScrollOffset(snapshot.uiState.listScrollOffset);
       actions.setFilterPanelOpen(snapshot.uiState.filterPanelOpen);
+      actions.setActiveBounds(snapshot.uiState.activeBounds);
       actions.setPendingViewport(null);
+      actions.setPendingBounds(null);
     }
 
     restoreFromHistory();
@@ -46,6 +48,7 @@ export function useDiscoveryHistorySync(): DiscoveryHistoryControls {
           bottomSheet: current.bottomSheet,
           listScrollOffset: current.listScrollOffset,
           filterPanelOpen: current.filterPanelOpen,
+          activeBounds: current.activeBounds,
         },
         mode,
       );
@@ -60,11 +63,13 @@ export function useDiscoveryHistorySync(): DiscoveryHistoryControls {
         bottomSheet: patch.bottomSheet ?? current.bottomSheet,
         listScrollOffset: patch.listScrollOffset ?? current.listScrollOffset,
         filterPanelOpen: patch.filterPanelOpen ?? current.filterPanelOpen,
+        activeBounds: patch.activeBounds ?? current.activeBounds,
       };
 
       if (patch.bottomSheet !== undefined) current.setBottomSheet(patch.bottomSheet);
       if (patch.listScrollOffset !== undefined) current.setListScrollOffset(patch.listScrollOffset);
       if (patch.filterPanelOpen !== undefined) current.setFilterPanelOpen(patch.filterPanelOpen);
+      if (patch.activeBounds !== undefined) current.setActiveBounds(patch.activeBounds);
 
       writeDiscoveryHistory(current.urlState, nextUiState, 'replace');
     },

--- a/tests/discovery-history.test.ts
+++ b/tests/discovery-history.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  readDiscoveryHistorySnapshot,
+  writeDiscoveryHistory,
+} from '../src/state/discovery-history';
+import { defaultDiscoveryUrlState } from '../src/state/discovery-url';
+
+beforeEach(() => {
+  window.history.replaceState({ preserved: true }, '', '/places');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState({}, '', '/');
+});
+
+describe('discovery browser history contract', () => {
+  it('parses URL-owned state and validates UI restoration state', () => {
+    const snapshot = readDiscoveryHistorySnapshot('?q=coffee&view=list', {
+      cpmDiscovery: {
+        bottomSheet: 'expanded',
+        listScrollOffset: 240,
+        filterPanelOpen: true,
+        activeBounds: { west: 139, south: 35, east: 140, north: 36 },
+      },
+    });
+
+    expect(snapshot.urlState.search).toBe('coffee');
+    expect(snapshot.urlState.view).toBe('list');
+    expect(snapshot.uiState).toEqual({
+      bottomSheet: 'expanded',
+      listScrollOffset: 240,
+      filterPanelOpen: true,
+      activeBounds: { west: 139, south: 35, east: 140, north: 36 },
+    });
+  });
+
+  it('falls back safely when UI restoration state is malformed', () => {
+    const snapshot = readDiscoveryHistorySnapshot('', {
+      cpmDiscovery: {
+        bottomSheet: 'invalid',
+        listScrollOffset: -40,
+        filterPanelOpen: 'yes',
+        activeBounds: { west: 'bad' },
+      },
+    });
+
+    expect(snapshot.uiState).toEqual({
+      bottomSheet: 'closed',
+      listScrollOffset: 0,
+      filterPanelOpen: false,
+      activeBounds: null,
+    });
+  });
+
+  it('writes bounded UI restoration state without dropping unrelated history state', () => {
+    writeDiscoveryHistory(
+      { ...defaultDiscoveryUrlState, selectedPlace: 'example-coffee-tokyo' },
+      {
+        bottomSheet: 'peek',
+        listScrollOffset: 180,
+        filterPanelOpen: false,
+        activeBounds: { west: 139, south: 35, east: 140, north: 36 },
+      },
+      'replace',
+    );
+
+    expect(window.location.search).toContain('place=example-coffee-tokyo');
+    expect(window.history.state.preserved).toBe(true);
+    expect(window.history.state.cpmDiscovery).toEqual({
+      bottomSheet: 'peek',
+      listScrollOffset: 180,
+      filterPanelOpen: false,
+      activeBounds: { west: 139, south: 35, east: 140, north: 36 },
+    });
+  });
+
+  it('uses pushState only for explicit history commits', () => {
+    const pushState = vi.spyOn(window.history, 'pushState');
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+
+    writeDiscoveryHistory(
+      { ...defaultDiscoveryUrlState, view: 'list' },
+      {
+        bottomSheet: 'closed',
+        listScrollOffset: 0,
+        filterPanelOpen: false,
+        activeBounds: null,
+      },
+      'push',
+    );
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+});

--- a/tests/place-result-list.test.tsx
+++ b/tests/place-result-list.test.tsx
@@ -53,6 +53,8 @@ describe('PlaceResultList', () => {
       <PlaceResultList
         pins={pins}
         selectedPlace={null}
+        scrollOffset={0}
+        onScrollOffsetChange={vi.fn()}
         onSelectPlace={vi.fn()}
         onClearFilters={vi.fn()}
       />,
@@ -74,6 +76,8 @@ describe('PlaceResultList', () => {
       <PlaceResultList
         pins={pins}
         selectedPlace="example-coffee-tokyo"
+        scrollOffset={0}
+        onScrollOffsetChange={vi.fn()}
         onSelectPlace={onSelectPlace}
         onClearFilters={vi.fn()}
       />,
@@ -95,6 +99,8 @@ describe('PlaceResultList', () => {
       <PlaceResultList
         pins={pins}
         selectedPlace={null}
+        scrollOffset={0}
+        onScrollOffsetChange={vi.fn()}
         onSelectPlace={vi.fn()}
         onClearFilters={vi.fn()}
       />,
@@ -104,6 +110,8 @@ describe('PlaceResultList', () => {
       <PlaceResultList
         pins={pins}
         selectedPlace="example-market-osaka"
+        scrollOffset={0}
+        onScrollOffsetChange={vi.fn()}
         onSelectPlace={vi.fn()}
         onClearFilters={vi.fn()}
       />,
@@ -112,12 +120,35 @@ describe('PlaceResultList', () => {
     expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', behavior: 'auto' });
   });
 
+  it('restores and reports the result-list scroll offset', () => {
+    const onScrollOffsetChange = vi.fn();
+    render(
+      <PlaceResultList
+        pins={pins}
+        selectedPlace={null}
+        scrollOffset={240}
+        onScrollOffsetChange={onScrollOffsetChange}
+        onSelectPlace={vi.fn()}
+        onClearFilters={vi.fn()}
+      />,
+    );
+
+    const list = screen.getByRole('list', { name: 'Place results' });
+    expect(list.scrollTop).toBe(240);
+
+    list.scrollTop = 360;
+    fireEvent.scroll(list);
+    expect(onScrollOffsetChange).toHaveBeenCalledWith(360);
+  });
+
   it('preserves the Candidate-free empty state and actions', () => {
     const onClearFilters = vi.fn();
     render(
       <PlaceResultList
         pins={[]}
         selectedPlace={null}
+        scrollOffset={0}
+        onScrollOffsetChange={vi.fn()}
         onSelectPlace={vi.fn()}
         onClearFilters={onClearFilters}
       />,

--- a/tests/places-app-shell.test.tsx
+++ b/tests/places-app-shell.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PlacesApp } from '../src/components/places/PlacesApp';
 import type { PublicPlacePin } from '../src/public/places-discovery';
 
@@ -43,6 +43,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   window.history.replaceState({}, '', '/');
 });
 
@@ -83,6 +84,49 @@ describe('PlacesApp shell', () => {
       expect(window.location.search).toContain('status=confirmed%2Cstale');
       expect(window.location.search).not.toContain('place=');
     });
+  });
+
+  it('replaces search typing but pushes explicit discovery selection', async () => {
+    const pushState = vi.spyOn(window.history, 'pushState');
+    render(<PlacesApp pins={pins} />);
+
+    const search = screen.getByRole('searchbox', { name: 'Search places' });
+    fireEvent.change(search, { target: { value: 'coffee' } });
+    await waitFor(() => expect(window.location.search).toContain('q=coffee'));
+    expect(pushState).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Select Example Coffee on map/ }));
+    await waitFor(() => expect(window.location.search).toContain('place=example-coffee-tokyo'));
+    expect(pushState).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores URL and UI state from popstate without adding a history entry', async () => {
+    const pushState = vi.spyOn(window.history, 'pushState');
+    render(<PlacesApp pins={pins} />);
+    await screen.findByText('Example Coffee');
+
+    const restoredState = {
+      cpmDiscovery: {
+        bottomSheet: 'peek',
+        listScrollOffset: 180,
+        filterPanelOpen: true,
+        activeBounds: null,
+      },
+    };
+    window.history.replaceState(
+      restoredState,
+      '',
+      '/places?q=coffee&place=example-coffee-tokyo&view=list',
+    );
+    window.dispatchEvent(new PopStateEvent('popstate', { state: restoredState }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('searchbox', { name: 'Search places' })).toHaveValue('coffee'),
+    );
+    expect(screen.getByRole('button', { name: 'List' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Selected place')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bitcoin (1)' })).toBeInTheDocument();
+    expect(pushState).not.toHaveBeenCalled();
   });
 
   it('never substitutes private candidates when public filters return no results', async () => {


### PR DESCRIPTION
## Implementation item
P4-07A.

## Scope
Restore Places URL state and session UI state through browser navigation.

## Included
- push versus replace history modes
- popstate restoration
- active bounds and list scroll restoration
- history snapshot validation
- component and unit tests

## Validation
In progress.