### PR TITLE
P4-08A: Add mobile selected Place sheet

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,13 +8,13 @@ Phase 4 — Public core / MVP-A
 
 ## Current implementation item
 
-P4-07 — URL state and browser-back restoration
+P4-08 — Mobile bottom sheet
 
 ## Active work
 
-- P4-07A — Places browser history restoration
-- Branch: `work/discovery-history-restoration`
-- Pull request: #105
+- P4-08A — mobile selected Place sheet lifecycle
+- Branch: `work/mobile-place-sheet`
+- Pull request: #106
 
 ## Latest completed work
 
@@ -28,24 +28,25 @@ P4-07 — URL state and browser-back restoration
 - P4-05A pin and list synchronization completed through pull request #102
 - P4-06A public Place facet filters completed through pull request #103
 - P4-06B bounded viewport result updates completed through pull request #104
+- P4-07A Places browser history restoration completed through pull request #105
 
-## P4-07A in progress
+## P4-08A in progress
 
-- explicit push and replace history modes
-- search typing uses replaceState without excessive history entries
-- discrete discovery changes create browser history entries
-- popstate restores URL-owned discovery state without push echo
-- validated session UI history snapshot
-- active map bounds restoration
-- bottom-sheet, filter-panel, and result-list scroll restoration state
-- result-list scroll DOM synchronization
-- history and restoration tests
+- dedicated mobile selected Place sheet
+- closed, peek, and expanded lifecycle states
+- selection opens the sheet in peek state
+- peek payment summary with status, asset, and last-confirmed date
+- expanded location, network, and payment-route context
+- payment detail and report actions
+- safe-area-aware fixed mobile layout
+- desktop selected panel separation
+- PlacesApp lifecycle coverage
 
 ## Next
 
-1. Validate and merge pull request #105.
-2. Implement the mobile bottom sheet lifecycle.
-3. Continue Online Services public discovery and detail work.
+1. Validate and merge pull request #106.
+2. Continue Online Services public discovery and detail work.
+3. Continue Home, Stats, Updates, Roadmap, and Changelog public surfaces.
 
 ## Blocked
 

--- a/src/components/places/MobilePlaceSheet.tsx
+++ b/src/components/places/MobilePlaceSheet.tsx
@@ -1,0 +1,157 @@
+import { ChevronDown, ChevronUp, X } from 'lucide-react';
+import type { PublicPlacePin } from '../../public/places-discovery';
+import type { BottomSheetState } from '../../state/discovery-store';
+
+interface MobilePlaceSheetProps {
+  place: PublicPlacePin | null;
+  state: BottomSheetState;
+  onStateChange: (state: BottomSheetState) => void;
+}
+
+function formatLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+}
+
+export function MobilePlaceSheet({
+  place,
+  state,
+  onStateChange,
+}: MobilePlaceSheetProps) {
+  if (!place || state === 'closed') return null;
+
+  const expanded = state === 'expanded';
+  const location = [place.locality, place.countryCode].filter(Boolean).join(', ');
+
+  return (
+    <section
+      className={`fixed inset-x-0 bottom-0 z-40 rounded-t-card border-x border-t border-border bg-surface shadow-panel lg:hidden ${
+        expanded ? 'max-h-[78svh]' : 'max-h-48'
+      }`}
+      aria-label={`Selected place: ${place.name}`}
+      data-sheet-state={state}
+    >
+      <div className="pb-[env(safe-area-inset-bottom)]">
+        <div className="relative border-b border-border px-4 pb-3 pt-2">
+          <button
+            className="motion-feedback mx-auto flex min-h-11 w-full items-center justify-center"
+            type="button"
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Collapse place details' : 'Expand place details'}
+            onClick={() => onStateChange(expanded ? 'peek' : 'expanded')}
+          >
+            <span className="h-1.5 w-12 rounded-pill bg-border" aria-hidden="true" />
+          </button>
+          <button
+            className="motion-feedback absolute right-2 top-2 flex size-11 items-center justify-center rounded-control text-muted hover:bg-canvas"
+            type="button"
+            aria-label="Close selected place"
+            onClick={() => onStateChange('closed')}
+          >
+            <X className="size-5" aria-hidden="true" />
+          </button>
+
+          <div className="pr-12">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={`rounded-pill px-2.5 py-1 text-xs font-semibold ${
+                  place.status === 'confirmed'
+                    ? 'bg-confirmed/10 text-confirmed'
+                    : 'bg-stale/10 text-stale'
+                }`}
+              >
+                {formatLabel(place.status)}
+              </span>
+              <span className="text-xs font-medium text-muted">
+                Last confirmed {formatDate(place.lastConfirmedAt)}
+              </span>
+            </div>
+            <h2 className="mt-2 text-lg font-semibold text-ink">{place.name}</h2>
+            <p className="mt-1 text-sm text-muted">
+              {place.assetSlugs.map(formatLabel).join(', ')}
+            </p>
+          </div>
+        </div>
+
+        {expanded ? (
+          <div className="max-h-[52svh] overflow-y-auto px-4 py-4">
+            <dl className="grid gap-4 text-sm">
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted">
+                  Location
+                </dt>
+                <dd className="mt-1 font-medium text-ink">{location}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted">
+                  Networks
+                </dt>
+                <dd className="mt-1 font-medium text-ink">
+                  {place.networkSlugs.map(formatLabel).join(', ')}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted">
+                  Payment routes
+                </dt>
+                <dd className="mt-1 font-medium text-ink">
+                  {place.routeTypes.map(formatLabel).join(', ')}
+                </dd>
+              </div>
+            </dl>
+
+            <p className="mt-5 text-sm leading-6 text-muted">
+              Open the full record for payment instructions, evidence, restrictions, and history.
+            </p>
+
+            <div className="mt-4 grid grid-cols-2 gap-2">
+              <a
+                className="motion-feedback inline-flex min-h-11 items-center justify-center rounded-control bg-brand-600 px-3 py-2 text-sm font-semibold text-white no-underline hover:bg-brand-700"
+                href={`/place/${place.placeSlug}`}
+              >
+                Payment details
+              </a>
+              <a
+                className="motion-feedback inline-flex min-h-11 items-center justify-center rounded-control border border-border px-3 py-2 text-sm font-semibold text-ink no-underline hover:bg-brand-50"
+                href="/report"
+              >
+                Report a problem
+              </a>
+            </div>
+          </div>
+        ) : (
+          <button
+            className="motion-feedback flex min-h-11 w-full items-center justify-center gap-2 px-4 py-2 text-sm font-semibold text-brand-700"
+            type="button"
+            onClick={() => onStateChange('expanded')}
+          >
+            More payment information
+            <ChevronUp className="size-4" aria-hidden="true" />
+          </button>
+        )}
+
+        {expanded ? (
+          <button
+            className="motion-feedback flex min-h-11 w-full items-center justify-center gap-2 border-t border-border px-4 py-2 text-sm font-semibold text-muted"
+            type="button"
+            onClick={() => onStateChange('peek')}
+          >
+            Show less
+            <ChevronDown className="size-4" aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/places/MobilePlaceSheet.tsx
+++ b/src/components/places/MobilePlaceSheet.tsx
@@ -24,11 +24,7 @@ function formatDate(value: string): string {
   }).format(new Date(value));
 }
 
-export function MobilePlaceSheet({
-  place,
-  state,
-  onStateChange,
-}: MobilePlaceSheetProps) {
+export function MobilePlaceSheet({ place, state, onStateChange }: MobilePlaceSheetProps) {
   if (!place || state === 'closed') return null;
 
   const expanded = state === 'expanded';

--- a/src/components/places/PlacesApp.tsx
+++ b/src/components/places/PlacesApp.tsx
@@ -20,6 +20,7 @@ import {
   type DiscoveryUrlState,
 } from '../../state/discovery-url';
 import { filterPinsByMapBounds } from './map-data';
+import { MobilePlaceSheet } from './MobilePlaceSheet';
 import { PlaceFilterPanel } from './PlaceFilterPanel';
 import { PlaceResultList } from './PlaceResultList';
 import { PlacesMap } from './PlacesMap';
@@ -270,7 +271,7 @@ export function PlacesApp({ pins }: PlacesAppProps) {
             ) : null}
 
             {selected ? (
-              <aside className="absolute inset-x-3 bottom-3 z-10 rounded-card border border-border bg-surface p-4 shadow-panel sm:inset-x-auto sm:left-4 sm:w-80">
+              <aside className="absolute inset-x-3 bottom-3 z-10 hidden rounded-card border border-border bg-surface p-4 shadow-panel sm:inset-x-auto sm:left-4 sm:w-80 lg:block">
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <p className="m-0 text-xs font-semibold uppercase tracking-[0.08em] text-brand-700">
@@ -311,6 +312,8 @@ export function PlacesApp({ pins }: PlacesAppProps) {
             />
           </div>
         </div>
+
+        <MobilePlaceSheet place={selected} state={bottomSheet} onStateChange={setBottomSheet} />
       </div>
     </section>
   );

--- a/tests/places-app-shell.test.tsx
+++ b/tests/places-app-shell.test.tsx
@@ -62,6 +62,34 @@ describe('PlacesApp shell', () => {
     await waitFor(() => expect(window.location.search).toContain('place=example-coffee-tokyo'));
   });
 
+  it('moves the mobile selected Place sheet through peek, expanded, and closed states', async () => {
+    render(<PlacesApp pins={pins} />);
+    fireEvent.click(screen.getByRole('button', { name: /Select Example Coffee on map/ }));
+
+    const sheet = screen.getByRole('region', { name: 'Selected place: Example Coffee' });
+    expect(sheet).toHaveAttribute('data-sheet-state', 'peek');
+    expect(screen.getByText(/Last confirmed Jun 20, 2026/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'More payment information' }));
+    await waitFor(() => expect(sheet).toHaveAttribute('data-sheet-state', 'expanded'));
+    expect(screen.getByText('Lightning')).toBeInTheDocument();
+    expect(screen.getByText('Direct Wallet')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Payment details' })).toHaveAttribute(
+      'href',
+      '/place/example-coffee-tokyo',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
+    await waitFor(() => expect(sheet).toHaveAttribute('data-sheet-state', 'peek'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close selected place' }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('region', { name: 'Selected place: Example Coffee' }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
   it('filters public results with URL-owned facets and clears hidden selection', async () => {
     render(<PlacesApp pins={pins} />);
 

--- a/tests/places-app-shell.test.tsx
+++ b/tests/places-app-shell.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PlacesApp } from '../src/components/places/PlacesApp';
 import type { PublicPlacePin } from '../src/public/places-discovery';
@@ -67,22 +67,23 @@ describe('PlacesApp shell', () => {
     fireEvent.click(screen.getByRole('button', { name: /Select Example Coffee on map/ }));
 
     const sheet = screen.getByRole('region', { name: 'Selected place: Example Coffee' });
+    const sheetQueries = within(sheet);
     expect(sheet).toHaveAttribute('data-sheet-state', 'peek');
-    expect(screen.getByText(/Last confirmed Jun 20, 2026/)).toBeInTheDocument();
+    expect(sheetQueries.getByText(/Last confirmed Jun 20, 2026/)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'More payment information' }));
+    fireEvent.click(sheetQueries.getByRole('button', { name: 'More payment information' }));
     await waitFor(() => expect(sheet).toHaveAttribute('data-sheet-state', 'expanded'));
-    expect(screen.getByText('Lightning')).toBeInTheDocument();
-    expect(screen.getByText('Direct Wallet')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Payment details' })).toHaveAttribute(
+    expect(sheetQueries.getByText('Lightning')).toBeInTheDocument();
+    expect(sheetQueries.getByText('Direct Wallet')).toBeInTheDocument();
+    expect(sheetQueries.getByRole('link', { name: 'Payment details' })).toHaveAttribute(
       'href',
       '/place/example-coffee-tokyo',
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
+    fireEvent.click(sheetQueries.getByRole('button', { name: 'Show less' }));
     await waitFor(() => expect(sheet).toHaveAttribute('data-sheet-state', 'peek'));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close selected place' }));
+    fireEvent.click(sheetQueries.getByRole('button', { name: 'Close selected place' }));
     await waitFor(() =>
       expect(
         screen.queryByRole('region', { name: 'Selected place: Example Coffee' }),


### PR DESCRIPTION
## Implementation item
P4-08A.

## Scope
Add the mobile selected Place bottom-sheet lifecycle.

## Included
- closed, peek, expanded states
- selection opens peek
- expanded payment context
- detail and report actions
- safe-area-aware fixed mobile sheet
- desktop selected panel separation
- PlacesApp lifecycle coverage

## Validation
In progress.