### PR TITLE
P4-11A: Add public Stats surface

### DIFF
--- a/public/data/stats.json
+++ b/public/data/stats.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-07-05T00:00:00Z",
+  "counts": {
+    "confirmedPhysicalPlaces": 0,
+    "confirmedOnlineServices": 0,
+    "countries": 0,
+    "cities": 0,
+    "staleRecords": 0,
+    "endedRecords": 0,
+    "directWalletClaims": 0,
+    "processorCheckoutClaims": 0
+  },
+  "topAssets": [],
+  "topNetworks": [],
+  "quality": {
+    "howToPayCoverage": 0,
+    "networkSpecifiedRate": 0,
+    "evidenceBackedRate": 0,
+    "reconfirmedWithin90Days": 0,
+    "reconfirmedWithin180Days": 0,
+    "staleRate": 0
+  },
+  "changes": {
+    "newlyConfirmed": 0,
+    "reconfirmed": 0,
+    "markedStale": 0,
+    "ended": 0
+  }
+}

--- a/public/data/stats.json
+++ b/public/data/stats.json
@@ -1,30 +1,18 @@
 {
-  "schemaVersion": "1.0.0",
-  "generatedAt": "2026-07-05T00:00:00Z",
-  "counts": {
-    "confirmedPhysicalPlaces": 0,
-    "confirmedOnlineServices": 0,
-    "countries": 0,
-    "cities": 0,
-    "staleRecords": 0,
-    "endedRecords": 0,
-    "directWalletClaims": 0,
-    "processorCheckoutClaims": 0
-  },
+  "confirmedPhysicalPlaces": 0,
+  "confirmedOnlineServices": 0,
+  "countries": 0,
+  "cities": 0,
+  "staleRecords": 0,
+  "endedRecords": 0,
+  "directWalletClaims": 0,
+  "processorCheckoutClaims": 0,
+  "howToPayCoverage": 0,
+  "networkSpecifiedRate": 0,
+  "evidenceBackedRate": 0,
+  "reconfirmedWithin90Days": 0,
+  "reconfirmedWithin180Days": 0,
+  "staleRate": 0,
   "topAssets": [],
-  "topNetworks": [],
-  "quality": {
-    "howToPayCoverage": 0,
-    "networkSpecifiedRate": 0,
-    "evidenceBackedRate": 0,
-    "reconfirmedWithin90Days": 0,
-    "reconfirmedWithin180Days": 0,
-    "staleRate": 0
-  },
-  "changes": {
-    "newlyConfirmed": 0,
-    "reconfirmed": 0,
-    "markedStale": 0,
-    "ended": 0
-  }
+  "topNetworks": []
 }

--- a/src/components/public/StatsOverview.astro
+++ b/src/components/public/StatsOverview.astro
@@ -7,12 +7,12 @@ interface Props {
 
 const { stats } = Astro.props;
 const overview = [
-  ['Confirmed physical places', stats.counts.confirmedPhysicalPlaces],
-  ['Confirmed online services', stats.counts.confirmedOnlineServices],
-  ['Countries', stats.counts.countries],
-  ['Cities', stats.counts.cities],
-  ['Stale records', stats.counts.staleRecords],
-  ['Ended records', stats.counts.endedRecords],
+  ['Confirmed physical places', stats.confirmedPhysicalPlaces],
+  ['Confirmed online services', stats.confirmedOnlineServices],
+  ['Countries', stats.countries],
+  ['Cities', stats.cities],
+  ['Stale records', stats.staleRecords],
+  ['Ended records', stats.endedRecords],
 ] as const;
 ---
 
@@ -39,12 +39,12 @@ const overview = [
   <div class="mt-8 grid gap-4 sm:grid-cols-2">
     <article class="rounded-card border border-border bg-brand-50 p-5">
       <p class="m-0 text-sm font-semibold text-brand-700">Direct wallet claims</p>
-      <p class="mt-2 text-4xl font-semibold tracking-tight text-ink">{stats.counts.directWalletClaims}</p>
+      <p class="mt-2 text-4xl font-semibold tracking-tight text-ink">{stats.directWalletClaims}</p>
       <p class="mt-2 text-sm leading-6 text-muted">Customer pays a merchant-controlled wallet or invoice route directly.</p>
     </article>
     <article class="rounded-card border border-border bg-brand-50 p-5">
       <p class="m-0 text-sm font-semibold text-brand-700">Processor checkout claims</p>
-      <p class="mt-2 text-4xl font-semibold tracking-tight text-ink">{stats.counts.processorCheckoutClaims}</p>
+      <p class="mt-2 text-4xl font-semibold tracking-tight text-ink">{stats.processorCheckoutClaims}</p>
       <p class="mt-2 text-sm leading-6 text-muted">Customer pays through a verified cryptocurrency checkout processor route.</p>
     </article>
   </div>

--- a/src/components/public/StatsOverview.astro
+++ b/src/components/public/StatsOverview.astro
@@ -1,0 +1,51 @@
+---
+import type { PublicStats } from '../../public/stats';
+
+interface Props {
+  stats: PublicStats;
+}
+
+const { stats } = Astro.props;
+const overview = [
+  ['Confirmed physical places', stats.counts.confirmedPhysicalPlaces],
+  ['Confirmed online services', stats.counts.confirmedOnlineServices],
+  ['Countries', stats.counts.countries],
+  ['Cities', stats.counts.cities],
+  ['Stale records', stats.counts.staleRecords],
+  ['Ended records', stats.counts.endedRecords],
+] as const;
+---
+
+<section aria-labelledby="stats-overview-title">
+  <p class="m-0 text-sm font-semibold text-brand-700">Dataset overview</p>
+  <h2 id="stats-overview-title" class="mt-1 text-3xl font-semibold tracking-tight text-ink">
+    Current public records
+  </h2>
+  <p class="mt-3 max-w-3xl text-sm leading-6 text-muted">
+    These figures describe CryptoPayMap’s validated public dataset, not worldwide cryptocurrency adoption.
+  </p>
+
+  <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {
+      overview.map(([label, value]) => (
+        <article class="rounded-card border border-border bg-surface p-5 shadow-sm">
+          <p class="m-0 text-sm font-medium text-muted">{label}</p>
+          <p class="mt-2 text-4xl font-semibold tracking-tight text-ink">{value}</p>
+        </article>
+      ))
+    }
+  </div>
+
+  <div class="mt-8 grid gap-4 sm:grid-cols-2">
+    <article class="rounded-card border border-border bg-brand-50 p-5">
+      <p class="m-0 text-sm font-semibold text-brand-700">Direct wallet claims</p>
+      <p class="mt-2 text-4xl font-semibold tracking-tight text-ink">{stats.counts.directWalletClaims}</p>
+      <p class="mt-2 text-sm leading-6 text-muted">Customer pays a merchant-controlled wallet or invoice route directly.</p>
+    </article>
+    <article class="rounded-card border border-border bg-brand-50 p-5">
+      <p class="m-0 text-sm font-semibold text-brand-700">Processor checkout claims</p>
+      <p class="mt-2 text-4xl font-semibold tracking-tight text-ink">{stats.counts.processorCheckoutClaims}</p>
+      <p class="mt-2 text-sm leading-6 text-muted">Customer pays through a verified cryptocurrency checkout processor route.</p>
+    </article>
+  </div>
+</section>

--- a/src/components/public/StatsQuality.astro
+++ b/src/components/public/StatsQuality.astro
@@ -7,18 +7,12 @@ interface Props {
 
 const { stats } = Astro.props;
 const quality = [
-  ['How-to-pay coverage', stats.quality.howToPayCoverage],
-  ['Network specified rate', stats.quality.networkSpecifiedRate],
-  ['Evidence-backed rate', stats.quality.evidenceBackedRate],
-  ['Reconfirmed within 90 days', stats.quality.reconfirmedWithin90Days],
-  ['Reconfirmed within 180 days', stats.quality.reconfirmedWithin180Days],
-  ['Stale rate', stats.quality.staleRate],
-] as const;
-const changes = [
-  ['Newly confirmed', stats.changes.newlyConfirmed],
-  ['Reconfirmed', stats.changes.reconfirmed],
-  ['Marked stale', stats.changes.markedStale],
-  ['Ended', stats.changes.ended],
+  ['How-to-pay coverage', stats.howToPayCoverage],
+  ['Network specified rate', stats.networkSpecifiedRate],
+  ['Evidence-backed rate', stats.evidenceBackedRate],
+  ['Reconfirmed within 90 days', stats.reconfirmedWithin90Days],
+  ['Reconfirmed within 180 days', stats.reconfirmedWithin180Days],
+  ['Stale rate', stats.staleRate],
 ] as const;
 const percent = (value: number) => `${Math.round(value * 1000) / 10}%`;
 ---
@@ -38,23 +32,6 @@ const percent = (value: number) => `${Math.round(value * 1000) / 10}%`;
           <div class="mt-4 h-2 overflow-hidden rounded-pill bg-canvas" aria-hidden="true">
             <div class="h-full rounded-pill bg-brand-600" style={`width: ${Math.min(100, value * 100)}%`} />
           </div>
-        </article>
-      ))
-    }
-  </div>
-</section>
-
-<section class="mt-12" aria-labelledby="stats-changes-title">
-  <p class="m-0 text-sm font-semibold text-brand-700">Public record changes</p>
-  <h2 id="stats-changes-title" class="mt-1 text-3xl font-semibold tracking-tight text-ink">
-    Verification activity
-  </h2>
-  <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-    {
-      changes.map(([label, value]) => (
-        <article class="rounded-card border border-border bg-surface p-5 shadow-sm">
-          <p class="m-0 text-sm font-medium text-muted">{label}</p>
-          <p class="mt-2 text-3xl font-semibold tracking-tight text-ink">{value}</p>
         </article>
       ))
     }

--- a/src/components/public/StatsQuality.astro
+++ b/src/components/public/StatsQuality.astro
@@ -1,0 +1,62 @@
+---
+import type { PublicStats } from '../../public/stats';
+
+interface Props {
+  stats: PublicStats;
+}
+
+const { stats } = Astro.props;
+const quality = [
+  ['How-to-pay coverage', stats.quality.howToPayCoverage],
+  ['Network specified rate', stats.quality.networkSpecifiedRate],
+  ['Evidence-backed rate', stats.quality.evidenceBackedRate],
+  ['Reconfirmed within 90 days', stats.quality.reconfirmedWithin90Days],
+  ['Reconfirmed within 180 days', stats.quality.reconfirmedWithin180Days],
+  ['Stale rate', stats.quality.staleRate],
+] as const;
+const changes = [
+  ['Newly confirmed', stats.changes.newlyConfirmed],
+  ['Reconfirmed', stats.changes.reconfirmed],
+  ['Marked stale', stats.changes.markedStale],
+  ['Ended', stats.changes.ended],
+] as const;
+const percent = (value: number) => `${Math.round(value * 1000) / 10}%`;
+---
+
+<section aria-labelledby="stats-quality-title">
+  <p class="m-0 text-sm font-semibold text-brand-700">Data quality</p>
+  <h2 id="stats-quality-title" class="mt-1 text-3xl font-semibold tracking-tight text-ink">
+    Coverage and freshness
+  </h2>
+
+  <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {
+      quality.map(([label, value]) => (
+        <article class="rounded-card border border-border bg-surface p-5 shadow-sm">
+          <p class="m-0 text-sm font-medium text-muted">{label}</p>
+          <p class="mt-2 text-3xl font-semibold tracking-tight text-ink">{percent(value)}</p>
+          <div class="mt-4 h-2 overflow-hidden rounded-pill bg-canvas" aria-hidden="true">
+            <div class="h-full rounded-pill bg-brand-600" style={`width: ${Math.min(100, value * 100)}%`} />
+          </div>
+        </article>
+      ))
+    }
+  </div>
+</section>
+
+<section class="mt-12" aria-labelledby="stats-changes-title">
+  <p class="m-0 text-sm font-semibold text-brand-700">Public record changes</p>
+  <h2 id="stats-changes-title" class="mt-1 text-3xl font-semibold tracking-tight text-ink">
+    Verification activity
+  </h2>
+  <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    {
+      changes.map(([label, value]) => (
+        <article class="rounded-card border border-border bg-surface p-5 shadow-sm">
+          <p class="m-0 text-sm font-medium text-muted">{label}</p>
+          <p class="mt-2 text-3xl font-semibold tracking-tight text-ink">{value}</p>
+        </article>
+      ))
+    }
+  </div>
+</section>

--- a/src/components/public/StatsRankings.astro
+++ b/src/components/public/StatsRankings.astro
@@ -1,0 +1,45 @@
+---
+import type { PublicStatDisplayEntry } from '../../public/stats';
+
+interface Props {
+  title: string;
+  description: string;
+  entries: PublicStatDisplayEntry[];
+}
+
+const { title, description, entries } = Astro.props;
+const formatLabel = (value: string) =>
+  value
+    .split('_')
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+---
+
+<section class="rounded-card border border-border bg-surface p-5 shadow-sm sm:p-6">
+  <h2 class="m-0 text-2xl font-semibold tracking-tight text-ink">{title}</h2>
+  <p class="mt-2 text-sm leading-6 text-muted">{description}</p>
+
+  {
+    entries.length === 0 ? (
+      <p class="mt-5 rounded-control bg-canvas p-4 text-sm leading-6 text-muted">
+        Public ranking data will appear after the minimum record threshold is met.
+      </p>
+    ) : (
+      <ol class="mt-5 grid list-none gap-3 p-0">
+        {entries.map((entry) => (
+          <li class="flex items-center justify-between gap-4 rounded-control border border-border p-4">
+            <div class="flex min-w-0 items-center gap-3">
+              {entry.rank ? (
+                <span class="flex size-8 shrink-0 items-center justify-center rounded-pill bg-brand-50 text-sm font-semibold text-brand-800">
+                  {entry.rank}
+                </span>
+              ) : null}
+              <span class="truncate font-semibold text-ink">{formatLabel(entry.slug)}</span>
+            </div>
+            <span class="shrink-0 text-sm font-semibold text-muted">{entry.count}</span>
+          </li>
+        ))}
+      </ol>
+    )
+  }
+</section>

--- a/src/components/public/StatsRankings.astro
+++ b/src/components/public/StatsRankings.astro
@@ -34,7 +34,7 @@ const formatLabel = (value: string) =>
                   {entry.rank}
                 </span>
               ) : null}
-              <span class="truncate font-semibold text-ink">{formatLabel(entry.slug)}</span>
+              <span class="truncate font-semibold text-ink">{formatLabel(entry.key)}</span>
             </div>
             <span class="shrink-0 text-sm font-semibold text-muted">{entry.count}</span>
           </li>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,6 +4,7 @@ import { z } from 'astro/zod';
 import { parsePublicOnlineServicesDocument } from './public/online-services';
 import { parsePublicPlacePinsDocument } from './public/places-discovery';
 import { parsePublicPlacesDocument } from './public/place-detail';
+import { parsePublicStatsDocument } from './public/stats';
 
 const roadmap = defineCollection({
   loader: file('content/roadmap.yml'),
@@ -74,10 +75,22 @@ const publicOnlineServices = defineCollection({
   }),
 });
 
+const publicStats = defineCollection({
+  loader: file('public/data/stats.json', {
+    parser: (text) => [
+      {
+        id: 'stats',
+        stats: parsePublicStatsDocument(JSON.parse(text) as unknown),
+      },
+    ],
+  }),
+});
+
 export const collections = {
   roadmap,
   changelog,
   publicPlaces,
   publicPlacePins,
   publicOnlineServices,
+  publicStats,
 };

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -14,7 +14,7 @@ const model = buildPublicStatsViewModel(stats);
 
 <BaseLayout
   title="Stats | CryptoPayMap"
-  description="Explore CryptoPayMap public dataset counts, payment routes, asset and network distribution, quality coverage, freshness, and public record changes."
+  description="Explore CryptoPayMap public dataset counts, payment routes, asset and network distribution, quality coverage, and freshness."
 >
   <main class="safe-area-inline page-container py-8 sm:py-12 lg:py-16">
     <header class="max-w-3xl">
@@ -23,7 +23,6 @@ const model = buildPublicStatsViewModel(stats);
       <p class="mt-4 text-base leading-7 text-muted">
         Stats describe the validated CryptoPayMap public dataset. They are not estimates of worldwide cryptocurrency adoption or merchant acceptance.
       </p>
-      <p class="mt-2 text-sm text-muted">Generated {model.stats.generatedAt}</p>
     </header>
 
     <div class="mt-10 grid gap-12">

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -1,0 +1,53 @@
+---
+import { readFile } from 'node:fs/promises';
+import StatsOverview from '../components/public/StatsOverview.astro';
+import StatsQuality from '../components/public/StatsQuality.astro';
+import StatsRankings from '../components/public/StatsRankings.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { buildPublicStatsViewModel, parsePublicStatsDocument } from '../public/stats';
+
+const statsUrl = new URL('../../public/data/stats.json', import.meta.url);
+const statsDocument = JSON.parse(await readFile(statsUrl, 'utf-8')) as unknown;
+const model = buildPublicStatsViewModel(parsePublicStatsDocument(statsDocument));
+---
+
+<BaseLayout
+  title="Stats | CryptoPayMap"
+  description="Explore CryptoPayMap public dataset counts, payment routes, asset and network distribution, quality coverage, freshness, and public record changes."
+>
+  <main class="safe-area-inline page-container py-8 sm:py-12 lg:py-16">
+    <header class="max-w-3xl">
+      <p class="m-0 text-sm font-semibold text-brand-700">Public dataset metrics</p>
+      <h1 class="mt-2 text-4xl font-semibold tracking-[-0.04em] text-ink sm:text-5xl">Stats</h1>
+      <p class="mt-4 text-base leading-7 text-muted">
+        Stats describe the validated CryptoPayMap public dataset. They are not estimates of worldwide cryptocurrency adoption or merchant acceptance.
+      </p>
+      <p class="mt-2 text-sm text-muted">Generated {model.stats.generatedAt}</p>
+    </header>
+
+    <div class="mt-10 grid gap-12">
+      <StatsOverview stats={model.stats} />
+
+      <section aria-labelledby="stats-distribution-title">
+        <p class="m-0 text-sm font-semibold text-brand-700">Distribution</p>
+        <h2 id="stats-distribution-title" class="mt-1 text-3xl font-semibold tracking-tight text-ink">
+          Assets and networks in public claims
+        </h2>
+        <div class="mt-6 grid gap-6 lg:grid-cols-2">
+          <StatsRankings
+            title="Top assets"
+            description="Entries appear only after the minimum public-record threshold is met. Rank numbers require the ranking threshold."
+            entries={model.topAssets}
+          />
+          <StatsRankings
+            title="Top networks"
+            description="Network distribution is based only on published claim payment combinations with explicit networks."
+            entries={model.topNetworks}
+          />
+        </div>
+      </section>
+
+      <StatsQuality stats={model.stats} />
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -1,14 +1,15 @@
 ---
-import { readFile } from 'node:fs/promises';
+import { getEntry } from 'astro:content';
 import StatsOverview from '../components/public/StatsOverview.astro';
 import StatsQuality from '../components/public/StatsQuality.astro';
 import StatsRankings from '../components/public/StatsRankings.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { buildPublicStatsViewModel, parsePublicStatsDocument } from '../public/stats';
 
-const statsUrl = new URL('../../public/data/stats.json', import.meta.url);
-const statsDocument = JSON.parse(await readFile(statsUrl, 'utf-8')) as unknown;
-const model = buildPublicStatsViewModel(parsePublicStatsDocument(statsDocument));
+const statsEntry = await getEntry('publicStats', 'stats');
+if (!statsEntry) throw new Error('Public Stats artifact is unavailable.');
+const stats = parsePublicStatsDocument((statsEntry.data as { stats: unknown }).stats);
+const model = buildPublicStatsViewModel(stats);
 ---
 
 <BaseLayout

--- a/src/public/stats.ts
+++ b/src/public/stats.ts
@@ -17,7 +17,7 @@ export interface PublicStatsViewModel {
 function buildDisplayEntries(entries: readonly PublicStatRankingEntry[]): PublicStatDisplayEntry[] {
   return [...entries]
     .filter((entry) => entry.count >= 3)
-    .sort((left, right) => right.count - left.count || left.slug.localeCompare(right.slug))
+    .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key))
     .map((entry, index) => ({
       ...entry,
       rank: entry.count >= 5 ? index + 1 : null,

--- a/src/public/stats.ts
+++ b/src/public/stats.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { publicStatsSchema } from '../schemas/public-exports';
+
+export type PublicStats = z.infer<typeof publicStatsSchema>;
+export type PublicStatRankingEntry = PublicStats['topAssets'][number];
+
+export interface PublicStatDisplayEntry extends PublicStatRankingEntry {
+  rank: number | null;
+}
+
+export interface PublicStatsViewModel {
+  stats: PublicStats;
+  topAssets: PublicStatDisplayEntry[];
+  topNetworks: PublicStatDisplayEntry[];
+}
+
+function buildDisplayEntries(entries: readonly PublicStatRankingEntry[]): PublicStatDisplayEntry[] {
+  return [...entries]
+    .filter((entry) => entry.count >= 3)
+    .sort((left, right) => right.count - left.count || left.slug.localeCompare(right.slug))
+    .map((entry, index) => ({
+      ...entry,
+      rank: entry.count >= 5 ? index + 1 : null,
+    }));
+}
+
+export function buildPublicStatsViewModel(stats: PublicStats): PublicStatsViewModel {
+  return {
+    stats,
+    topAssets: buildDisplayEntries(stats.topAssets),
+    topNetworks: buildDisplayEntries(stats.topNetworks),
+  };
+}
+
+export function parsePublicStatsDocument(value: unknown): PublicStats {
+  return publicStatsSchema.parse(value);
+}

--- a/tests/stats-model.test.ts
+++ b/tests/stats-model.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPublicStatsViewModel,
+  parsePublicStatsDocument,
+  type PublicStats,
+} from '../src/public/stats';
+
+const stats: PublicStats = {
+  schemaVersion: '1.0.0',
+  generatedAt: '2026-07-05T00:00:00Z',
+  counts: {
+    confirmedPhysicalPlaces: 10,
+    confirmedOnlineServices: 5,
+    countries: 4,
+    cities: 7,
+    staleRecords: 2,
+    endedRecords: 1,
+    directWalletClaims: 8,
+    processorCheckoutClaims: 7,
+  },
+  topAssets: [
+    { slug: 'bitcoin', count: 8 },
+    { slug: 'usdc', count: 4 },
+    { slug: 'xrp', count: 2 },
+  ],
+  topNetworks: [
+    { slug: 'lightning', count: 6 },
+    { slug: 'base', count: 3 },
+  ],
+  quality: {
+    howToPayCoverage: 1,
+    networkSpecifiedRate: 1,
+    evidenceBackedRate: 1,
+    reconfirmedWithin90Days: 0.8,
+    reconfirmedWithin180Days: 0.9,
+    staleRate: 0.1,
+  },
+  changes: {
+    newlyConfirmed: 3,
+    reconfirmed: 5,
+    markedStale: 1,
+    ended: 1,
+  },
+};
+
+describe('public Stats view model', () => {
+  it('enforces public display and ranking thresholds', () => {
+    const model = buildPublicStatsViewModel(stats);
+
+    expect(model.topAssets).toEqual([
+      { slug: 'bitcoin', count: 8, rank: 1 },
+      { slug: 'usdc', count: 4, rank: null },
+    ]);
+    expect(model.topNetworks).toEqual([
+      { slug: 'lightning', count: 6, rank: 1 },
+      { slug: 'base', count: 3, rank: null },
+    ]);
+  });
+
+  it('rejects private or non-contract fields in the public Stats document', () => {
+    expect(() => parsePublicStatsDocument({ ...stats, candidateCount: 500 })).toThrow();
+  });
+});

--- a/tests/stats-model.test.ts
+++ b/tests/stats-model.test.ts
@@ -6,41 +6,29 @@ import {
 } from '../src/public/stats';
 
 const stats: PublicStats = {
-  schemaVersion: '1.0.0',
-  generatedAt: '2026-07-05T00:00:00Z',
-  counts: {
-    confirmedPhysicalPlaces: 10,
-    confirmedOnlineServices: 5,
-    countries: 4,
-    cities: 7,
-    staleRecords: 2,
-    endedRecords: 1,
-    directWalletClaims: 8,
-    processorCheckoutClaims: 7,
-  },
+  confirmedPhysicalPlaces: 10,
+  confirmedOnlineServices: 5,
+  countries: 4,
+  cities: 7,
+  staleRecords: 2,
+  endedRecords: 1,
+  directWalletClaims: 8,
+  processorCheckoutClaims: 7,
+  howToPayCoverage: 1,
+  networkSpecifiedRate: 1,
+  evidenceBackedRate: 1,
+  reconfirmedWithin90Days: 0.8,
+  reconfirmedWithin180Days: 0.9,
+  staleRate: 0.1,
   topAssets: [
-    { slug: 'bitcoin', count: 8 },
-    { slug: 'usdc', count: 4 },
-    { slug: 'xrp', count: 2 },
+    { key: 'bitcoin', count: 8 },
+    { key: 'usdc', count: 4 },
+    { key: 'xrp', count: 2 },
   ],
   topNetworks: [
-    { slug: 'lightning', count: 6 },
-    { slug: 'base', count: 3 },
+    { key: 'lightning', count: 6 },
+    { key: 'base', count: 3 },
   ],
-  quality: {
-    howToPayCoverage: 1,
-    networkSpecifiedRate: 1,
-    evidenceBackedRate: 1,
-    reconfirmedWithin90Days: 0.8,
-    reconfirmedWithin180Days: 0.9,
-    staleRate: 0.1,
-  },
-  changes: {
-    newlyConfirmed: 3,
-    reconfirmed: 5,
-    markedStale: 1,
-    ended: 1,
-  },
 };
 
 describe('public Stats view model', () => {
@@ -48,12 +36,12 @@ describe('public Stats view model', () => {
     const model = buildPublicStatsViewModel(stats);
 
     expect(model.topAssets).toEqual([
-      { slug: 'bitcoin', count: 8, rank: 1 },
-      { slug: 'usdc', count: 4, rank: null },
+      { key: 'bitcoin', count: 8, rank: 1 },
+      { key: 'usdc', count: 4, rank: null },
     ]);
     expect(model.topNetworks).toEqual([
-      { slug: 'lightning', count: 6, rank: 1 },
-      { slug: 'base', count: 3, rank: null },
+      { key: 'lightning', count: 6, rank: 1 },
+      { key: 'base', count: 3, rank: null },
     ]);
   });
 


### PR DESCRIPTION
## Implementation item
P4-11A.

## Scope
Add the public Stats artifact, model, and static Stats surface using only validated public metrics.

## Included
- schema-validated public Stats artifact
- public dataset overview counts
- Direct wallet and Processor checkout claim counts
- threshold-aware asset and network displays
- data quality and freshness metrics
- no Candidate counts, review queues, or internal source metrics
- threshold and privacy-boundary tests

## Validation
In progress through Foundation validation and Migration drift.