### PR TITLE
CI: keep review environment synced with main

### DIFF
--- a/.github/workflows/staging-review-deploy.yml
+++ b/.github/workflows/staging-review-deploy.yml
@@ -4,27 +4,21 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - staging-review
+      - main
 
 concurrency:
   group: staging-review-deploy
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
-    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
-    env:
-      PUBLIC_MAP_STYLE_URL: https://demotiles.maplibre.org/style.json
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          ref: staging-review
-          fetch-depth: 0
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -67,7 +61,7 @@ jobs:
           DEPLOY_COMMIT: ${{ github.sha }}
         run: |
           node <<'NODE'
-          const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+          const { existsSync, readFileSync, mkdirSync, writeFileSync } = require('node:fs');
           const credentials = process.env.CREDENTIALS_OUTCOME;
           const deploy = process.env.DEPLOY_OUTCOME;
           const status = credentials !== 'success' ? 'missing_credentials' : deploy === 'success' ? 'deployed' : 'deploy_failed';
@@ -76,20 +70,21 @@ jobs:
           const receipt = {
             status,
             commit: process.env.DEPLOY_COMMIT,
-            url: urls.at(-1) ?? null,
+            url: urls.at(-1) ?? 'https://review.cryptopaymap-staging.pages.dev',
             generatedAt: new Date().toISOString(),
           };
-          writeFileSync('config/staging-review/deployment-receipt.json', `${JSON.stringify(receipt, null, 2)}\n`);
+          mkdirSync('staging-review-receipt', { recursive: true });
+          writeFileSync('staging-review-receipt/deployment-receipt.json', `${JSON.stringify(receipt, null, 2)}\n`);
           NODE
 
-      - name: Publish deployment receipt
+      - name: Upload deployment receipt
         if: always()
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add config/staging-review/deployment-receipt.json
-          git commit -m "STG-01: record staging deployment result"
-          git push origin HEAD:staging-review
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-review-deployment-receipt
+          path: staging-review-receipt/deployment-receipt.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Enforce successful deployment
         if: always()

--- a/.github/workflows/staging-review-validation.yml
+++ b/.github/workflows/staging-review-validation.yml
@@ -22,8 +22,6 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-24.04
-    env:
-      PUBLIC_MAP_STYLE_URL: https://demotiles.maplibre.org/style.json
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The fixed review URL was not updating after normal merges because `Staging review deploy` only ran on pushes to `staging-review`, while pull requests only ran artifact validation. The review build also forced the MapLibre demo style, masking the new default map style.

## Changes

- deploy the staging review environment on every push to `main`;
- check out the actual triggering `main` commit instead of the legacy `staging-review` branch;
- keep deploying to Cloudflare Pages branch `review`, so the user-facing review URL remains fixed;
- remove the forced demo map-style override from deploy and validation workflows;
- store deployment receipts as workflow artifacts instead of bot commits to `staging-review`;
- keep deployment failure fail-closed.

## Expected behavior

After merge, the push to `main` builds the staging review artifact and updates `https://review.cryptopaymap-staging.pages.dev/` automatically.