### PR TITLE
CI: publish observable review deployment receipt

### DIFF
--- a/.github/workflows/staging-review-deploy.yml
+++ b/.github/workflows/staging-review-deploy.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   deploy:
@@ -85,6 +85,21 @@ jobs:
           path: staging-review-receipt/deployment-receipt.json
           if-no-files-found: error
           retention-days: 30
+
+      - name: Publish deployment receipt to status branch
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          CONTENT="$(base64 -w 0 staging-review-receipt/deployment-receipt.json)"
+          CURRENT_SHA="$(gh api "repos/$REPOSITORY/contents/config/staging-review/deployment-receipt.json?ref=staging-review" --jq '.sha')"
+          gh api --method PUT "repos/$REPOSITORY/contents/config/staging-review/deployment-receipt.json" \
+            -f message='STG-01: record staging deployment result' \
+            -f content="$CONTENT" \
+            -f sha="$CURRENT_SHA" \
+            -f branch='staging-review'
 
       - name: Enforce successful deployment
         if: always()


### PR DESCRIPTION
## Problem

The review deploy receipt was retained only as a workflow artifact, making it difficult to confirm from repository state which `main` commit is actually deployed to the fixed review URL.

## Changes

- grant the deploy workflow repository write permission;
- keep the receipt artifact upload;
- publish the latest deployment receipt to `config/staging-review/deployment-receipt.json` on the `staging-review` status branch;
- keep deploy triggering only from `main`, so status receipt commits do not cause deployment loops.

## Expected result

After each `main` deployment, the status branch records deployment status, deployed commit SHA, fixed review URL, and timestamp.