### PR TITLE
QA: add representative visual capture scenarios

### DIFF
--- a/.github/workflows/capture-review-screenshots.yml
+++ b/.github/workflows/capture-review-screenshots.yml
@@ -1,0 +1,86 @@
+name: Capture representative review screenshots
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/capture-review-screenshots.yml'
+      - 'scripts/capture-review-screenshots.mjs'
+      - 'scripts/staging-review-data.ts'
+      - 'scripts/materialize-staging-review-data.mjs'
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      CAPTURE_BASE_URL: http://127.0.0.1:4173
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Install screenshot runtime
+        run: |
+          npm install --no-save --package-lock=false playwright@1.57.0
+          npx playwright install --with-deps chromium
+
+      - name: Build staging review site
+        run: npm run staging:review:build
+
+      - name: Start local review site
+        run: |
+          python3 -m http.server 4173 --directory dist > /tmp/cpm-review-screenshot-server.log 2>&1 &
+          echo $! > /tmp/cpm-review-screenshot-server.pid
+          for attempt in $(seq 1 30); do
+            if curl -fsS "$CAPTURE_BASE_URL/" > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat /tmp/cpm-review-screenshot-server.log
+          exit 1
+
+      - name: Capture desktop and mobile scenarios
+        run: |
+          node scripts/capture-review-screenshots.mjs \
+            --device all \
+            --base-url "$CAPTURE_BASE_URL"
+
+      - name: Upload screenshot artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpm-review-screenshots-${{ github.run_id }}
+          path: artifacts/review-screenshots/**
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Write capture summary
+        if: always()
+        run: |
+          echo '## CryptoPayMap representative screenshot capture' >> "$GITHUB_STEP_SUMMARY"
+          for DEVICE in desktop mobile; do
+            MANIFEST="artifacts/review-screenshots/manifest.$DEVICE.json"
+            if [ -f "$MANIFEST" ]; then
+              CAPTURED=$(node -e "const x=require('./$MANIFEST'); console.log(x.capturedCount)")
+              FAILED=$(node -e "const x=require('./$MANIFEST'); console.log(x.failedCount)")
+              echo "- $DEVICE: $CAPTURED captured / $FAILED failed" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          echo '- Interactive states include menu open, filters open, list mode, Place sheet peek, Place sheet expanded, selected desktop panel, and Gallery lightbox.' >> "$GITHUB_STEP_SUMMARY"

--- a/docs/LEGACY_PLACE_FIELD_PARITY.md
+++ b/docs/LEGACY_PLACE_FIELD_PARITY.md
@@ -1,0 +1,82 @@
+# Legacy Place field parity baseline
+
+**Status:** Internal implementation reference  
+**Recorded:** 2026-07-08
+
+This document records the practical Place fields exposed by the previous CryptoPayMap v2 map/public model and maps them to the current v3 public contract. It prevents practical merchant information from disappearing during schema or UI work.
+
+## Legacy v2 record surface
+
+The previous repository defined the following Place fields in `types/places.ts`:
+
+- identity and classification: `id`, `name`, `category`, `verification`;
+- coordinates and locality: `lat`, `lng`, `country`, `city`, `address_full`;
+- payment summary: `supported_crypto` and legacy `accepted`;
+- practical contact fields: `website`, `phone`, `twitter`, `instagram`, `facebook`;
+- public descriptive fields: `description`, `about`, `about_short`, `amenities`, `paymentNote`;
+- media fields: `photos`, `images`, `coverImage`;
+- compatibility and operational fields: `address`, `social_website`, `social_twitter`, `social_instagram`, `submitterName`, `updatedAt`.
+
+The previous map DTO `PlaceSummaryPlus` explicitly projected:
+
+- `address_full`;
+- `about_short`;
+- `paymentNote`;
+- `amenities`;
+- `phone`;
+- `website`;
+- `twitter`;
+- `instagram`;
+- `facebook`;
+- `coverImage`.
+
+The old v2 database projection also read contact values from the `socials` table, including `website`, `phone`, `twitter`/`x`, `instagram`, and `facebook`, and fell back to legacy JSON fields when the DB projection did not provide them.
+
+## Current v3 public equivalents
+
+The current `publicPlaceSchema` supports:
+
+- identity and classification: `placeSlug`, `entitySlug`, `name`, `categorySlug`, entity/location status;
+- full location structure: `addressLine`, `locality`, `region`, `postalCode`, `countryCode`, latitude and longitude;
+- practical contact fields: `websiteUrl`, optional `phone`, and structured `socialLinks`;
+- public profile fields: optional `description`, `openingHours`, and `amenities`;
+- structured payment information: `claims`, `paymentAssets`, `paymentMethod`, route type, processor, merchant receipt state, instructions, restrictions, freshness, and Evidence;
+- public media: `media` with role, URL, dimensions, alt text, attribution, and license metadata;
+- field provenance: `provenance`.
+
+## Required parity rule
+
+A field does not count as recovered merely because the schema allows it. Representative review data and selected-Place surfaces must exercise practical information that a real user needs.
+
+At least one staging review Place must therefore include and visibly exercise:
+
+1. full street address and postal code;
+2. phone number;
+3. website;
+4. at least one social link;
+5. description/about text;
+6. opening hours;
+7. amenities;
+8. public Gallery media;
+9. payment assets and networks;
+10. payment method and route;
+11. merchant receipt state;
+12. How to pay instructions;
+13. restrictions when applicable;
+14. freshness status;
+15. Google Maps and Apple Maps navigation.
+
+Flat legacy fields such as `accepted`, `supported_crypto`, and individual social-network columns must not be reintroduced merely for shape parity. Their current structured v3 equivalents are the canonical representation.
+
+`submitterName` is also not a public parity requirement. Submission identity and review provenance are governed by the v3 candidate, Evidence, administration, privacy, and public-projection boundaries.
+
+## Visual review requirement
+
+The representative screenshot workflow must capture the practical Place surface in these states:
+
+- desktop selected Place panel;
+- mobile sheet peek;
+- mobile sheet expanded;
+- Gallery lightbox.
+
+The screenshot set must also include mobile Menu open, mobile Places Filters open, Places List mode, and representative static public pages so layout and navigation regressions can be reviewed from one artifact set.

--- a/scripts/capture-review-screenshots.mjs
+++ b/scripts/capture-review-screenshots.mjs
@@ -28,7 +28,6 @@ const COMMON_SCENARIOS = [
   ['service-detail', '/service/staging-vpn'],
   ['stats', '/stats'],
   ['updates', '/updates'],
-  ['contribute', '/contribute'],
   ['about', '/about'],
   ['methodology', '/methodology'],
   ['sources-and-licenses', '/sources-and-licenses'],

--- a/scripts/capture-review-screenshots.mjs
+++ b/scripts/capture-review-screenshots.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+import { mkdir, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+const ROOT = process.cwd();
+const OUTPUT_ROOT = path.join(ROOT, 'artifacts', 'review-screenshots');
+const DEFAULT_BASE_URL = 'http://127.0.0.1:4173';
+const STAGING_PLACE_NAME = 'Staging Coffee Tokyo';
+
+const DEVICES = {
+  desktop: {
+    viewport: { width: 1440, height: 900 },
+  },
+  mobile: {
+    viewport: { width: 393, height: 852 },
+    isMobile: true,
+    hasTouch: true,
+  },
+};
+
+const COMMON_SCENARIOS = [
+  ['home', '/'],
+  ['places-default', '/places'],
+  ['online-index', '/online'],
+  ['place-detail', '/place/staging-coffee-tokyo'],
+  ['service-detail', '/service/staging-vpn'],
+  ['stats', '/stats'],
+  ['updates', '/updates'],
+  ['contribute', '/contribute'],
+  ['about', '/about'],
+  ['methodology', '/methodology'],
+  ['sources-and-licenses', '/sources-and-licenses'],
+  ['data', '/data'],
+  ['roadmap', '/roadmap'],
+  ['changelog', '/changelog'],
+  ['support', '/support'],
+  ['partners', '/partners'],
+].map(([id, route]) => ({ id, route, action: 'none', fullPage: true }));
+
+const DESKTOP_SCENARIOS = [
+  {
+    id: 'places-selected',
+    route: '/places',
+    action: 'select-place-desktop',
+    fullPage: true,
+  },
+];
+
+const MOBILE_SCENARIOS = [
+  {
+    id: 'home-menu-open',
+    route: '/',
+    action: 'open-mobile-menu',
+    fullPage: false,
+  },
+  {
+    id: 'places-filters-open',
+    route: '/places',
+    action: 'open-filters',
+    fullPage: false,
+  },
+  {
+    id: 'places-list',
+    route: '/places',
+    action: 'show-list',
+    fullPage: true,
+  },
+  {
+    id: 'places-sheet-peek',
+    route: '/places',
+    action: 'select-place-mobile',
+    fullPage: false,
+  },
+  {
+    id: 'places-sheet-expanded',
+    route: '/places',
+    action: 'expand-place-sheet',
+    fullPage: false,
+  },
+  {
+    id: 'places-gallery-lightbox',
+    route: '/places',
+    action: 'open-place-gallery',
+    fullPage: false,
+  },
+];
+
+function argValue(name, fallback) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+function scenariosForDevice(deviceName) {
+  return [
+    ...COMMON_SCENARIOS,
+    ...(deviceName === 'desktop' ? DESKTOP_SCENARIOS : MOBILE_SCENARIOS),
+  ];
+}
+
+async function settle(page) {
+  await page.evaluate(async () => {
+    await document.fonts?.ready;
+  });
+  await page.waitForTimeout(500);
+}
+
+async function gotoScenario(page, baseUrl, route) {
+  const response = await page.goto(`${baseUrl}${route}`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  if (!response || !response.ok()) {
+    throw new Error(`HTTP ${response?.status() ?? 'no response'} for ${route}`);
+  }
+  await settle(page);
+}
+
+async function showPlacesList(page) {
+  await page.getByRole('button', { name: 'List', exact: true }).click();
+  await page.getByRole('list', { name: 'Place results' }).waitFor({ state: 'visible' });
+  await settle(page);
+}
+
+async function selectPlaceFromList(page) {
+  await showPlacesList(page);
+  await page
+    .getByRole('button', { name: `Select ${STAGING_PLACE_NAME} on map`, exact: true })
+    .click();
+}
+
+async function runAction(page, action) {
+  switch (action) {
+    case 'none':
+      return;
+    case 'open-mobile-menu':
+      await page.getByRole('button', { name: 'Menu', exact: true }).click();
+      await page.getByLabel('Mobile primary').waitFor({ state: 'visible' });
+      break;
+    case 'open-filters':
+      await page.getByRole('button', { name: 'Filters', exact: true }).first().click();
+      await page.getByLabel('Place filters').waitFor({ state: 'visible' });
+      break;
+    case 'show-list':
+      await showPlacesList(page);
+      break;
+    case 'select-place-mobile':
+      await selectPlaceFromList(page);
+      await page
+        .locator('[data-sheet-state="peek"][data-sheet-entered="true"]')
+        .waitFor({ state: 'visible' });
+      break;
+    case 'expand-place-sheet':
+      await selectPlaceFromList(page);
+      await page
+        .locator('[data-sheet-state="peek"][data-sheet-entered="true"]')
+        .waitFor({ state: 'visible' });
+      await page.getByRole('button', { name: 'Expand place details', exact: true }).click();
+      await page.locator('[data-sheet-state="expanded"]').waitFor({ state: 'visible' });
+      break;
+    case 'open-place-gallery':
+      await selectPlaceFromList(page);
+      await page
+        .locator('[data-sheet-state="peek"][data-sheet-entered="true"]')
+        .waitFor({ state: 'visible' });
+      await page.getByRole('button', { name: 'Expand place details', exact: true }).click();
+      await page.locator('[data-sheet-state="expanded"]').waitFor({ state: 'visible' });
+      await page.getByRole('button', { name: /Enlarge image 1 of/ }).click();
+      await page.getByRole('dialog', { name: /Image viewer:/ }).waitFor({ state: 'visible' });
+      break;
+    case 'select-place-desktop':
+      await page
+        .getByRole('button', { name: `Select ${STAGING_PLACE_NAME} on map`, exact: true })
+        .click();
+      await page
+        .getByRole('complementary', { name: `Selected place details: ${STAGING_PLACE_NAME}` })
+        .waitFor({ state: 'visible' });
+      break;
+    default:
+      throw new Error(`Unknown screenshot action: ${action}`);
+  }
+  await settle(page);
+}
+
+async function measurePage(page) {
+  return page.evaluate(() => {
+    const root = document.documentElement;
+    return {
+      title: document.title,
+      h1Count: document.querySelectorAll('h1').length,
+      mainCount: document.querySelectorAll('main').length,
+      horizontalOverflowPx: Math.max(0, root.scrollWidth - root.clientWidth),
+      bodyHeight: Math.round(document.body.getBoundingClientRect().height),
+      viewportWidth: root.clientWidth,
+      viewportHeight: root.clientHeight,
+      menuOpen:
+        document.querySelector('#mobile-primary-menu')?.getAttribute('aria-hidden') === 'false',
+      filterPanelOpen: Boolean(document.querySelector('[aria-label="Place filters"]')),
+      placeSheetState:
+        document.querySelector('[data-sheet-state]')?.getAttribute('data-sheet-state') ?? null,
+      dialogOpen: Boolean(document.querySelector('[role="dialog"][aria-modal="true"]')),
+    };
+  });
+}
+
+async function captureDevice(browser, deviceName, baseUrl) {
+  const device = DEVICES[deviceName];
+  const outputDir = path.join(OUTPUT_ROOT, deviceName);
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  const context = await browser.newContext({
+    viewport: device.viewport,
+    deviceScaleFactor: 1,
+    isMobile: device.isMobile ?? false,
+    hasTouch: device.hasTouch ?? false,
+    reducedMotion: 'reduce',
+    colorScheme: 'light',
+  });
+  const page = await context.newPage();
+  const records = [];
+  const failures = [];
+
+  for (const scenario of scenariosForDevice(deviceName)) {
+    const file = path.join(outputDir, `${scenario.id}.png`);
+    try {
+      await gotoScenario(page, baseUrl, scenario.route);
+      await runAction(page, scenario.action);
+      const metrics = await measurePage(page);
+      await page.screenshot({
+        path: file,
+        fullPage: scenario.fullPage,
+        animations: 'disabled',
+      });
+      records.push({
+        id: scenario.id,
+        route: scenario.route,
+        action: scenario.action,
+        fullPage: scenario.fullPage,
+        file,
+        screenshotBytes: (await stat(file)).size,
+        metrics,
+      });
+      console.log(`[${deviceName}] captured ${scenario.id}`);
+    } catch (error) {
+      failures.push({
+        id: scenario.id,
+        route: scenario.route,
+        action: scenario.action,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      console.error(`[${deviceName}] failed ${scenario.id}: ${failures.at(-1).error}`);
+    }
+  }
+
+  await context.close();
+  const manifest = {
+    schemaVersion: '1.0',
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    device: deviceName,
+    viewport: device.viewport,
+    scenarioCount: records.length + failures.length,
+    capturedCount: records.length,
+    failedCount: failures.length,
+    records,
+    failures,
+  };
+  await writeFile(
+    path.join(OUTPUT_ROOT, `manifest.${deviceName}.json`),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  if (failures.length > 0) {
+    throw new Error(`${deviceName} screenshot capture failed for ${failures.length} scenario(s).`);
+  }
+}
+
+async function main() {
+  const baseUrl = argValue(
+    'base-url',
+    process.env.CPM_SCREENSHOT_BASE_URL ?? DEFAULT_BASE_URL,
+  ).replace(/\/$/, '');
+  const deviceName = argValue('device', 'all');
+  const selectedDevices = deviceName === 'all' ? Object.keys(DEVICES) : [deviceName];
+  for (const selected of selectedDevices) {
+    if (!DEVICES[selected]) throw new Error(`Unsupported device: ${selected}`);
+  }
+
+  await mkdir(OUTPUT_ROOT, { recursive: true });
+  const browser = await chromium.launch();
+  try {
+    for (const selected of selectedDevices) {
+      await captureDevice(browser, selected, baseUrl);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/capture-review-screenshots.mjs
+++ b/scripts/capture-review-screenshots.mjs
@@ -34,6 +34,10 @@ const COMMON_SCENARIOS = [
   ['data', '/data'],
   ['roadmap', '/roadmap'],
   ['changelog', '/changelog'],
+  ['privacy', '/privacy'],
+  ['terms', '/terms'],
+  ['disclaimer', '/disclaimer'],
+  ['contact', '/contact'],
   ['support', '/support'],
   ['partners', '/partners'],
 ].map(([id, route]) => ({ id, route, action: 'none', fullPage: true }));
@@ -98,11 +102,17 @@ function scenariosForDevice(deviceName) {
   ];
 }
 
-async function settle(page) {
+async function settle(page, delayMs = 1_000) {
   await page.evaluate(async () => {
     await document.fonts?.ready;
   });
-  await page.waitForTimeout(500);
+  await page.waitForTimeout(delayMs);
+}
+
+async function waitForPlacesMap(page) {
+  const loading = page.getByText('Loading map...', { exact: true });
+  await loading.waitFor({ state: 'hidden', timeout: 20_000 }).catch(() => {});
+  await page.waitForTimeout(1_500);
 }
 
 async function gotoScenario(page, baseUrl, route) {
@@ -114,6 +124,7 @@ async function gotoScenario(page, baseUrl, route) {
     throw new Error(`HTTP ${response?.status() ?? 'no response'} for ${route}`);
   }
   await settle(page);
+  if (route === '/places') await waitForPlacesMap(page);
 }
 
 async function showPlacesList(page) {
@@ -129,13 +140,24 @@ async function selectPlaceFromList(page) {
     .click();
 }
 
+async function expandPlaceSheet(page) {
+  await selectPlaceFromList(page);
+  const peekSheet = page.locator('[data-sheet-state="peek"][data-sheet-entered="true"]');
+  await peekSheet.waitFor({ state: 'visible' });
+  const expandButton = page.getByRole('button', { name: 'Expand place details', exact: true });
+  await expandButton.evaluate((button) => button.click());
+  await page.locator('[data-sheet-state="expanded"]').waitFor({ state: 'visible' });
+}
+
 async function runAction(page, action) {
   switch (action) {
     case 'none':
       return;
     case 'open-mobile-menu':
       await page.getByRole('button', { name: 'Menu', exact: true }).click();
-      await page.getByLabel('Mobile primary').waitFor({ state: 'visible' });
+      await page
+        .getByRole('complementary', { name: 'Mobile primary', exact: true })
+        .waitFor({ state: 'visible' });
       break;
     case 'open-filters':
       await page.getByRole('button', { name: 'Filters', exact: true }).first().click();
@@ -151,23 +173,15 @@ async function runAction(page, action) {
         .waitFor({ state: 'visible' });
       break;
     case 'expand-place-sheet':
-      await selectPlaceFromList(page);
-      await page
-        .locator('[data-sheet-state="peek"][data-sheet-entered="true"]')
-        .waitFor({ state: 'visible' });
-      await page.getByRole('button', { name: 'Expand place details', exact: true }).click();
-      await page.locator('[data-sheet-state="expanded"]').waitFor({ state: 'visible' });
+      await expandPlaceSheet(page);
       break;
-    case 'open-place-gallery':
-      await selectPlaceFromList(page);
-      await page
-        .locator('[data-sheet-state="peek"][data-sheet-entered="true"]')
-        .waitFor({ state: 'visible' });
-      await page.getByRole('button', { name: 'Expand place details', exact: true }).click();
-      await page.locator('[data-sheet-state="expanded"]').waitFor({ state: 'visible' });
-      await page.getByRole('button', { name: /Enlarge image 1 of/ }).click();
+    case 'open-place-gallery': {
+      await expandPlaceSheet(page);
+      const imageButton = page.getByRole('button', { name: /Enlarge image 1 of/ }).first();
+      await imageButton.evaluate((button) => button.click());
       await page.getByRole('dialog', { name: /Image viewer:/ }).waitFor({ state: 'visible' });
       break;
+    }
     case 'select-place-desktop':
       await page
         .getByRole('button', { name: `Select ${STAGING_PLACE_NAME} on map`, exact: true })
@@ -179,12 +193,16 @@ async function runAction(page, action) {
     default:
       throw new Error(`Unknown screenshot action: ${action}`);
   }
-  await settle(page);
+  await settle(page, 1_500);
 }
 
 async function measurePage(page) {
   return page.evaluate(() => {
     const root = document.documentElement;
+    const sheet = document.querySelector('[data-sheet-state]');
+    const map = document.querySelector('.maplibregl-canvas');
+    const sheetRect = sheet?.getBoundingClientRect();
+    const mapRect = map?.getBoundingClientRect();
     return {
       title: document.title,
       h1Count: document.querySelectorAll('h1').length,
@@ -196,8 +214,23 @@ async function measurePage(page) {
       menuOpen:
         document.querySelector('#mobile-primary-menu')?.getAttribute('aria-hidden') === 'false',
       filterPanelOpen: Boolean(document.querySelector('[aria-label="Place filters"]')),
-      placeSheetState:
-        document.querySelector('[data-sheet-state]')?.getAttribute('data-sheet-state') ?? null,
+      placeSheetState: sheet?.getAttribute('data-sheet-state') ?? null,
+      placeSheetRect: sheetRect
+        ? {
+            top: Math.round(sheetRect.top),
+            bottom: Math.round(sheetRect.bottom),
+            height: Math.round(sheetRect.height),
+          }
+        : null,
+      placeSheetZIndex: sheet ? getComputedStyle(sheet).zIndex : null,
+      mapRect: mapRect
+        ? {
+            top: Math.round(mapRect.top),
+            bottom: Math.round(mapRect.bottom),
+            height: Math.round(mapRect.height),
+          }
+        : null,
+      mapZIndex: map ? getComputedStyle(map).zIndex : null,
       dialogOpen: Boolean(document.querySelector('[role="dialog"][aria-modal="true"]')),
     };
   });

--- a/scripts/materialize-staging-review-data.mjs
+++ b/scripts/materialize-staging-review-data.mjs
@@ -55,11 +55,29 @@ const serviceGallery = publicMedia(
   'Abstract synthetic gallery artwork for the staging Online Service review record',
 );
 
+mediaPlace.addressLine = '1-1 Marunouchi, Chiyoda City';
+mediaPlace.postalCode = '100-0005';
+mediaPlace.phone = '+81 3 0000 0000';
 mediaPlace.description =
   'Synthetic staging café profile used to review practical Place information in selected surfaces.';
 mediaPlace.openingHours = 'Mon–Fri 08:00–18:00\nSat–Sun 09:00–17:00';
 mediaPlace.amenities = ['wifi', 'outdoor-seating'];
-mediaPlace.provenance[0]?.fields.push('description', 'openingHours', 'amenities');
+mediaPlace.socialLinks = [
+  {
+    platform: 'instagram',
+    url: 'https://example.com/staging/social/staging-coffee-tokyo',
+    handle: '@stagingcoffee',
+  },
+];
+mediaPlace.provenance[0]?.fields.push(
+  'addressLine',
+  'postalCode',
+  'phone',
+  'description',
+  'openingHours',
+  'amenities',
+  'socialLinks',
+);
 mediaPlace.media = [placeCover, placeGallery];
 mediaPin.thumbnail = placeCover;
 mediaService.media = [serviceCover, serviceGallery];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import { ClientRouter } from 'astro:transitions';
 import SiteFooter from '../components/SiteFooter.astro';
 import SiteHeader from '../components/SiteHeader.astro';
 import '../styles/global.css';
+import '../styles/visual-recovery.css';
 
 interface Props {
   title: string;

--- a/src/styles/visual-recovery.css
+++ b/src/styles/visual-recovery.css
@@ -1,0 +1,10 @@
+html,
+body {
+  overflow-x: clip;
+}
+
+[data-sheet-state] {
+  z-index: 60;
+  isolation: isolate;
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Purpose

Make CryptoPayMap visually reviewable from GitHub Actions, including interactive mobile states that cannot be inspected from route-only screenshots.

## Included

- Playwright capture script for representative desktop and mobile public pages;
- full-page captures for representative static routes;
- viewport captures for interactive states:
  - mobile Menu open;
  - Places Filters sheet open;
  - Places List mode;
  - Place sheet peek;
  - Place sheet expanded;
  - Gallery lightbox;
  - desktop selected Place panel;
- GitHub Actions workflow that builds the staging review dataset locally, captures both device sets, writes manifests, and uploads screenshots as retained artifacts;
- legacy v2 Place field parity baseline;
- staging review fixture coverage for full address, postal code, phone, website, social link, description, opening hours, amenities, and Gallery media.

## Reason

The current review process exposed two gaps:

1. visual defects can be numerous and difficult to enumerate from ad hoc phone screenshots;
2. the review fixture did not exercise address and phone despite the current public schema and selected surfaces supporting them.

The new capture artifact is intended to let visual review start from a stable representative screen set rather than user-reported screenshots one issue at a time.