### PR TITLE
UX: repair selected Place focus and panel containment

### DIFF
--- a/src/components/places/PlacesMap.tsx
+++ b/src/components/places/PlacesMap.tsx
@@ -29,7 +29,7 @@ const mapLoadTimeoutMs = 12_000;
 
 const confirmedPinColor = [5, 150, 105] as const;
 const stalePinColor = [217, 119, 6] as const;
-const selectedPinHaloColor = [15, 118, 110] as const;
+const selectedPinAccentColor = [15, 95, 89] as const;
 const white = [255, 255, 255] as const;
 
 type Rgb = readonly [number, number, number];
@@ -103,18 +103,15 @@ function createPlacePinImage(fill: Rgb, selected: boolean) {
       const offset = (y * width + x) * 4;
       if (!pinShapeContains(x, y, 0)) continue;
 
-      if (selected) {
-        setPixel(data, offset, selectedPinHaloColor);
-        if (pinShapeContains(x, y, 4)) setPixel(data, offset, white);
-        if (pinShapeContains(x, y, 8)) setPixel(data, offset, fill);
-      } else {
-        setPixel(data, offset, white);
-        if (pinShapeContains(x, y, 4)) setPixel(data, offset, fill);
-      }
+      setPixel(data, offset, white);
+      if (pinShapeContains(x, y, 4)) setPixel(data, offset, fill);
 
       const dx = x - 32;
       const dy = y - 28;
       if (dx * dx + dy * dy <= 7.5 * 7.5) setPixel(data, offset, white);
+      if (selected && dx * dx + dy * dy <= 3.25 * 3.25) {
+        setPixel(data, offset, selectedPinAccentColor);
+      }
     }
   }
 
@@ -180,7 +177,7 @@ function addPlaceLayers(map: MapLibreMap, data: ReturnType<typeof buildPlaceMapF
     filter: ['!', ['has', 'point_count']],
     layout: {
       'icon-image': pinImageExpression(),
-      'icon-size': ['case', ['==', ['get', 'selected'], true], 1.12, 1],
+      'icon-size': ['case', ['==', ['get', 'selected'], true], 1.18, 1],
       'icon-anchor': 'bottom',
       'icon-allow-overlap': true,
       'icon-ignore-placement': true,
@@ -221,6 +218,8 @@ export function PlacesMap({
   const committedViewportRef = useRef(committedViewport);
   const pinsRef = useRef(pins);
   const selectedPlaceRef = useRef(selectedPlace);
+  const initialSelectedPlaceRef = useRef(selectedPlace);
+  const lastFocusedSelectedPlaceRef = useRef<string | null>(null);
   const focusMovePendingRef = useRef(false);
   const [runtimeState, setRuntimeState] = useState<RuntimeState>('loading');
   const featureCollection = useMemo(
@@ -412,14 +411,35 @@ export function PlacesMap({
 
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || runtimeState !== 'ready' || !selectedPlace) return;
+    if (!map || runtimeState !== 'ready') return;
+    if (!selectedPlace) {
+      lastFocusedSelectedPlaceRef.current = null;
+      return;
+    }
+    if (lastFocusedSelectedPlaceRef.current === selectedPlace) return;
+
     const selectedPin = pins.find((pin) => pin.placeSlug === selectedPlace);
     if (!selectedPin) return;
+
+    const initialSelectionWithCommittedViewport =
+      lastFocusedSelectedPlaceRef.current === null &&
+      initialSelectedPlaceRef.current === selectedPlace &&
+      committedViewportRef.current !== null;
+    lastFocusedSelectedPlaceRef.current = selectedPlace;
+    if (initialSelectionWithCommittedViewport) return;
+
     const current = map.getCenter();
     const alreadyCentered =
       Math.abs(current.lat - selectedPin.latitude) < 0.000001 &&
       Math.abs(current.lng - selectedPin.longitude) < 0.000001;
-    if (!alreadyCentered) map.easeTo({ center: [selectedPin.longitude, selectedPin.latitude] });
+    const targetZoom = Math.max(map.getZoom(), selectedPlaceInitialZoom);
+    const needsZoom = map.getZoom() < selectedPlaceInitialZoom;
+    if (!alreadyCentered || needsZoom) {
+      map.easeTo({
+        center: [selectedPin.longitude, selectedPin.latitude],
+        zoom: targetZoom,
+      });
+    }
   }, [pins, runtimeState, selectedPlace]);
 
   return (

--- a/src/styles/visual-recovery.css
+++ b/src/styles/visual-recovery.css
@@ -8,3 +8,9 @@ body {
   isolation: isolate;
   pointer-events: auto;
 }
+
+@media (min-width: 64rem) {
+  aside[aria-label^='Selected place details:'] {
+    height: 100%;
+  }
+}

--- a/src/styles/visual-recovery.css
+++ b/src/styles/visual-recovery.css
@@ -10,7 +10,7 @@ body {
 }
 
 @media (min-width: 64rem) {
-  aside[aria-label^='Selected place details:'] {
+  aside[aria-label^="Selected place details:"] {
     height: 100%;
   }
 }


### PR DESCRIPTION
## Problems found from representative screenshot audit

The first visual artifact exposed two Places regressions:

1. selecting a Place from the broad map state only recentered the map without raising zoom, so the selected record could remain hidden inside a cluster;
2. the desktop selected panel was not constrained to the discovery grid height, so its content painted beyond the normal page flow and over the footer area.

The user also reported that the selected marker silhouette was visually poor.

## Changes

- focus a newly selected Place at at least zoom 13 while preserving higher existing zoom;
- preserve committed URL viewport precedence for an initial restored selection;
- simplify selected marker rendering so it uses the same clean pin silhouette as normal markers, with larger scale and a small center accent instead of the previous thick teal/white/colored triple silhouette;
- constrain the desktop selected panel to its grid height so the existing internal scroll container handles long practical/payment content.

## Visual validation

The representative screenshot workflow runs on this PR and must verify the selected desktop map/panel and mobile interaction states alongside the normal Foundation, migration, and staging review checks.