### PR TITLE
P4-18A: establish closure and Phase 5 execution contracts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,16 @@
 ## Implementation item
 
-<!-- Example: P0-01, P1-03, FIX-P1-001 -->
+<!-- Example: P4-18B2, P5-03, FIX-P1-001 -->
 
 `ITEM-ID`
+
+## Required references read
+
+<!-- List the active status, plan, closure, and feature specifications used for this change. -->
+
+- `docs/PROJECT_STATUS.md`
+- `docs/IMPLEMENTATION_PLAN.md`
+- 
 
 ## Purpose
 
@@ -20,6 +28,7 @@
 
 - [ ] The implementation item completion criteria are satisfied.
 - [ ] The change remains within the stated scope.
+- [ ] Newly discovered material gaps are recorded in active tracking rather than silently deferred.
 
 ## Checks
 
@@ -33,26 +42,44 @@ Mark only checks that were actually run.
 - [ ] End-to-end tests
 - [ ] Accessibility checks where applicable
 - [ ] Data or public-export validation where applicable
+- [ ] Representative screenshot capture where applicable
+- [ ] Relevant screenshots were inspected, not only generated
+
+## Practical profile operational path
+
+Complete when the PR adds or changes practical Place fields. Otherwise mark not applicable.
+
+- [ ] Source or submission intake boundary checked
+- [ ] Safe review projection checked
+- [ ] Reviewer control checked
+- [ ] Field provenance checked
+- [ ] Canonical create or correction operation checked
+- [ ] Public projection allowlist checked
+- [ ] Runtime and leakage validation checked
+- [ ] Staging review coverage checked
+- [ ] Affected public surfaces checked
+- [ ] Not applicable
 
 ## Documentation and tracking
 
 - [ ] `docs/IMPLEMENTATION_PLAN.md` is updated where required.
 - [ ] `docs/PROJECT_STATUS.md` is updated where required.
-- [ ] Public product roadmap impact was checked.
-- [ ] Product changelog impact was checked.
+- [ ] Active closure or phase plan impact was checked.
+- [ ] Public product Roadmap impact was checked.
+- [ ] Product Changelog impact was checked.
 - [ ] Route, schema, policy, or operating documentation was updated where applicable.
 
 ## Publication, privacy, and integrity
 
-- [ ] No private planning document or internal-only information is included.
-- [ ] No secret, credential, token, connection string, or wallet secret is included.
-- [ ] No private candidate, submission contact, private evidence, or unreviewed media is exposed.
+- [ ] No non-public review or submission material is exposed.
+- [ ] No operational access material is exposed.
 - [ ] User submissions cannot modify public canonical data without review.
-- [ ] Sponsorship or payment does not affect verification status.
+- [ ] Commercial relationships do not affect verification status.
+- [ ] Public projection remains separate from canonical mutation.
 
 ## Data impact
 
-<!-- None, migration, import, export contract, or public data change. -->
+<!-- None, migration, import, export contract, canonical operation, or public data change. -->
 
 ## Public impact
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,25 +11,35 @@ Before changing files:
 3. Read the public specification documents relevant to the change.
 4. Compare the documents with the actual `main` branch, merged pull requests, and available CI results.
 
-For any Places map, list, selected-Place panel, bottom-sheet, Place information, gallery, navigation, camera, marker, current-location, or selection-state work, also read:
+For Phase 4 closure work, also read `docs/PHASE4_CLOSURE_PLAN.md`.
+
+For Places work, also read:
 
 1. `docs/PLACES_UX_ACCEPTANCE.md`;
 2. `docs/PLACES_RECOVERY_PLAN.md`;
-3. the active P4-17 item in `docs/IMPLEMENTATION_PLAN.md`.
+3. `docs/PLACES_UX_FINAL_AUDIT.md`;
+4. `docs/PLACE_PUBLIC_PROFILE.md` when practical Place information is affected.
 
-The complete Places acceptance contract remains in force even when the current pull request implements only one bounded part of it. A narrower pull-request body or temporary task description does not supersede the documented recovery contract.
+The complete Places contract remains in force even when one pull request implements only a bounded part of it.
 
-When repository reality and a status document disagree, repository reality is authoritative. Correct the status document in the same pull request or the next dedicated correction pull request.
+For Phase 5 submission work, also read:
+
+1. `docs/SUBMISSION_WORKFLOW.md`;
+2. `docs/PHASE5_IMPLEMENTATION_SEQUENCE.md`;
+3. `docs/DATA_MODEL.md`;
+4. `docs/PHASE4_CLOSURE_PLAN.md` for the handoff gate;
+5. `docs/MEDIA_POLICY.md` when Media intake or review is affected.
+
+When repository reality and a status document disagree, repository reality is authoritative. Correct tracking in the same pull request or the next dedicated correction pull request.
 
 ## 2. Use implementation item IDs
 
 Every planned change must reference an implementation item ID, such as:
 
-- `P0-01`
-- `P1-03`
-- `FIX-P1-001`
-- `SEC-P2-001`
-- `DATA-P2-001`
+- `P0-01`;
+- `P4-18B2`;
+- `P5-03`;
+- `FIX-P1-001`.
 
 Pull request numbers are not implementation item IDs. Do not renumber the implementation plan when an unplanned fix is inserted.
 
@@ -37,23 +47,17 @@ Pull request numbers are not implementation item IDs. Do not renumber the implem
 
 A pull request should have one primary responsibility.
 
-- Do not combine a large database migration with an unrelated UI redesign.
-- State the purpose, scope, exclusions, completion criteria, and checks.
+- Do not combine a large data migration with an unrelated UI redesign.
+- State purpose, scope, exclusions, completion criteria, and checks.
 - Keep changes reviewable and reversible.
 - Update documentation when behavior, data contracts, routes, or operating procedures change.
-- For Places work, state which P4-17 recovery items are covered and which remain open.
+- State which active closure or phase item is covered and which work remains open.
+
+P4-18 is a bounded closure term. Do not expand P4-18C into an unlimited redesign cycle. Do not start Phase 5 implementation before the P4-18E handoff gate is complete.
 
 ## 4. Protect publication boundaries
 
-This is a public repository. Do not add:
-
-- private planning documents;
-- non-public candidate records;
-- submission contact details;
-- private evidence or unreviewed media;
-- secrets, credentials, tokens, connection strings, or wallet secrets;
-- internal commercial targets, private partnership discussions, or unpublished operational limits;
-- personal information or unrelated project information.
+This is a public repository. Keep non-public review material, personal information, private submission material, restricted Evidence or Media, operational access material, and unrelated internal project information out of public repository content and public artifacts.
 
 Candidate records must never become public merely because they exist in an import, submission, or review queue.
 
@@ -61,13 +65,37 @@ Candidate records must never become public merely because they exist in an impor
 
 Changes must maintain these principles:
 
-- reviewed canonical data is separate from source candidates and user submissions;
+- reviewed canonical data is separate from source Candidates and user submissions;
 - user submissions never update public canonical records automatically;
-- published acceptance claims identify the asset, network, payment route, payment method, instructions, evidence, and last confirmation date;
-- sponsorship, advertising, or payment never determines verification status;
-- public exports exclude private fields and internal review data.
+- published acceptance Claims identify the asset, network, payment route, payment method, instructions, Evidence, and last confirmation date;
+- commercial relationships do not determine verification status;
+- public exports exclude non-public review and submission material.
 
-Places recovery work that adds practical business information must extend canonical review, provenance, public projection allowlists, runtime schemas, and leakage checks together. UI convenience does not justify exporting unreviewed or private fields.
+Practical Place information changes must extend the complete operational path where applicable:
+
+```text
+source or submission intake
+    ↓
+safe review projection
+    ↓
+reviewer controls
+    ↓
+field provenance
+    ↓
+canonical create or correction transaction
+    ↓
+public projection allowlist
+    ↓
+runtime and leakage validation
+    ↓
+staging review
+    ↓
+public surfaces
+```
+
+A database column, schema property, fixture, or UI section alone does not complete a practical field.
+
+Structured fields such as amenities and social links require explicit normalization, duplicate behavior, provenance, replacement and removal semantics, and safe public projection.
 
 ## 6. Keep project tracking synchronized
 
@@ -79,19 +107,21 @@ At the start of an implementation item:
 
 Before completion:
 
-- verify the documented completion criteria;
+- verify documented completion criteria;
 - record the pull request number in the implementation plan;
-- mark the item `Completed` only after the change is merged or otherwise completed;
+- mark the item `Completed` only after merge or equivalent completion;
 - move `docs/PROJECT_STATUS.md` to the next real item;
-- check whether the public roadmap or product changelog is affected.
+- check public Roadmap and Changelog impact.
 
-Do not add a product changelog entry for repository administration alone.
+Do not add a product Changelog entry for repository administration alone.
 
-For P4-17, do not declare the Places recovery complete until the full 17-point acceptance matrix has been reviewed. Newly discovered Places defects must be added to the acceptance contract and implementation tracking before they are treated as completion work.
+P4-18 completion is controlled by `docs/PHASE4_CLOSURE_PLAN.md`. Phase 5 implementation begins only after P4-18E completes the handoff and `docs/PROJECT_STATUS.md` moves to P5-01.
+
+Material newly discovered Places defects must be added to active acceptance or closure tracking before they are treated as completion work. Small later visual preferences may be handled as bounded fixes without reopening the closure term.
 
 ## 7. Quality checks
 
-Run every check available for the affected area. As the repository gains tooling, this normally includes:
+Run every check available for the affected area. This normally includes:
 
 - formatting or linting;
 - type checking;
@@ -100,15 +130,20 @@ Run every check available for the affected area. As the repository gains tooling
 - build validation;
 - end-to-end tests where applicable;
 - accessibility checks where applicable;
-- schema and public-export validation for data changes.
+- schema and public-export validation for data changes;
+- representative screenshot capture and image inspection for affected public UI states.
 
-Do not claim a check passed unless it was actually run and passed.
+Do not claim a check passed unless it actually ran and passed.
 
-Places changes must test the user-visible contract appropriate to the item, including camera defaults, marker/cluster distinction, selected-Place completeness, sheet gestures and reduced motion, gallery/lightbox behavior, external navigation links, current-location focus versus commit behavior, and selection restoration where applicable.
+A successful screenshot capture job proves that the requested screenshots were produced. It does not prove visual acceptance. Inspect relevant images and record material findings before completing affected UI work.
+
+Places changes must test the user-visible contract appropriate to the item, including camera defaults, marker and cluster distinction, selected-Place completeness, sheet gestures and reduced motion, Gallery behavior, navigation links, current-location focus versus commit behavior, and selection restoration where applicable.
+
+Practical profile work must test presence, absence, malformed input, duplicate structured values, provenance assignment, canonical persistence or correction, strict public projection, and leakage rejection where applicable.
 
 ## 8. User experience requirements
 
-Interactive surfaces, especially Places, contribution flows, and administration, must be designed as application experiences rather than static pages.
+Interactive surfaces, especially Places, submission flows, and administration, must be designed as application experiences rather than static pages.
 
 Maintain:
 
@@ -122,12 +157,14 @@ Maintain:
 
 For Places specifically:
 
-- the default map must read as practical place discovery;
+- the default map must read as practical Place discovery;
 - single Places and clusters must be visually distinct;
 - selected-Place surfaces must not hide ordinary public information behind unnecessary route changes;
 - mobile peek and expanded states have different responsibilities;
 - direct sheet dragging follows input movement where motion is enabled;
-- approved media and navigation handoff follow the Places acceptance contract.
+- approved Media and navigation handoff follow the Places contract.
+
+P4-18C has a fixed residual scope: Mobile List compactness, Mobile Menu density, expanded-sheet information order, Filters completion flow, and only material long-page density defects. Fine-grained preference changes discovered later should be handled as bounded follow-up fixes.
 
 ## 9. Documentation language
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ For Places work, also read:
 1. `docs/PLACES_UX_ACCEPTANCE.md`;
 2. `docs/PLACES_RECOVERY_PLAN.md`;
 3. `docs/PLACES_UX_FINAL_AUDIT.md`;
-4. `docs/PLACE_PUBLIC_PROFILE.md` when practical Place information is affected.
+4. `docs/PLACE_PUBLIC_PROFILE.md` when practical Place information is affected;
+5. `docs/PRACTICAL_PROFILE_DATA_MODEL_EXTENSION.md` for P4-18B practical profile data work.
 
 The complete Places contract remains in force even when one pull request implements only a bounded part of it.
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # CryptoPayMap implementation plan
 
 **Status:** Active  
-**Last updated:** 2026-07-07
+**Last updated:** 2026-07-08
 
 This file tracks repository implementation work. GitHub main, merged pull requests, and CI are authoritative when this file differs from repository reality.
 
@@ -10,10 +10,13 @@ This file tracks repository implementation work. GitHub main, merged pull reques
 - Implementation item IDs are independent of pull request numbers.
 - Candidate, canonical, and public-export layers remain separate.
 - Each pull request has one primary responsibility and explicit completion checks.
-- Live Cloudflare and database verification may be deferred without blocking repository-only work.
+- Live environment verification may be deferred only when the exact deferred check is recorded.
 - Public product Roadmap and repository implementation status are separate documents.
+- Phase 4 closure work must read `docs/PHASE4_CLOSURE_PLAN.md`.
 - Places work must read `docs/PLACES_UX_ACCEPTANCE.md`, `docs/PLACES_RECOVERY_PLAN.md`, and `docs/PLACES_UX_FINAL_AUDIT.md` before implementation or review.
-- A narrow pull-request description does not supersede the complete Places acceptance contract.
+- Practical Place profile work must also read `docs/PLACE_PUBLIC_PROFILE.md` and trace the complete operational path defined by P4-18B.
+- A narrow pull-request description does not supersede the complete Places acceptance or active closure contract.
+- Phase 5 implementation does not begin before the P4-18E handoff gate is complete.
 
 ## Phase 0 — Public specifications and development control
 
@@ -32,7 +35,7 @@ This file tracks repository implementation work. GitHub main, merged pull reques
 
 ## Phase 1 — Foundation
 
-**Status:** Repository work completed; live staging verification deferred
+**Status:** Repository work completed; remaining live checks are tracked by later integration and launch items
 
 | ID | Item | Status | Pull request |
 |---|---|---|---|
@@ -47,7 +50,7 @@ This file tracks repository implementation work. GitHub main, merged pull reques
 | P1-09 | PWA manifest and installability baseline | Completed | #19 |
 | P1-10 | Accessibility baseline | Completed | #20 |
 | P1-11 | Public Roadmap and Changelog loaders | Completed | #21 |
-| P1-12 | Integration and quality audit | Repository completed; live verification deferred | #22, #23 |
+| P1-12 | Integration and quality audit | Repository completed | #22, #23 |
 
 ## Phase 2 — Data core
 
@@ -73,7 +76,7 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 
 ## Phase 3 — Administration and review
 
-**Status:** Repository completed; live verification deferred
+**Status:** Repository completed; P4-18D/E will reconcile remaining integration and environment checks
 
 | ID | Item | Status | Depends on | Pull request |
 |---|---|---|---|---|
@@ -87,52 +90,18 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 | P3-08 | Evidence review and verification decisions | Completed | P3-07 | #59, #60, #62, #63 |
 | P3-09 | Status transitions and reconfirmation queue | Completed | P3-07, P3-08 | #64–#67 |
 | P3-10 | Media review | Completed | P3-02, P2-10 | #69–#74 |
-| P3-11 | Export controls and release workflow | Repository completed; live verification deferred | P3-07 through P3-10 | #75–#87 |
+| P3-11 | Export controls and release workflow | Repository completed | P3-07 through P3-10 | #75–#87 |
 | P3-12 | Audit history and Phase 3 integration audit | Completed | P3-01 through P3-11 | #88, #89, #92–#95 |
 
-### Completed P3-07 deliveries
+### Phase 3 result
 
-P3-07 established isolated promotion authorization, durable atomic promotion and existing-target linking, protected workspaces, exact candidate and Claim-set guards, target search and selection, field-level provenance, reviewer controls, and cross-path integration. P3-07 is repository-complete; live Access, database, and production verification remain deferred.
+Phase 3 established protected Candidate review, duplicate resolution, new-target promotion, existing-target linking, field-level provenance, Evidence decisions, Claim transitions, reconfirmation queues, Media review, export release decisions, publication activation, release history, restore boundaries, and cross-domain Audit history.
 
-### Completed P3-08 deliveries
+Repository-complete components remain subject to the P4-18D operator-journey audit and the P4-18E environment-specific handoff checks. A repository test result must not be described as a live environment verification result.
 
-P3-08 established Evidence review authorization, strict decision contracts, durable decision persistence, Claim transitions and verification events, protected queue and detail workspaces, reviewer UI, API behavior, threshold enforcement, replay and conflict handling, and a final cross-layer audit. Live Access, database, and production verification remain deferred.
+## Phase 4 — Public core / MVP-A and closure
 
-### Completed P3-09 deliveries
-
-P3-09 established bounded reconfirmation queues, exact Claim guards, durable expiration receipts, atomic stale transitions, protected Rechecks APIs and UI, scheduled-run identity and replay behavior, and the final handoff audit. Live scheduler configuration remains deferred.
-
-### Completed P3-10 deliveries
-
-P3-10 established isolated Media review authorization, strict Media decision contracts, durable receipts, exact file-set guards, deterministic private and public storage plans, R2 adapter boundaries, protected queue, detail and preview routes, reviewer UI, publication and revocation behavior, replay safety, and the final Media integration audit. Live Access, R2, database, and production verification remain deferred.
-
-### Completed P3-11 deliveries
-
-P3-11A through P3-11D established release-decision authorization, exact candidate and snapshot guards, durable release decisions, protected release queue and detail workspaces, reviewer actions, and private candidate revalidation.
-
-P3-11E through P3-11H established separate publication authorization, immutable release-object staging, exact metadata checks, conditional active-pointer activation, durable activation history, request replay and conflicts, bounded release-history reads, and the protected history API.
-
-P3-11I through P3-11L established restore preparation, pointer inventory and execution-record contracts, target-object preflight, conditional pointer switching, switch-receipt validation, replay-safe workflow composition, and explicit post-switch persistence failure handling.
-
-P3-11M aligned restore readiness with the implemented execution workflow, added readiness-to-execution runtime verification, completed the repository integration audit, documented deferred live verification, and handed off to P3-12 in pull request #87.
-
-### Completed P3-12 deliveries
-
-P3-12A defined the protected normalized audit-history read contract across candidate, Evidence, reconfirmation, Media, and export administration. It added bounded filters, stable cursor semantics, deterministic ordering, source-domain validation, target metadata, and privacy leakage boundaries in pull request #88.
-
-P3-12B added metadata-only source normalizers, bounded concurrent aggregation, source-domain validation, duplicate identity rejection, defensive filtering, deterministic cross-source ordering, and fail-closed source handling in pull request #89.
-
-P3-12C connected bounded audit history sources to the existing durable Phase 3 tables in pull request #92. It pushes actor, time-range, target, and stable cursor filters into source queries, preserves source ordering compatible with the global cursor, and excludes restore execution from the Drizzle registry until a corresponding table exists.
-
-P3-12D added the protected audit history API, isolated audit read authorization, fail-closed environment handling, bounded response mapping, runtime checks, and API tests in pull request #93.
-
-P3-12E added the protected `/admin/audit` administration surface, metadata-only history cards, domain, actor, target, and time filters, stable cursor loading, explicit loading and failure states, component tests, and built-artifact leakage checks in pull request #94.
-
-P3-12F completed the final repository-level Phase 3 cross-domain integration audit in pull request #95. It verified deterministic history ordering, bounded pagination, domain and target filtering, stable cursor continuation, isolated audit-read authorization, rejection of source items carrying non-contract fields, explicit deferred live-verification boundaries, and the Phase 4 handoff.
-
-## Phase 4 — Public core / MVP-A
-
-**Status:** Repository work completed and merged through pull request #122
+**Status:** MVP-A public surfaces are merged; P4-18 closure is active
 
 | ID | Item | Status | Depends on | Pull request |
 |---|---|---|---|---|
@@ -158,56 +127,101 @@ P3-12F completed the final repository-level Phase 3 cross-domain integration aud
 | P4-17D | Desktop selected panel and mobile sheet recovery | Completed | P4-17B, P4-17C | #122 |
 | P4-17E | Gallery, image enlargement, and external navigation | Completed | P4-17C, P4-17D | #122 |
 | P4-17F | State, responsive, accessibility, and final 17-point acceptance audit | Completed | P4-17B through P4-17E | #122 |
+| P4-18A | Tracking correction and closure inventory | In progress | P4-17, closure findings | — |
+| P4-18B1 | Source and Candidate practical-profile contract | Planned | P4-18A | — |
+| P4-18B2 | Promotion editor and field provenance parity | Planned | P4-18B1 | — |
+| P4-18B3 | Canonical persistence and public projection integration | Planned | P4-18B2 | — |
+| P4-18B4 | Existing-record practical-profile correction path audit and completion | Planned | P4-18B3 | — |
+| P4-18C | Bounded UI residual closure | Planned | P4-18A, representative screenshot capture | — |
+| P4-18D | Administration workflow integration audit | Planned | P4-18B | — |
+| P4-18E | Live review and Phase 5 handoff audit | Planned | P4-18B, P4-18C, P4-18D | — |
 
-### Completed P4-01 delivery
+### P4-17 Places recovery result
 
-P4-01A established the first public Place detail boundary in pull request #96. It reads only validated published `places.json` records through the build-time content layer, generates canonical `/place/{slug}` paths from those public records, derives a status-aware detail view model, renders payment assets, networks, routes, methods, instructions, restrictions, freshness, Evidence, and approved public Media, and covers the model and privacy boundary with tests.
-
-### Completed P4-02 delivery
-
-P4-02A established the coordinated PlacesApp public shell in pull request #97. It loads only validated public Place pins, connects existing Discovery URL state and isolated Zustand UI state, coordinates map/list mode, public result selection, selected-place detail navigation, search and status filtering, and explicit empty states that never substitute Candidate records.
-
-### P4-03 deliveries
-
-P4-03A established deterministic public Place point-feature conversion, stable feature identity and selection state, and normalized camera contracts aligned with the public URL boundary in pull request #98.
-
-P4-03B added the MapLibre renderer to the coordinated PlacesApp shell in pull request #100. It registers the public GeoJSON source, clustered and point layers, marker selection and cluster expansion behavior, camera and pending viewport coordination, Search this area behavior, resize handling, fallback states, and renderer component tests.
-
-### P4-16 audit outcome and P4-17 recovery requirement
-
-The MVP-A integration review found that repository-complete foundations did not yet provide a complete map-service interaction contract. The fixed recovery set is documented in:
+The MVP-A integration review found that repository-complete foundations did not yet provide a complete map-service interaction contract. P4-17 fixed the 17-point recovery set documented in:
 
 - `docs/PLACES_UX_ACCEPTANCE.md`;
 - `docs/PLACES_RECOVERY_PLAN.md`;
 - `docs/PLACES_UX_FINAL_AUDIT.md`.
 
-P4-17 resolves the complete 17-point set in dependency order:
+P4-17A through P4-17F are implemented, validated, and merged through pull request #122. The final audit matrix remains the durable interaction boundary for future Places changes.
 
-1. initial camera;
-2. basemap style;
-3. Place pin markers;
-4. cluster/Place distinction;
-5. practical public Place information path;
-6. full address/location presentation;
-7. desktop selected-Place completeness;
-8. mobile expanded-sheet completeness;
-9. peek/expanded role separation;
-10. drag-following position-based sheet motion;
-11. gallery in selected surfaces;
-12. image enlargement;
-13. Google Maps and Apple Maps navigation handoff;
-14. correct canonical detail-page responsibility;
-15. current-location focus/commit separation;
-16. deterministic selection semantics;
-17. durable acceptance and regression coverage.
+### P4-18 closure groundwork already merged
 
-P4-17A through P4-17F are implemented, validated, and merged through pull request #122. The final audit matrix remains the durable acceptance boundary for future Places changes.
+Before the formal closure sequence was added, the following groundwork landed:
+
+- #123 — review deployment follows `main` and updates the fixed review URL;
+- #124 — observable deployment receipt records the deployed `main` commit;
+- #125 — representative desktop/mobile screenshot capture, interactive-state capture, legacy Place field parity baseline, and practical profile staging fixture coverage;
+- #126 — selected Place focus and marker correction plus desktop selected-panel containment.
+
+These changes improve observability and baseline UI behavior. They do not complete P4-18B operational parity, P4-18C residual UI closure, P4-18D administration integration, or P4-18E handoff.
+
+### P4-18 execution order
+
+The authoritative closure details and completion criteria are in `docs/PHASE4_CLOSURE_PLAN.md`.
+
+Execution order:
+
+1. P4-18A — tracking correction and closure inventory;
+2. P4-18B1 — source and Candidate practical-profile contract;
+3. P4-18B2 — promotion editor and field provenance parity;
+4. P4-18B3 — canonical persistence and public projection integration;
+5. P4-18B4 — existing-record correction path audit and completion;
+6. P4-18C — bounded UI residual closure;
+7. P4-18D — administration workflow integration audit;
+8. P4-18E — live review and Phase 5 handoff audit.
+
+P4-18 is a bounded closure term. P4-18C must not become an unlimited redesign cycle. P4-18B is a prerequisite for public submission work because external corrections must not arrive before the operator can safely review, provenance, apply, and publish the same field classes.
 
 ## Phase 5 — Public submissions / MVP-B
 
-**Status:** Planned
+**Status:** Planned; blocked on P4-18E handoff
 
-Suggestions, payment reports, problem reports, owner claims, photos, private status links, quarantine uploads, review diffs, information requests, holds, partial approval, canonical transactions, and retention jobs.
+| ID | Item | Status | Depends on |
+|---|---|---|---|
+| P5-01 | Shared submission foundation | Planned | P4-18E |
+| P5-02 | Suggest Place and Online Service | Planned | P5-01 |
+| P5-03 | Payment and problem reports | Planned | P5-01, P5-02 target conventions |
+| P5-04 | Business and service claims | Planned | P5-01, practical-profile correction path |
+| P5-05 | Photo and Media submission intake | Planned | P5-01, P3-10 Media review boundary |
+| P5-06 | Review workflow extensions | Planned | P5-02 through P5-05 |
+| P5-07 | Canonical application transactions and retention | Planned | P5-06, P4-18B correction boundary |
+| P5-08 | MVP-B integration audit | Planned | P5-01 through P5-07 |
+
+### P5-01 — Shared submission foundation
+
+Provide the common submission envelope, opaque public reference, private follow-up secret handling, workflow status, contact privacy boundary, abuse controls, safe parsing, idempotency, and audit foundation used by later submission types.
+
+### P5-02 — Suggest Place and Online Service
+
+Add public suggestion intake and protected review entry without direct canonical or public mutation. Useful but insufficient submissions may become private Candidates.
+
+### P5-03 — Payment and problem reports
+
+Add target-aware positive and negative payment reports plus factual, privacy, rights, duplicate, and other problem reports. Reports create review material and may trigger recheck priority; they do not automatically change Claim state.
+
+### P5-04 — Business and service claims
+
+Add claimant intake and ownership-verification workflow boundaries. Ownership verification does not bypass payment Evidence review or publication validation.
+
+### P5-05 — Photo and Media submission intake
+
+Add upload intake, quarantine, file validation, privacy and rights acknowledgements, and handoff to the existing protected Media review boundary. Original submissions remain non-public.
+
+### P5-06 — Review workflow extensions
+
+Add reviewer diffs, information requests, time-bounded holds, partial approval, duplicate/no-change handling, and private status communication required by real submission review.
+
+### P5-07 — Canonical application transactions and retention
+
+Apply approved field decisions through explicit guarded canonical transactions, preserve correction provenance and audit history, run normal export/publication validation, and enforce private submission retention and deletion rules.
+
+### P5-08 — MVP-B integration audit
+
+Verify each submission type from public intake through private status, protected review, decision, canonical application where approved, public export, publication state, privacy boundaries, failure handling, and retention behavior.
+
+Detailed submission behavior remains governed by `docs/SUBMISSION_WORKFLOW.md` and related data, Media, verification, privacy, and publication specifications.
 
 ## Phase 6 — Launch and cutover
 

--- a/docs/PHASE4_CLOSURE_PLAN.md
+++ b/docs/PHASE4_CLOSURE_PLAN.md
@@ -1,0 +1,330 @@
+# Phase 4 closure and operational parity plan
+
+**Implementation item:** P4-18  
+**Status:** Active  
+**Last updated:** 2026-07-08
+
+## Purpose
+
+Phase 4 delivered the public MVP-A surfaces and the Places interaction recovery. Subsequent staging review, representative screenshot capture, and practical profile review exposed remaining work that must be closed before Phase 5 public submissions begin.
+
+P4-18 is a bounded closure term. It does not reopen Phase 4 as an unlimited redesign cycle. Its purpose is to make the existing MVP-A operationally coherent across source review, canonical writes, provenance, public projection, administration, visual review, deployment review, and the Phase 5 handoff.
+
+The required order is:
+
+```text
+P4-18A tracking and closure inventory
+    ↓
+P4-18B practical profile operational parity
+    ↓
+P4-18C bounded UI residual closure
+    ↓
+P4-18D administration workflow integration audit
+    ↓
+P4-18E live review and Phase 5 handoff audit
+    ↓
+Phase 5 public submissions / MVP-B
+```
+
+## Required references
+
+Before P4-18 work, read:
+
+1. `docs/PROJECT_STATUS.md`;
+2. `docs/IMPLEMENTATION_PLAN.md`;
+3. this document;
+4. `docs/PLACE_PUBLIC_PROFILE.md` for practical Place fields;
+5. `docs/DATA_MODEL.md` for source, review, canonical, provenance, and submission boundaries;
+6. `docs/SUBMISSION_WORKFLOW.md` for the Phase 5 handoff;
+7. `docs/PLACES_UX_ACCEPTANCE.md`, `docs/PLACES_RECOVERY_PLAN.md`, and `docs/PLACES_UX_FINAL_AUDIT.md` for Places interaction work.
+
+Media-related work must also read `docs/MEDIA_POLICY.md`.
+
+## Closure groundwork already merged
+
+The following work is treated as P4-18 groundwork rather than as completion of the remaining closure term:
+
+- review deployment follows `main` and updates the fixed review URL after merge;
+- deployment receipts record which `main` commit is deployed to the fixed review URL;
+- representative GitHub Actions screenshot capture covers desktop and mobile pages plus interactive states;
+- staging review data exercises a practical Place profile including address, phone, website, social link, description, hours, amenities, and Gallery Media;
+- selected Place focus, selected marker presentation, mobile sheet stacking, horizontal overflow, and desktop selected-panel containment were corrected through the latest merged review cycle.
+
+These foundations make later audits observable. They do not replace the operational parity and integration checks below.
+
+---
+
+## P4-18A — Tracking correction and closure inventory
+
+### Goal
+
+Make repository tracking match current `main`, record the bounded closure term, and establish the documents that later P4-18 work must use.
+
+### Required work
+
+- synchronize `docs/IMPLEMENTATION_PLAN.md` with merged work through the current `main`;
+- synchronize `docs/PROJECT_STATUS.md` with the active P4-18 item;
+- record P4-18A through P4-18E and their dependencies;
+- split Phase 5 into bounded implementation items with explicit ordering;
+- record representative screenshot capture as a required visual-review instrument for affected public UI changes;
+- record practical Place operational parity as a full-path requirement, not a schema-only requirement;
+- correct specification drift discovered during the closure inventory.
+
+### Completion criteria
+
+- current state and next item are unambiguous;
+- P4-18 and Phase 5 IDs are stable;
+- every later P4-18 PR can identify its required references and completion boundary;
+- no private planning material is copied into the public repository.
+
+---
+
+## P4-18B — Practical profile operational parity
+
+### Goal
+
+Make practical Place information operable through the full reviewed data path before public submissions can propose or correct those fields.
+
+The practical profile set is:
+
+- address and locality fields;
+- phone;
+- website;
+- description;
+- opening hours;
+- amenities;
+- structured social links.
+
+Payment Claims, Evidence, and Media remain separate models and must not be collapsed into the practical profile.
+
+### Full-path rule
+
+A practical field is not operationally complete merely because a database column or public schema exists.
+
+Completion requires a traceable path where applicable:
+
+```text
+source observation or submission
+    ↓
+safe normalized review snapshot
+    ↓
+Candidate or proposed-change review
+    ↓
+reviewer-visible field value
+    ↓
+explicit field source or correction provenance
+    ↓
+atomic canonical create or update operation
+    ↓
+public projection allowlist
+    ↓
+runtime schema and leakage validation
+    ↓
+staging review fixture
+    ↓
+public Place surfaces
+```
+
+No source observation, Candidate value, or submission value may update public canonical fields automatically.
+
+### P4-18B1 — Source and Candidate profile contract
+
+Verify and, where needed, extend:
+
+- physical-place source snapshot schemas;
+- Candidate detail safe projection;
+- normalization rules for arrays and structured social links;
+- source and license attribution boundaries;
+- duplicate and malformed-value behavior;
+- compatibility with legacy source records without treating legacy values as current truth.
+
+Completion requires representative tests for populated, absent, malformed, duplicate, and private-value cases.
+
+### P4-18B2 — Promotion editor and field provenance
+
+Verify and, where needed, extend both new-target and existing-target review paths so reviewers can intentionally handle the practical profile fields.
+
+Required properties:
+
+- reviewer-visible inputs or explicit review decisions for supported practical fields;
+- safe normalization of hours, amenities, and social links;
+- field-level source assignment for non-empty reviewed factual values;
+- exact Candidate version and source-set guards remain in force;
+- promotion remains hidden and does not verify or publish Claims;
+- no fallback that silently assigns all sources to fields when field-level review is required.
+
+### P4-18B3 — Canonical persistence and public projection integration
+
+Verify the complete create path from reviewed field input to canonical persistence and then to public projection.
+
+Required checks:
+
+- atomic persistence;
+- replay and conflict behavior;
+- field provenance rows;
+- public allowlisting;
+- strict schema validation;
+- leakage rejection;
+- absence semantics;
+- staging artifact coverage;
+- desktop selected panel, mobile expanded sheet, and canonical Place detail presentation.
+
+### P4-18B4 — Existing-record correction path audit
+
+Audit how an already canonical Place receives reviewed practical profile corrections.
+
+At minimum consider:
+
+- address correction;
+- phone change or removal;
+- website change or removal;
+- opening-hours change;
+- amenities addition, removal, and replacement;
+- social-link addition, removal, and replacement;
+- description correction.
+
+The audit must determine whether an existing safe canonical update transaction already satisfies the requirements. Missing operations must be implemented before P4-18B is complete.
+
+Required properties:
+
+- exact current-version guards;
+- field-level diff;
+- correction provenance;
+- reviewer decision record;
+- idempotent replay;
+- conflict on stale review state;
+- no publication before the normal public export and release boundary.
+
+---
+
+## P4-18C — Bounded UI residual closure
+
+### Goal
+
+Close the material UI issues already visible in representative screenshots without reopening an unlimited redesign phase.
+
+### Fixed scope
+
+1. Mobile Places List compactness and scanability;
+2. Mobile Menu density and use of screen area;
+3. mobile expanded-sheet information order and access to payment instructions;
+4. Filters completion, clear, zero-result, and Map/List behavior;
+5. only material density or layout defects on representative long-form public pages.
+
+Fine-grained visual preference changes discovered later may be handled as bounded follow-up fixes. They do not keep P4-18C open indefinitely.
+
+### Visual review requirement
+
+Affected UI PRs must run and inspect the representative screenshot workflow, including the relevant interactive states. A green capture job proves that screenshots were produced; it does not by itself prove visual acceptance. The PR review must inspect the relevant images and record material findings.
+
+### Completion criteria
+
+- no known material horizontal overflow or hidden interactive surface;
+- Mobile List remains useful at realistic result counts;
+- Menu and Filters use bounded mobile space coherently;
+- expanded Place details make practical and payment-critical information reachable without confusing responsibility overlap;
+- representative affected screenshots have been reviewed.
+
+---
+
+## P4-18D — Administration workflow integration audit
+
+### Goal
+
+Verify the protected administration workflow as an operator journey rather than as a collection of isolated repository-complete components.
+
+### Required journey
+
+```text
+Candidate queue
+    ↓
+Candidate detail and source provenance
+    ↓
+duplicate review when applicable
+    ↓
+new-target promotion or existing-target linking
+    ↓
+Evidence review and Claim transition
+    ↓
+recheck / reconfirmation workflow
+    ↓
+Media review
+    ↓
+private export candidate review
+    ↓
+release decision
+    ↓
+publication activation
+    ↓
+release history / restore boundary
+    ↓
+Audit history
+```
+
+### Audit categories
+
+- route reachability and navigation;
+- Access capability mapping;
+- protected API request and response compatibility;
+- current database migration assumptions;
+- stale explanatory copy or impossible controls;
+- version, source-set, and accepted-Evidence guards;
+- replay and conflict behavior;
+- failure and retry states;
+- publication and restore boundaries;
+- audit visibility without private payload leakage.
+
+The known stale Admin Home description must be corrected as part of this audit.
+
+### Completion criteria
+
+- every implemented operation has a reachable and accurate operator path or is explicitly documented as a non-UI boundary;
+- stale descriptions do not contradict implemented capability;
+- unresolved live-environment dependencies are explicit and assigned to P4-18E or a later launch item;
+- no repository-only test result is mislabeled as live verification.
+
+---
+
+## P4-18E — Live review and Phase 5 handoff audit
+
+### Goal
+
+Close Phase 4 only after repository validation, deployed review observability, representative UI review, practical profile parity, and administration integration have been reconciled.
+
+### Required checks
+
+- fixed review URL deployment receipt matches the intended `main` commit;
+- staging review artifact validates;
+- representative screenshot capture succeeds and relevant images are inspected;
+- practical profile create and correction paths satisfy P4-18B;
+- public projection and leakage checks pass;
+- protected administration flow has been reviewed to the extent supported by the configured environment;
+- live-only checks that cannot be performed are enumerated precisely rather than hidden behind a generic deferred-verification label;
+- Phase 5 prerequisites are confirmed.
+
+### Phase 5 handoff gate
+
+Phase 5 implementation may begin only when:
+
+1. P4-18B practical profile operational parity is complete;
+2. P4-18C material UI residuals are closed;
+3. P4-18D administration integration findings are resolved or explicitly assigned;
+4. P4-18E records the remaining live-only launch risks;
+5. `docs/PROJECT_STATUS.md` moves to P5-01.
+
+---
+
+## Phase 5 handoff sequence
+
+After P4-18E, the implementation order is:
+
+1. P5-01 — Shared submission foundation;
+2. P5-02 — Suggest Place and Online Service;
+3. P5-03 — Payment and problem reports;
+4. P5-04 — Business and service claims;
+5. P5-05 — Photo and Media submission intake;
+6. P5-06 — Review workflow extensions;
+7. P5-07 — Canonical application transactions and retention;
+8. P5-08 — MVP-B integration audit.
+
+The detailed public submission behavior remains governed by `docs/SUBMISSION_WORKFLOW.md`. This sequence controls repository implementation order; it does not weaken any privacy, evidence, verification, Media, or publication boundary.

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -1,0 +1,288 @@
+# Phase 5 public submissions implementation sequence
+
+**Phase:** Phase 5 — Public submissions / MVP-B  
+**Status:** Planned; blocked on P4-18E handoff  
+**Last updated:** 2026-07-08
+
+## Purpose
+
+`docs/SUBMISSION_WORKFLOW.md` defines submission behavior, privacy boundaries, workflow states, review outcomes, and publication rules.
+
+This document defines repository implementation order. It does not replace or narrow the submission workflow contract.
+
+Phase 5 begins only after the P4-18E handoff gate in `docs/PHASE4_CLOSURE_PLAN.md` is complete.
+
+## Non-negotiable boundaries
+
+Throughout Phase 5:
+
+- submissions remain separate from canonical records;
+- no public form writes directly to canonical Entity, Location, Claim, Evidence, or Media public state;
+- automated checks may reject malformed or abusive intake but do not approve factual claims;
+- accepted field changes use explicit reviewed canonical application operations;
+- ownership verification does not bypass payment-acceptance verification;
+- private contact, transaction evidence, ownership proof, and non-public Media remain outside public projections;
+- publication remains a separate validated export and release operation.
+
+## Execution order
+
+```text
+P5-01 Shared submission foundation
+    ↓
+P5-02 Suggest Place and Online Service
+    ↓
+P5-03 Payment and problem reports
+    ↓
+P5-04 Business and service claims
+    ↓
+P5-05 Photo and Media submission intake
+    ↓
+P5-06 Review workflow extensions
+    ↓
+P5-07 Canonical application transactions and retention
+    ↓
+P5-08 MVP-B integration audit
+```
+
+P5-03 through P5-05 share P5-01 but may only overlap when their data, privacy, and reviewer boundaries remain independent and reviewable. P5-06 and P5-07 depend on the real intake shapes delivered before them.
+
+---
+
+## P5-01 — Shared submission foundation
+
+### Goal
+
+Create the common private intake and follow-up foundation used by all public submission types.
+
+### Scope
+
+- common submission envelope;
+- submission type and workflow status;
+- opaque public reference;
+- one-time private follow-up secret issuance and stored verification representation;
+- safe original-payload preservation and normalized review projection separation;
+- optional contact boundary and protected storage;
+- relationship disclosure field;
+- common evidence-link intake boundary;
+- request-size, content-type, URL, and text safety validation;
+- abuse and rate-control adapter boundary;
+- request replay and duplicate-request behavior;
+- audit event foundation;
+- private submission status read contract;
+- public status labels that do not expose internal review information.
+
+### Out of scope
+
+- type-specific approval logic;
+- canonical mutations;
+- public publication;
+- Media processing.
+
+### Completion gate
+
+A synthetic submission can be received, assigned a public reference, retrieved through its private follow-up boundary, and kept isolated from canonical/public data.
+
+---
+
+## P5-02 — Suggest Place and Online Service
+
+### Goal
+
+Accept new Place or Online Service suggestions into protected review without direct canonical mutation.
+
+### Scope
+
+- physical Place and Online Service suggestion forms;
+- target-type-specific validation;
+- business identity and official URL fields;
+- Place address and coordinate input;
+- optional practical profile proposals such as phone, hours, official social links, amenities, and description;
+- category and payment proposal fields;
+- observation date;
+- evidence link or allowed evidence attachment reference;
+- relationship disclosure;
+- normalization to review-safe proposal fields;
+- duplicate Candidate or existing-target signals;
+- reviewer entry path;
+- accepted-as-Candidate outcome.
+
+### Operational dependency
+
+P4-18B must already provide safe operator handling and correction behavior for practical profile fields. Suggestion intake must not introduce field classes that the protected review and canonical application paths cannot safely process.
+
+### Completion gate
+
+A suggestion can move from public intake to protected review and resolve without directly changing a public record. A useful but insufficient suggestion may become a private Candidate.
+
+---
+
+## P5-03 — Payment and problem reports
+
+### Goal
+
+Accept target-aware reports about payment success, failure, and incorrect or problematic public information.
+
+### Scope
+
+- preselected Place or Online Service targets;
+- positive and negative payment outcomes;
+- asset, network, route, method, and observed payment steps;
+- optional public evidence links;
+- restricted transaction or receipt evidence boundary;
+- factual correction proposals;
+- practical profile correction proposals for address, phone, website, hours, amenities, social links, and description where relevant;
+- privacy, rights, duplicate, closure, and other problem categories;
+- priority recheck signal generation;
+- negative Evidence review entry;
+- no automatic Claim status change.
+
+### Completion gate
+
+Reports become review material, may add Evidence or recheck priority after explicit review, and cannot directly confirm, stale, end, hide, or publish a canonical Claim.
+
+---
+
+## P5-04 — Business and service claims
+
+### Goal
+
+Accept representative claims and verify ownership or authority separately from payment verification.
+
+### Scope
+
+- claimant role and target scope;
+- official contact method boundary;
+- proposed practical profile and payment corrections;
+- ownership-verification method state;
+- official-domain, website, DNS, official-social, and approved assisted verification adapter boundaries where implemented;
+- protected ownership proof handling;
+- ownership relationship status and scope;
+- expiration and revocation boundaries;
+- handoff of proposed changes to normal field and Claim review.
+
+### Completion gate
+
+A verified representative relationship can be recorded without granting uncontrolled editing rights or bypassing Evidence, canonical application, and publication review.
+
+---
+
+## P5-05 — Photo and Media submission intake
+
+### Goal
+
+Accept public-gallery Media proposals safely and connect them to the existing protected Media review system.
+
+### Scope
+
+- target binding;
+- image role;
+- capture date and description;
+- rights and authorization basis;
+- public-display permission;
+- privacy and rights acknowledgements;
+- bounded upload authorization;
+- quarantine object path;
+- MIME, size, dimension, and file-integrity validation;
+- duplicate file hash behavior;
+- derivative processing boundary;
+- Media asset creation in non-public state;
+- handoff to the existing Media review queue;
+- cleanup and retention of rejected or abandoned private uploads.
+
+### Completion gate
+
+A submitted image remains non-public until the existing Media decision and controlled publication boundaries approve it.
+
+---
+
+## P5-06 — Review workflow extensions
+
+### Goal
+
+Support the review states and partial decisions required by real public submissions.
+
+### Scope
+
+- submission review queue and detail workspace;
+- field-level proposed-versus-current diff;
+- information request;
+- submitter follow-up response;
+- time-bounded hold with reason and next review date;
+- partial approval;
+- duplicate and no-change outcomes;
+- accepted-as-Candidate outcome;
+- withdrawal behavior;
+- status history;
+- private reviewer notes separated from public status text;
+- bounded public-facing resolution summaries.
+
+### Completion gate
+
+A multi-field submission can resolve fields independently, request more information, pause safely, and report a bounded public status without exposing private review content.
+
+---
+
+## P5-07 — Canonical application transactions and retention
+
+### Goal
+
+Apply approved submission decisions safely to canonical data and enforce private-data lifecycle rules.
+
+### Scope
+
+- explicit application plan derived from approved field decisions;
+- exact canonical version or state expectations;
+- field-level diff and correction provenance;
+- atomic canonical create or update transaction;
+- Claim, Claim Asset, identity, and practical profile boundaries kept distinct;
+- Media decisions remain delegated to Media review operations;
+- request replay and stale-state conflict handling;
+- application receipt and audit history;
+- public export and release remain separate;
+- contact, private payload, evidence, ownership proof, and upload retention jobs;
+- deletion or anonymization where required;
+- preservation of minimum audit records where lawful and necessary.
+
+### Completion gate
+
+Approved changes can be applied once, replay safely, conflict on stale state, retain provenance and review identity, and reach public output only through the normal export and release workflow.
+
+---
+
+## P5-08 — MVP-B integration audit
+
+### Goal
+
+Verify the complete submission system across all public and protected boundaries before launch preparation.
+
+### Required journeys
+
+1. Suggestion → review → Candidate or approved canonical change → export → publication.
+2. Positive payment report → Evidence review → optional reconfirmation → publication.
+3. Negative payment report → Evidence/recheck → explicit Claim decision if justified.
+4. Problem report → correction, no change, duplicate, privacy, or rights outcome.
+5. Business claim → ownership verification → normal proposed-change review.
+6. Photo submission → quarantine → Media review → controlled public Media publication.
+7. Information request → private follow-up → resumed review.
+8. Partial approval → approved-field application with rejected or held fields preserved correctly.
+
+### Audit categories
+
+- privacy and data minimization;
+- authorization;
+- abuse controls;
+- replay and duplicate handling;
+- status secret handling;
+- field-level review and provenance;
+- stale-state conflict behavior;
+- canonical/public separation;
+- Media isolation;
+- export leakage validation;
+- public status privacy;
+- retention and cleanup;
+- mobile and accessibility behavior;
+- failure, retry, and rollback boundaries.
+
+### Completion gate
+
+Phase 5 is complete only when the full submission-to-publication path is auditable and the system can demonstrate that unreviewed submission data never becomes public canonical data automatically.

--- a/docs/PLACE_PUBLIC_PROFILE.md
+++ b/docs/PLACE_PUBLIC_PROFILE.md
@@ -1,7 +1,7 @@
 # Place public profile contract
 
 **Status:** Active  
-**Last updated:** 2026-07-07
+**Last updated:** 2026-07-08
 
 ## Purpose
 
@@ -13,6 +13,7 @@ This document must be read with:
 
 - `docs/PLACES_UX_ACCEPTANCE.md`;
 - `docs/PLACES_RECOVERY_PLAN.md`;
+- `docs/PHASE4_CLOSURE_PLAN.md` while P4-18 remains active;
 - `docs/DATA_MODEL.md`;
 - `docs/PUBLIC_EXPORT_SCHEMAS.md`;
 - `docs/SOURCE_AND_LICENSE_POLICY.md`;
@@ -56,6 +57,53 @@ The canonical location model may store the following public-eligible practical f
 
 Existing canonical status, visibility, OSM identity, timestamps, provenance, Claims, Evidence, and Media remain separate fields or relationships.
 
+## Operational parity requirement
+
+A practical Place field is not considered operationally complete merely because one or more of the following exists:
+
+- a database column;
+- a canonical runtime schema;
+- a public export field;
+- a staging fixture;
+- a UI section.
+
+The complete reviewed path must be traceable where applicable:
+
+```text
+source observation or submission
+    ↓
+safe normalized review snapshot
+    ↓
+Candidate or proposed-change review
+    ↓
+reviewer-visible value and explicit decision
+    ↓
+field source or correction provenance
+    ↓
+atomic canonical create or correction operation
+    ↓
+public projection allowlist
+    ↓
+runtime schema and leakage validation
+    ↓
+staging review data
+    ↓
+public Place surfaces
+```
+
+P4-18B is responsible for closing this path for the practical profile set before Phase 5 public submission work begins.
+
+Required behavior:
+
+- source values and user-submitted values remain non-canonical until reviewed;
+- malformed structured values fail closed or remain unavailable to the canonical editor;
+- non-empty factual values receive the required provenance assignment;
+- arrays and structured links define duplicate, replacement, and removal behavior;
+- canonical correction operations use exact current-state guards and record reviewer decisions;
+- stale review state conflicts rather than silently overwriting a newer canonical value;
+- replay of the same accepted operation is deterministic;
+- public projection occurs only through the normal validated export and release boundary.
+
 ## Optional-field policy
 
 `description`, `openingHours`, `amenities`, and `socialLinks` are optional reviewed extensions.
@@ -81,11 +129,12 @@ Requirements:
 - no private review notes;
 - no unsupported promotional claims presented as verified facts;
 - source and provenance remain traceable;
+- correction must preserve the reviewed previous/current distinction in the operation history;
 - UI may show a shorter excerpt but must not change the meaning.
 
 ## Opening hours
 
-The initial recovery contract stores `openingHours` as reviewed public text rather than forcing a lossy normalized weekly schedule.
+The current contract stores `openingHours` as reviewed public text rather than forcing a lossy normalized weekly schedule.
 
 This is intentional. Real opening schedules may include:
 
@@ -100,6 +149,7 @@ Requirements:
 
 - maximum 2,000 characters;
 - reviewed source basis;
+- explicit replacement or removal semantics for corrections;
 - no automatic “Open now” calculation unless a future normalized-hours contract explicitly supports it;
 - UI labels must not imply real-time operating certainty from stale text.
 
@@ -114,6 +164,8 @@ Requirements:
 - maximum 100 entries;
 - each entry maximum 80 characters;
 - duplicate entries are removed or rejected before public projection;
+- canonical update review distinguishes additions, removals, and complete replacement;
+- field provenance must remain meaningful when the stored array changes;
 - values describe practical Place attributes, not payment acceptance status;
 - controlled vocabulary may be introduced later without treating unrecognized historical values as verified new facts.
 
@@ -136,6 +188,7 @@ Requirements:
 - `handle` is nullable because not every platform exposes a stable human-readable handle;
 - maximum 30 links;
 - duplicate `platform + url` pairs are rejected;
+- canonical update review defines add, remove, replace, and handle-change behavior explicitly;
 - links must represent reviewed official accounts or another explicitly approved official relationship;
 - user-submitted or guessed accounts do not become public automatically.
 
@@ -166,11 +219,13 @@ Public projection rules remain fail closed:
 
 ## Selected-Place presentation
 
-P4-17D and P4-17E consume this profile contract.
+P4-17D and P4-17E established the selected-Place presentation baseline. P4-18C may refine information order and density only within its bounded residual scope.
 
 Desktop selected Place and mobile expanded Place may show the practical fields when available. They must not force the user to open the canonical detail page merely to see already-public routine Place information.
 
 The canonical detail page remains responsible for complete Evidence, history, provenance, long-form record context, stable sharing, and indexing.
+
+The mobile peek state remains compact. Practical profile expansion must not turn peek into a second detail page.
 
 ## Navigation boundary
 
@@ -180,15 +235,39 @@ Navigation handoff is not stored as a separate business fact. CryptoPayMap provi
 
 Official website, phone, social links, and payment instructions remain separate actions from navigation handoff.
 
+## Existing-record correction boundary
+
+Existing canonical Places must be correctable without creating duplicate identities or bypassing normal review.
+
+P4-18B4 audits and completes the correction path for:
+
+- address and locality changes;
+- phone addition, replacement, or removal;
+- website addition, replacement, or removal;
+- description correction;
+- opening-hours correction or removal;
+- amenities addition, removal, or replacement;
+- social-link addition, removal, replacement, or handle change.
+
+The correction path must preserve exact current-state expectations, field-level diff information, correction provenance, reviewer decision identity, replay safety, conflict behavior, and the normal public export/release boundary.
+
+Existing-target Candidate linking is not automatically equivalent to an approved canonical profile correction. The audit must verify the actual operation path rather than infer parity from shared UI or schema fields.
+
 ## Validation checklist
 
-Before a practical Place field is considered publicly available:
+Before a practical Place field is considered operationally available:
 
-- the canonical field exists in the approved data model;
-- ingestion or promotion preserves the field intentionally;
+- the canonical field exists in the approved data model and implementation schema;
+- source or submission intake preserves the value safely when the input path supports it;
+- the protected review projection exposes only allowed values;
+- the operator can intentionally review the value;
 - provenance is available at the required field or record level;
+- canonical create and existing-record correction behavior are defined where applicable;
+- stale-state conflicts and replay behavior are tested;
 - public projection allowlisting is explicit;
 - runtime schema validation passes;
 - privacy and leakage validation passes;
 - source and license rules are satisfied;
-- selected-Place UI treats absence as unknown, not as a negative fact.
+- staging review data exercises representative populated values;
+- selected-Place UI treats absence as unknown, not as a negative fact;
+- affected representative screenshots are inspected when public presentation changes.

--- a/docs/PRACTICAL_PROFILE_DATA_MODEL_EXTENSION.md
+++ b/docs/PRACTICAL_PROFILE_DATA_MODEL_EXTENSION.md
@@ -1,0 +1,171 @@
+# Practical Place profile data model extension
+
+**Status:** Active  
+**Implementation boundary:** P4-18B  
+**Last updated:** 2026-07-08
+
+## Purpose
+
+This document records the additive canonical Location fields and operational requirements introduced for practical Place profiles.
+
+It supplements the `locations` section of `docs/DATA_MODEL.md` and must be read with:
+
+- `docs/DATA_MODEL.md`;
+- `docs/PLACE_PUBLIC_PROFILE.md`;
+- `docs/PHASE4_CLOSURE_PLAN.md`;
+- `docs/PUBLIC_EXPORT_SCHEMAS.md`;
+- `docs/SOURCE_AND_LICENSE_POLICY.md`.
+
+The runtime database schema and canonical validation contracts already include these fields. P4-18B is responsible for closing the remaining operator, provenance, correction, and integration path.
+
+## Additive `locations` fields
+
+The canonical `locations` model includes these practical profile fields in addition to the identity, address, coordinate, status, visibility, website, phone, OSM, and timestamp fields already described in `docs/DATA_MODEL.md`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `description` | text nullable | Reviewed public Place description. |
+| `opening_hours` | text nullable | Reviewed public hours text; not a real-time open/closed calculation. |
+| `amenities` | text array nullable | Bounded reviewed practical attributes. |
+| `social_links` | jsonb nullable | Bounded structured official social-link records. |
+
+`social_links` entries use the canonical shape:
+
+```text
+platform
+url
+handle
+```
+
+where `handle` is nullable.
+
+## Canonical and public boundaries
+
+These fields are canonical Location facts only after explicit review. Their presence in a source record, Candidate snapshot, user submission, staging fixture, or public-schema type does not make them canonical.
+
+The required logical flow is:
+
+```text
+source or submission value
+    ↓
+private review projection
+    ↓
+reviewer decision
+    ↓
+field provenance
+    ↓
+canonical Location create or correction transaction
+    ↓
+validated public projection
+```
+
+The following boundaries remain mandatory:
+
+- source material is not canonical data;
+- Candidate values are not canonical data;
+- submission values are not canonical data;
+- canonical values are not automatically public;
+- public projection never serializes an operational table directly;
+- practical profile facts do not verify payment acceptance;
+- ownership verification does not automatically approve practical profile corrections.
+
+## Field provenance
+
+P4-18B must verify field-level provenance coverage for practical Location facts.
+
+For non-empty reviewed values, the review and write path must support the required source or correction provenance for:
+
+- `description`;
+- `openingHours` / `opening_hours`;
+- `amenities`;
+- `socialLinks` / `social_links`;
+- existing address, website, and phone fields where the same operation handles them.
+
+Implementation naming may use camelCase in TypeScript contracts and snake_case in database field paths where required. The provenance layer must use a stable documented field-path convention and tests must reject silent mismatches.
+
+Record-level origin provenance may remain useful, but it does not replace field-level review when a workflow presents independent factual values for approval.
+
+## Structured update semantics
+
+### Description and opening hours
+
+Scalar text fields support:
+
+- add when currently absent;
+- replace with a reviewed value;
+- remove after an explicit reviewed decision.
+
+An empty form value must not silently mean removal unless the operation contract explicitly distinguishes unchanged, set, and clear states.
+
+### Amenities
+
+The canonical operation must distinguish:
+
+- unchanged;
+- add one or more reviewed values;
+- remove one or more reviewed values;
+- replace the complete reviewed set;
+- clear the reviewed set.
+
+Duplicate entries must be rejected or normalized deterministically before canonical persistence and before public projection.
+
+### Social links
+
+The canonical operation must distinguish:
+
+- unchanged;
+- add a reviewed official link;
+- remove an obsolete link;
+- replace a URL;
+- change or clear a handle;
+- replace or clear the complete reviewed set.
+
+Duplicate `platform + url` pairs are not permitted in the public contract.
+
+## Existing-record correction requirements
+
+P4-18B4 must verify or implement a guarded correction operation for already canonical Places.
+
+A correction operation must provide:
+
+- exact current canonical version or equivalent current-state expectation;
+- explicit field-level diff;
+- reviewer identity and decision time;
+- accepted source or correction provenance;
+- atomic persistence;
+- deterministic request replay;
+- conflict on stale expected state;
+- an auditable application receipt;
+- no direct public publication.
+
+Existing-target Candidate linking must not be assumed to satisfy canonical profile correction requirements merely because it can associate a Candidate with an existing identity.
+
+## Public projection requirements
+
+A practical profile field may enter the public Place projection only when:
+
+- the canonical Location value is eligible for publication;
+- the field is explicitly allowlisted;
+- the public runtime schema accepts the shape;
+- structured duplicates and malformed values are rejected;
+- privacy and leakage checks pass;
+- source and license requirements are satisfied;
+- absence remains absence rather than an inferred negative fact.
+
+## P4-18B completion matrix
+
+P4-18B must record evidence for each practical field class across these boundaries:
+
+| Boundary | Address/contact | Description | Hours | Amenities | Social links |
+|---|---|---|---|---|---|
+| Source or Candidate review contract | Required | Required | Required | Required | Required |
+| Protected operator handling | Required | Required | Required | Required | Required |
+| Field provenance | Required where factual value is written | Required | Required | Required | Required |
+| New canonical create path | Required | Required | Required | Required | Required |
+| Existing canonical correction path | Required | Required | Required | Required | Required |
+| Public projection | Required | Required | Required | Required | Required |
+| Runtime and leakage validation | Required | Required | Required | Required | Required |
+| Staging review fixture | Representative | Representative | Representative | Representative | Representative |
+| Public surface review | Required | Required | Required | Required | Required |
+
+A matrix row is not complete because an adjacent layer happens to carry the same TypeScript property. The actual operation and validation path must be demonstrated.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,92 +1,141 @@
 # CryptoPayMap project status
 
-**Last verified:** 2026-07-07
+**Last verified:** 2026-07-08
 
 ## Current phase
 
-Phase 4 — Public core / MVP-A — Repository work completed through pull request #122
+Phase 4 — Public core / MVP-A closure
+
+## Current implementation item
+
+P4-18A — Tracking correction and closure inventory
 
 ## Current repository state
 
-- P4-16 — MVP-A integration and quality audit — Completed
-- P4-17A through P4-17F — Places UX recovery — Completed, validated, and merged
-- Pull request #122 merged into `main`
-- Merge commit: `ddd7265e095590c66af10b64c4679d3b2ab5669b`
+- Phase 3 administration and review repository work is complete through P3-12.
+- Phase 4 public MVP-A surfaces are implemented.
+- P4-17A through P4-17F Places recovery is completed, validated, and merged through pull request #122.
+- Review deployment now follows `main` and updates the fixed review URL after merge through #123.
+- Deployment receipts record the deployed `main` commit through #124.
+- Representative desktop/mobile and interactive-state screenshot capture is merged through #125.
+- Selected Place focus, marker presentation, and desktop selected-panel containment corrections are merged through #126.
+- P4-18 is the active bounded closure term before Phase 5 public submissions.
 
-## Required Places references
+## Fixed review environment
 
-Before changing Places behavior, read:
+Review URL:
 
-1. `docs/PLACES_UX_ACCEPTANCE.md`
-2. `docs/PLACES_RECOVERY_PLAN.md`
-3. `docs/PLACES_UX_FINAL_AUDIT.md`
-4. `docs/PLACES_VALIDATION_EVIDENCE.md`
-5. the P4-17 section of `docs/IMPLEMENTATION_PLAN.md`
-6. `docs/PLACE_PUBLIC_PROFILE.md`
+`https://review.cryptopaymap-staging.pages.dev`
 
-The complete 17-point recovery set remains the acceptance boundary for future Places changes.
+Latest verified deployment receipt at the start of P4-18A:
 
-## Recovery sequence
+`49d68be44cf453d5fa50315c0bd933352ad05fbf`
 
-- P4-17A — contract and tracking correction — Completed
-- P4-17B — map presentation foundation recovery — Completed and validated
-- P4-17C — Place information and public projection recovery — Completed and validated
-- P4-17D — desktop selected panel and mobile sheet recovery — Completed and validated
-- P4-17E — gallery, image enlargement, and external navigation — Completed and validated
-- P4-17F — state, responsive, accessibility, and final 17-point acceptance audit — Completed and validated
+The receipt records that the fixed review URL was deployed from that `main` commit. Later P4-18 work must verify the current receipt rather than assuming the URL is current.
 
-## Validated recovery result
+## Required current references
 
-The merged implementation includes:
+Before starting or reviewing P4-18 work, read:
 
-- stable broad initial camera and street-map-oriented default style;
-- explicit Place pin symbols distinct from aggregate clusters;
-- reviewed practical Place profile fields through canonical, promotion, public-schema, staging, and selected-surface boundaries;
-- near-complete desktop selected-Place information;
-- compact mobile peek and practical expanded sheet;
-- position-based direct drag-following sheet motion with first-entry and same-Place reentry coverage;
-- Gallery and enlarged-media viewer with keyboard, touch, focus containment, focus return, body scroll lock, and attribution behavior;
-- Google Maps and Apple Maps navigation handoff;
-- Current location ephemeral focus with explicit area commit and distinct error states;
-- dynamic mobile map height and deterministic selection, URL, and history behavior;
-- accessible mobile site-menu and mobile Filters focus containment;
-- covered desktop Result List hidden from keyboard focus while selected details are active;
-- durable 17-point audit and regression coverage.
+1. `docs/IMPLEMENTATION_PLAN.md`;
+2. `docs/PHASE4_CLOSURE_PLAN.md`;
+3. the public specification documents relevant to the active item.
 
-## Validation
+For Places work also read:
 
-Validated implementation head:
+1. `docs/PLACES_UX_ACCEPTANCE.md`;
+2. `docs/PLACES_RECOVERY_PLAN.md`;
+3. `docs/PLACES_UX_FINAL_AUDIT.md`;
+4. `docs/PLACE_PUBLIC_PROFILE.md` when practical Place information is affected.
 
-`7f1c3f7c3d2efa9234584401a8984da23b0564ba`
+For Phase 5 preparation and submission work also read:
 
-The complete recovery implementation passed:
+1. `docs/SUBMISSION_WORKFLOW.md`;
+2. `docs/DATA_MODEL.md`;
+3. `docs/MEDIA_POLICY.md` when Media intake or review is affected.
 
-1. Foundation validation
-2. Migration drift
-3. Staging review validation
+## Active closure sequence
 
-Foundation validation included formatting, lint, Astro/TypeScript checks, runtime schema checks, migration history, 126 passing test files with 505 passing tests, static build, accessibility foundation checks, Phase 1 file checks, and staging artifact checks.
+1. P4-18A — tracking correction and closure inventory — In progress
+2. P4-18B1 — source and Candidate practical-profile contract — Planned
+3. P4-18B2 — promotion editor and field provenance parity — Planned
+4. P4-18B3 — canonical persistence and public projection integration — Planned
+5. P4-18B4 — existing-record practical-profile correction path audit and completion — Planned
+6. P4-18C — bounded UI residual closure — Planned
+7. P4-18D — administration workflow integration audit — Planned
+8. P4-18E — live review and Phase 5 handoff audit — Planned
 
-The only commit after the validated implementation head within #122 updated validation documentation and did not change the validated implementation.
+The authoritative scope and completion criteria are in `docs/PHASE4_CLOSURE_PLAN.md`.
+
+## Known P4-18B operational parity gap
+
+The practical Place profile schema and persistence layer support reviewed fields including description, opening hours, amenities, and structured social links. The closure inventory found that the protected promotion form and field-source selection path do not yet provide complete operator handling and provenance coverage for the entire practical profile set.
+
+P4-18B must trace and close the complete path:
+
+```text
+source observation or submission
+    ↓
+safe review projection
+    ↓
+reviewer-visible field value
+    ↓
+field provenance
+    ↓
+canonical create or correction transaction
+    ↓
+public projection
+    ↓
+validation and leakage checks
+    ↓
+staging review
+    ↓
+public surfaces
+```
+
+A schema column or display fixture alone does not complete operational parity.
+
+## P4-18C bounded UI residual scope
+
+The remaining scheduled UI closure scope is limited to:
+
+- Mobile Places List compactness and scanability;
+- Mobile Menu density;
+- expanded-sheet information order and access to payment-critical information;
+- Filters completion, clear, zero-result, and Map/List behavior;
+- only material density or layout defects on representative long-form public pages.
+
+Representative screenshot capture is now a standard review instrument. A successful capture job does not replace image inspection.
+
+Small later visual findings may be handled as bounded fixes and do not keep P4-18C open indefinitely.
+
+## Phase 5 handoff
+
+Phase 5 does not begin until P4-18E completes the handoff and this status file moves to P5-01.
+
+Planned Phase 5 order:
+
+1. P5-01 — Shared submission foundation
+2. P5-02 — Suggest Place and Online Service
+3. P5-03 — Payment and problem reports
+4. P5-04 — Business and service claims
+5. P5-05 — Photo and Media submission intake
+6. P5-06 — Review workflow extensions
+7. P5-07 — Canonical application transactions and retention
+8. P5-08 — MVP-B integration audit
 
 ## Next
 
-1. Treat the merged 17-point Places contract as the baseline for all future Places work.
-2. Keep deferred live verification separate from repository completion status.
-3. Determine the next repository work from the Phase 5 Public submissions / MVP-B handoff and current roadmap priorities before starting implementation.
-
-## Repository history relevant to this work
-
-- Phase 3 repository work completed through #95.
-- Public-core foundations P4-01 through P4-15 progressed through #119.
-- P4-16A staging acceptance coverage completed through #120.
-- P4-16B mobile List-to-Map synchronization completed through #121.
-- P4-17A through P4-17F completed and merged through #122.
+Complete P4-18A documentation and tracking synchronization, merge it, then begin P4-18B1 from the updated reference set.
 
 ## Blocked
 
-No repository blocker. Deferred live verification remains separate from repository completion work.
+No known repository blocker.
+
+P4-18D and P4-18E must replace broad deferred-verification language with a precise inventory of environment-specific checks that were completed, could not be completed, or remain assigned to launch work.
 
 ## Verification rule
 
-Repository reality is determined by current `main`, merged pull requests, and CI results. Required Places behavior is determined by the merged Places acceptance contract, recovery plan, final 17-point audit matrix, and validation evidence.
+Repository reality is determined by current `main`, merged pull requests, and actual CI results. Current work order is determined by `docs/PROJECT_STATUS.md`, `docs/IMPLEMENTATION_PLAN.md`, and the active closure or phase specification.
+
+Do not claim live verification from repository checks alone. Do not claim visual acceptance from screenshot generation alone; relevant images must be inspected.


### PR DESCRIPTION
## Implementation item

`P4-18A`

## Purpose

Synchronize repository tracking with current `main`, define the bounded Phase 4 closure term, close documentation drift around practical Place profile operations, and split Phase 5 into an explicit implementation sequence before further implementation begins.

## Changes

- add `docs/PHASE4_CLOSURE_PLAN.md` with P4-18A through P4-18E scope, dependencies, and completion gates;
- update `docs/IMPLEMENTATION_PLAN.md` through merged groundwork #123–#126 and add P4-18B1–B4, P4-18C, P4-18D, P4-18E;
- decompose Phase 5 into P5-01 through P5-08;
- add `docs/PHASE5_IMPLEMENTATION_SEQUENCE.md` while retaining `docs/SUBMISSION_WORKFLOW.md` as the behavioral contract;
- move `docs/PROJECT_STATUS.md` to active P4-18A and record the fixed review environment and next sequence;
- strengthen `docs/PLACE_PUBLIC_PROFILE.md` with full operational parity and existing-record correction requirements;
- add `docs/PRACTICAL_PROFILE_DATA_MODEL_EXTENSION.md` to document the additive Location profile fields and P4-18B operation requirements;
- update `AGENTS.md` reference order and handoff rules;
- update the pull request template with active-reference, screenshot-inspection, and practical-profile path checks.

## Out of scope

- practical profile implementation changes;
- UI residual fixes;
- Admin workflow code changes;
- public submission implementation;
- live-environment claims beyond already recorded deployment receipt state.

## Completion criteria

- P4-18 execution order is explicit and bounded;
- practical profile operational parity is defined across source/review/provenance/canonical/public boundaries;
- remaining UI scope is fixed rather than open-ended;
- Admin integration and live handoff audits have explicit scope;
- Phase 5 implementation order and handoff gate are explicit;
- future work has a stable reference order.

## Checks

Documentation-focused validation should still run all repository CI triggered for this pull request. No product Changelog or public Roadmap entry is intended because this PR changes repository development control rather than public product behavior.