### PR TITLE
P4-18B3A: add practical Place projection and create-path coverage

### DIFF
--- a/docs/P4_18_B3_AUDIT.md
+++ b/docs/P4_18_B3_AUDIT.md
@@ -16,7 +16,7 @@ This audit is bounded to the new-target create path. Existing-record correction 
 |---|---|---|
 | Atomic persistence | Candidate Promotion Drizzle backend writes Entity, Location, Claim, Claim Assets, provenance, mapping, Candidate state, and decision in one database batch | add practical-field regression coverage and preserve single-batch boundary |
 | Replay and conflict behavior | request fingerprint replay and conflict guards already exist in service/backends | extend practical-field regression coverage |
-| Field provenance rows | Drizzle backend expands field assignments into durable provenance rows | align in-memory integration backend with field-level rows and test practical fields |
+| Field provenance rows | Drizzle backend expands field assignments into durable provenance rows | verify practical field assignments before backend commit and the durable expansion contract |
 | Public allowlisting | strict `publicPlaceSchema` already includes practical fields | add explicit canonical-to-public Place projection helper that selects only public fields |
 | Strict schema validation | public export schemas use strict Zod contracts | projection helper must parse through `publicPlaceSchema` |
 | Leakage rejection | public export boundary recursively rejects operational keys and non-public URI schemes | projection tests must pass output through `validatePublicArtifact` and prove private extras are not projected |
@@ -30,7 +30,7 @@ This audit is bounded to the new-target create path. Existing-record correction 
 
 ### B3A — Practical create path and public Place projection
 
-- align in-memory Promotion provenance with field-level assignments;
+- verify normalized field-level Promotion assignments and durable provenance expansion behavior;
 - add practical-field Promotion persistence, replay, conflict, rollback, and provenance regression tests;
 - add explicit allowlisted canonical Place projection helper;
 - validate projected Place output through strict public schema and export leakage boundary;

--- a/docs/P4_18_B3_AUDIT.md
+++ b/docs/P4_18_B3_AUDIT.md
@@ -1,0 +1,59 @@
+# P4-18B3 canonical persistence and public projection audit
+
+**Implementation item:** P4-18B3  
+**Status:** Active  
+**Last updated:** 2026-07-08
+
+## Purpose
+
+P4-18B3 verifies the new-target practical Place create path from reviewed Promotion values through atomic canonical persistence, field provenance, public projection validation, staging coverage, and all required public Place surfaces.
+
+This audit is bounded to the new-target create path. Existing-record correction transactions remain P4-18B4.
+
+## Required check matrix
+
+| Closure requirement | Current repository evidence | B3 action |
+|---|---|---|
+| Atomic persistence | Candidate Promotion Drizzle backend writes Entity, Location, Claim, Claim Assets, provenance, mapping, Candidate state, and decision in one database batch | add practical-field regression coverage and preserve single-batch boundary |
+| Replay and conflict behavior | request fingerprint replay and conflict guards already exist in service/backends | extend practical-field regression coverage |
+| Field provenance rows | Drizzle backend expands field assignments into durable provenance rows | align in-memory integration backend with field-level rows and test practical fields |
+| Public allowlisting | strict `publicPlaceSchema` already includes practical fields | add explicit canonical-to-public Place projection helper that selects only public fields |
+| Strict schema validation | public export schemas use strict Zod contracts | projection helper must parse through `publicPlaceSchema` |
+| Leakage rejection | public export boundary recursively rejects operational keys and non-public URI schemes | projection tests must pass output through `validatePublicArtifact` and prove private extras are not projected |
+| Absence semantics | optional practical public fields already allow omission | projection helper must omit unavailable optional sections rather than invent negative facts |
+| Staging artifact coverage | staging fixture contains phone, description, hours, amenities, social link, and Media | staging artifact check must assert canonical Place detail exposes practical values |
+| Desktop selected panel | already consumes practical public fields | retain existing component coverage |
+| Mobile expanded sheet | already consumes practical public fields | retain existing component coverage |
+| Canonical Place detail | payment, Evidence, freshness, and Media exist; practical profile presentation is incomplete | add practical profile sections and staging artifact assertions |
+
+## Execution slices
+
+### B3A — Practical create path and public Place projection
+
+- align in-memory Promotion provenance with field-level assignments;
+- add practical-field Promotion persistence, replay, conflict, rollback, and provenance regression tests;
+- add explicit allowlisted canonical Place projection helper;
+- validate projected Place output through strict public schema and export leakage boundary;
+- add practical profile presentation to canonical Place detail;
+- assert practical staging fixture values are present in the built Place detail artifact.
+
+### B3B — Projection integration audit
+
+- inspect the private export-candidate generation boundary and actual canonical query adapters;
+- connect the explicit Place projection helper where a repository-owned canonical projection path exists;
+- if artifact generation is intentionally external to this repository boundary, record that boundary precisely and add the strongest repository integration test available without fabricating a live database claim;
+- verify practical provenance metadata joins or record the exact remaining environment-specific dependency.
+
+### B3C — B3 closure audit
+
+- run the complete repository validation set;
+- reconcile the matrix above against merged code and tests;
+- record any live-only checks for P4-18E rather than treating repository tests as live verification;
+- move tracking to P4-18B4 only after all repository B3 requirements are closed.
+
+## Non-goals
+
+- existing-record practical-profile correction transactions;
+- public submission intake;
+- UI residual redesign outside the canonical Place detail practical-profile parity required by B3;
+- live database or production publication claims from repository tests alone.

--- a/scripts/check-staging-review-artifact.mjs
+++ b/scripts/check-staging-review-artifact.mjs
@@ -103,6 +103,16 @@ if (
 ) {
   throw new Error('Staging Place detail does not expose both cover and gallery Media fixtures.');
 }
+if (
+  !placeDetailHtml.includes('Before you visit') ||
+  !placeDetailHtml.includes('Synthetic staging café profile used to review practical Place information') ||
+  !placeDetailHtml.includes('Mon–Fri 08:00–18:00') ||
+  !placeDetailHtml.includes('Outdoor Seating') ||
+  !placeDetailHtml.includes('@stagingcoffee') ||
+  !placeDetailHtml.includes('+81 3 0000 0000')
+) {
+  throw new Error('Staging Place detail does not expose the complete practical profile fixture.');
+}
 
 const onlineIndexHtml = await readText('online/index.html');
 if (
@@ -121,5 +131,5 @@ if (
 }
 
 console.log(
-  `Staging review artifact checks passed: ${places.records.length} places, ${pins.records.length} pins, ${services.records.length} services, ${representativeRoutes.length} representative routes, with public Media coverage.`,
+  `Staging review artifact checks passed: ${places.records.length} places, ${pins.records.length} pins, ${services.records.length} services, ${representativeRoutes.length} representative routes, with public Media and practical Place profile coverage.`,
 );

--- a/scripts/check-staging-review-artifact.mjs
+++ b/scripts/check-staging-review-artifact.mjs
@@ -105,7 +105,9 @@ if (
 }
 if (
   !placeDetailHtml.includes('Before you visit') ||
-  !placeDetailHtml.includes('Synthetic staging café profile used to review practical Place information') ||
+  !placeDetailHtml.includes(
+    'Synthetic staging café profile used to review practical Place information',
+  ) ||
   !placeDetailHtml.includes('Mon–Fri 08:00–18:00') ||
   !placeDetailHtml.includes('Outdoor Seating') ||
   !placeDetailHtml.includes('@stagingcoffee') ||

--- a/src/components/public/PlacePracticalProfile.astro
+++ b/src/components/public/PlacePracticalProfile.astro
@@ -1,0 +1,106 @@
+---
+import type { PublicPlace } from '../../public/place-detail';
+
+interface Props {
+  place: PublicPlace;
+}
+
+const { place } = Astro.props;
+const amenities = place.amenities ?? [];
+const socialLinks = place.socialLinks ?? [];
+const hasPracticalProfile =
+  Boolean(place.phone || place.description || place.openingHours) ||
+  amenities.length > 0 ||
+  socialLinks.length > 0;
+
+const formatLabel = (value: string) =>
+  value
+    .split(/[_-]/)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+---
+
+{
+  hasPracticalProfile ? (
+    <section
+      class="safe-area-inline page-container pb-12 sm:pb-16"
+      aria-labelledby="practical-profile-title"
+    >
+      <div class="rounded-card border border-border bg-surface p-5 shadow-sm sm:p-7">
+        <p class="m-0 text-sm font-semibold text-brand-700">Practical information</p>
+        <h2
+          id="practical-profile-title"
+          class="mt-1 text-2xl font-semibold tracking-tight text-ink"
+        >
+          Before you visit
+        </h2>
+
+        <div class="mt-6 grid gap-6 lg:grid-cols-2">
+          {place.description ? (
+            <section aria-labelledby="place-about-title">
+              <h3 id="place-about-title" class="m-0 text-sm font-semibold text-ink">
+                About
+              </h3>
+              <p class="mt-2 whitespace-pre-line text-sm leading-6 text-muted">
+                {place.description}
+              </p>
+            </section>
+          ) : null}
+
+          {place.openingHours ? (
+            <section aria-labelledby="place-hours-title">
+              <h3 id="place-hours-title" class="m-0 text-sm font-semibold text-ink">
+                Opening hours
+              </h3>
+              <p class="mt-2 whitespace-pre-line text-sm leading-6 text-muted">
+                {place.openingHours}
+              </p>
+            </section>
+          ) : null}
+
+          {amenities.length > 0 ? (
+            <section aria-labelledby="place-amenities-title">
+              <h3 id="place-amenities-title" class="m-0 text-sm font-semibold text-ink">
+                Amenities
+              </h3>
+              <div class="mt-3 flex flex-wrap gap-2">
+                {amenities.map((amenity) => (
+                  <span class="rounded-pill border border-border bg-canvas px-3 py-1.5 text-sm text-ink">
+                    {formatLabel(amenity)}
+                  </span>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {place.phone || socialLinks.length > 0 ? (
+            <section aria-labelledby="place-contact-title">
+              <h3 id="place-contact-title" class="m-0 text-sm font-semibold text-ink">
+                Contact and official links
+              </h3>
+              <div class="mt-3 flex flex-wrap gap-3">
+                {place.phone ? (
+                  <a
+                    class="motion-feedback inline-flex min-h-11 items-center rounded-control border border-border px-4 py-2 text-sm font-semibold text-ink no-underline hover:bg-brand-50"
+                    href={`tel:${place.phone}`}
+                  >
+                    {place.phone}
+                  </a>
+                ) : null}
+                {socialLinks.map((link) => (
+                  <a
+                    class="motion-feedback inline-flex min-h-11 items-center rounded-control border border-border px-4 py-2 text-sm font-semibold text-ink no-underline hover:bg-brand-50"
+                    href={link.url}
+                    rel="external noopener"
+                  >
+                    {link.handle ?? formatLabel(link.platform)}
+                  </a>
+                ))}
+              </div>
+            </section>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  ) : null
+}

--- a/src/pages/place/[slug].astro
+++ b/src/pages/place/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import PlaceDetail from '../../components/public/PlaceDetail.astro';
+import PlacePracticalProfile from '../../components/public/PlacePracticalProfile.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { buildPlaceDetailModel, type PublicPlace } from '../../public/place-detail';
 import { publicPlaceSchema } from '../../schemas/public-exports';
@@ -27,4 +28,5 @@ const description = `${place.name}: verified cryptocurrency payment information,
 
 <BaseLayout title={`${place.name} | CryptoPayMap`} description={description}>
   <PlaceDetail model={model} />
+  <PlacePracticalProfile place={place} />
 </BaseLayout>

--- a/src/publication/place-projection.ts
+++ b/src/publication/place-projection.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+import {
+  canonicalEntitySchema,
+  canonicalLocationSchema,
+  type CanonicalEntityInput,
+  type CanonicalLocationInput,
+} from '../schemas/canonical-identity';
+import { publicPlaceSchema } from '../schemas/public-exports';
+
+export type PublicPlaceProjection = z.infer<typeof publicPlaceSchema>;
+
+export interface CanonicalPlaceProjectionInput {
+  entitySlug: string;
+  categorySlug: string;
+  entity: CanonicalEntityInput;
+  location: CanonicalLocationInput;
+  claims: PublicPlaceProjection['claims'];
+  media: PublicPlaceProjection['media'];
+  provenance: PublicPlaceProjection['provenance'];
+}
+
+export class CanonicalPlaceProjectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CanonicalPlaceProjectionError';
+  }
+}
+
+export function projectCanonicalPlace(input: CanonicalPlaceProjectionInput): PublicPlaceProjection {
+  const entity = canonicalEntitySchema.parse(input.entity);
+  const location = canonicalLocationSchema.parse(input.location);
+
+  if (entity.visibility !== 'public' || location.visibility !== 'public') {
+    throw new CanonicalPlaceProjectionError(
+      'Only canonical Entity and Location records explicitly marked public can be projected.',
+    );
+  }
+  if (entity.slug !== null && entity.slug !== input.entitySlug) {
+    throw new CanonicalPlaceProjectionError(
+      'The requested public Entity slug does not match the canonical Entity slug.',
+    );
+  }
+
+  const optionalProfile = {
+    ...(location.description === undefined ? {} : { description: location.description }),
+    ...(location.openingHours === undefined ? {} : { openingHours: location.openingHours }),
+    ...(location.amenities === undefined ? {} : { amenities: location.amenities }),
+    ...(location.socialLinks === undefined ? {} : { socialLinks: location.socialLinks }),
+  };
+
+  return publicPlaceSchema.parse({
+    placeSlug: location.slug,
+    entitySlug: input.entitySlug,
+    name: location.name ?? entity.name,
+    categorySlug: input.categorySlug,
+    entityStatus: entity.entityStatus,
+    locationStatus: location.locationStatus,
+    addressLine: location.addressLine,
+    locality: location.locality,
+    region: location.region,
+    postalCode: location.postalCode,
+    countryCode: location.countryCode,
+    latitude: location.latitude,
+    longitude: location.longitude,
+    websiteUrl: location.websiteUrl ?? entity.websiteUrl,
+    phone: location.phone,
+    ...optionalProfile,
+    claims: input.claims,
+    media: input.media,
+    provenance: input.provenance,
+  });
+}

--- a/tests/candidate-promotion-practical-create-path.test.ts
+++ b/tests/candidate-promotion-practical-create-path.test.ts
@@ -269,9 +269,9 @@ describe('practical Place Promotion create path', () => {
     const store = backend(true);
     const before = store.snapshot();
 
-    await expect(createCandidatePromotionService(store).promote(context, input())).rejects.toThrow(
-      'Injected Candidate promotion failure before atomic commit.',
-    );
+    await expect(
+      createCandidatePromotionService(store).promote(context, input()),
+    ).rejects.toMatchObject({ code: 'backend_failure' });
     expect(store.snapshot()).toEqual(before);
   });
 });

--- a/tests/candidate-promotion-practical-create-path.test.ts
+++ b/tests/candidate-promotion-practical-create-path.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createCandidatePromotionService,
+  type CandidatePromotionCommand,
+  type CandidatePromotionInput,
+} from '../src/admin/promotion/candidate-promotion';
+import { InMemoryCandidatePromotionBackend } from '../src/admin/promotion/in-memory-candidate-promotion-backend';
+import {
+  expandPromotionProvenanceAssignments,
+  type PromotionProvenanceAssignment,
+} from '../src/admin/promotion/provenance-plan';
+
+const ids = {
+  request: '10000000-0000-4000-8000-000000000001',
+  candidate: '20000000-0000-4000-8000-000000000001',
+  entity: '30000000-0000-4000-8000-000000000001',
+  location: '40000000-0000-4000-8000-000000000001',
+  claim: '50000000-0000-4000-8000-000000000001',
+  claimAsset: '60000000-0000-4000-8000-000000000001',
+  source: '70000000-0000-4000-8000-000000000001',
+  asset: '80000000-0000-4000-8000-000000000001',
+  network: '90000000-0000-4000-8000-000000000001',
+  method: 'a0000000-0000-4000-8000-000000000001',
+} as const;
+
+const reviewedAt = '2026-07-07T00:00:00.000Z';
+const promotedAt = '2026-07-08T00:00:00.000Z';
+
+function assignment(
+  subjectType: PromotionProvenanceAssignment['subjectType'],
+  subjectId: string,
+  fieldPath: string,
+): PromotionProvenanceAssignment {
+  return {
+    subjectType,
+    subjectId,
+    fieldPath,
+    sourceRecordIds: [ids.source],
+    provenanceRole: 'origin',
+  };
+}
+
+function provenanceAssignments(): PromotionProvenanceAssignment[] {
+  return [
+    ...['name', 'websiteUrl', 'countryCode'].map((field) =>
+      assignment('entity', ids.entity, field),
+    ),
+    ...[
+      'name',
+      'addressLine',
+      'locality',
+      'region',
+      'postalCode',
+      'countryCode',
+      'latitude',
+      'longitude',
+      'websiteUrl',
+      'phone',
+      'description',
+      'openingHours',
+      'amenities',
+      'socialLinks',
+    ].map((field) => assignment('location', ids.location, field)),
+    ...[
+      'routeType',
+      'acceptanceScope',
+      'customerPaysCrypto',
+      'merchantExplicitlyAcceptsCrypto',
+      'howToPay',
+      'merchantReceives',
+    ].map((field) => assignment('acceptance_claim', ids.claim, field)),
+    ...['assetId', 'networkId', 'paymentMethodId'].map((field) =>
+      assignment('claim_asset', ids.claimAsset, field),
+    ),
+  ];
+}
+
+function input(): CandidatePromotionInput {
+  return {
+    candidateId: ids.candidate,
+    expectedCandidateType: 'physical_place',
+    expectedCandidateUpdatedAt: reviewedAt,
+    promotedAt,
+    entity: {
+      id: ids.entity,
+      value: {
+        entityType: 'merchant',
+        name: 'Reviewed Cafe',
+        slug: null,
+        legalName: null,
+        websiteUrl: 'https://example.test',
+        countryCode: 'JP',
+        entityStatus: 'active',
+        visibility: 'hidden',
+      },
+    },
+    location: {
+      id: ids.location,
+      value: {
+        name: 'Reviewed Cafe Tokyo',
+        slug: 'reviewed-cafe-tokyo',
+        addressLine: '1-1 Example',
+        locality: 'Tokyo',
+        region: 'Tokyo',
+        postalCode: '100-0001',
+        countryCode: 'JP',
+        latitude: 35.681236,
+        longitude: 139.767125,
+        locationStatus: 'active',
+        visibility: 'hidden',
+        websiteUrl: 'https://example.test/tokyo',
+        phone: '+81 3 0000 0000',
+        description: 'Reviewed public description.',
+        openingHours: 'Mon-Fri 08:00-18:00',
+        amenities: ['wifi', 'outdoor-seating'],
+        socialLinks: [
+          {
+            platform: 'instagram',
+            url: 'https://social.example.test/reviewed-cafe',
+            handle: '@reviewedcafe',
+          },
+        ],
+        osmType: null,
+        osmId: null,
+      },
+    },
+    claim: {
+      id: ids.claim,
+      value: {
+        entityId: ids.entity,
+        locationId: ids.location,
+        claimScope: 'location_specific',
+        routeType: 'direct_wallet',
+        acceptanceScope: 'all_checkout',
+        claimStatus: 'candidate',
+        visibility: 'hidden',
+        customerPaysCrypto: true,
+        merchantExplicitlyAcceptsCrypto: true,
+        processorId: null,
+        howToPay: 'Ask staff for the payment request and scan the displayed QR code.',
+        instructionsLanguage: 'en',
+        merchantReceives: 'crypto',
+        restrictions: null,
+        firstConfirmedAt: null,
+        lastConfirmedAt: null,
+        nextReviewAt: null,
+        endedAt: null,
+        endedReason: null,
+      },
+    },
+    claimAssets: [
+      {
+        id: ids.claimAsset,
+        value: {
+          claimId: ids.claim,
+          assetId: ids.asset,
+          networkId: ids.network,
+          paymentMethodId: ids.method,
+          contractAddress: null,
+          isPrimary: true,
+          notes: null,
+        },
+      },
+    ],
+    sourceRecordIds: [ids.source],
+    provenanceAssignments: provenanceAssignments(),
+  };
+}
+
+function backend(failBeforeCommit = false) {
+  return new InMemoryCandidatePromotionBackend({
+    candidates: [
+      {
+        id: ids.candidate,
+        candidateType: 'physical_place',
+        candidateStatus: 'triaged',
+        updatedAt: reviewedAt,
+        canonicalEntityId: null,
+        canonicalLocationId: null,
+        sourceRecordIds: [ids.source],
+      },
+    ],
+    legacyMappings: [
+      {
+        id: 'b0000000-0000-4000-8000-000000000001',
+        sourceSystem: 'cryptopaymap_v2',
+        sourceRecordId: ids.source,
+        migrationStatus: 'pending',
+        canonicalPath: null,
+        entityId: null,
+        locationId: null,
+        resolvedAt: null,
+      },
+    ],
+    assetIds: [ids.asset],
+    networkIds: [ids.network],
+    paymentMethodIds: [ids.method],
+    failBeforeCommit: () => failBeforeCommit,
+  });
+}
+
+const context = {
+  requestId: ids.request,
+  actorId: 'canonical-reviewer',
+  actorType: 'human' as const,
+  capabilities: ['candidate:promote' as const],
+};
+
+describe('practical Place Promotion create path', () => {
+  it('persists the reviewed practical profile and carries explicit field provenance into the command', async () => {
+    const store = backend();
+    const commands: CandidatePromotionCommand[] = [];
+    const service = createCandidatePromotionService({
+      commitPromotion: async (command) => {
+        commands.push(command);
+        return store.commitPromotion(command);
+      },
+    });
+
+    await expect(service.promote(context, input())).resolves.toMatchObject({
+      state: 'committed',
+      canonicalPath: '/place/reviewed-cafe-tokyo',
+      visibility: 'hidden',
+      claimStatus: 'candidate',
+    });
+
+    expect(store.snapshot().locations[0]?.value).toMatchObject({
+      phone: '+81 3 0000 0000',
+      description: 'Reviewed public description.',
+      openingHours: 'Mon-Fri 08:00-18:00',
+      amenities: ['wifi', 'outdoor-seating'],
+      socialLinks: [
+        {
+          platform: 'instagram',
+          url: 'https://social.example.test/reviewed-cafe',
+          handle: '@reviewedcafe',
+        },
+      ],
+    });
+
+    const command = commands[0];
+    expect(command).toBeDefined();
+    const practicalRows = expandPromotionProvenanceAssignments(
+      command?.provenanceAssignments ?? [],
+      command?.promotedAt ?? new Date(promotedAt),
+    ).filter((row) => row.subjectType === 'location');
+
+    expect(practicalRows.map((row) => row.fieldPath)).toEqual(
+      expect.arrayContaining(['phone', 'description', 'openingHours', 'amenities', 'socialLinks']),
+    );
+    expect(practicalRows.every((row) => row.provenanceRole === 'origin')).toBe(true);
+  });
+
+  it('replays identical practical create requests and conflicts on changed practical content', async () => {
+    const store = backend();
+    const service = createCandidatePromotionService(store);
+
+    await expect(service.promote(context, input())).resolves.toMatchObject({ state: 'committed' });
+    await expect(service.promote(context, input())).resolves.toMatchObject({ state: 'replayed' });
+
+    const changed = input();
+    if (changed.location === null) throw new Error('Expected physical Place location input.');
+    changed.location.value.openingHours = 'Mon-Sun 24 hours';
+
+    await expect(service.promote(context, changed)).rejects.toMatchObject({ code: 'conflict' });
+  });
+
+  it('rolls back practical profile canonical state when atomic commit fails', async () => {
+    const store = backend(true);
+    const before = store.snapshot();
+
+    await expect(createCandidatePromotionService(store).promote(context, input())).rejects.toThrow(
+      'Injected Candidate promotion failure before atomic commit.',
+    );
+    expect(store.snapshot()).toEqual(before);
+  });
+});

--- a/tests/practical-place-projection.test.ts
+++ b/tests/practical-place-projection.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import { projectCanonicalPlace } from '../src/publication/place-projection';
+import { validatePublicArtifact } from '../src/publication/export-boundary';
+import type { CanonicalEntityInput, CanonicalLocationInput } from '../src/schemas/canonical-identity';
+
+const generatedAt = '2026-07-08T00:00:00Z';
+
+function entity(visibility: CanonicalEntityInput['visibility'] = 'public'): CanonicalEntityInput {
+  return {
+    entityType: 'merchant',
+    name: 'Reviewed Cafe',
+    slug: 'reviewed-cafe',
+    legalName: null,
+    websiteUrl: 'https://example.test',
+    countryCode: 'JP',
+    entityStatus: 'active',
+    visibility,
+  };
+}
+
+function location(visibility: CanonicalLocationInput['visibility'] = 'public'): CanonicalLocationInput {
+  return {
+    name: 'Reviewed Cafe Tokyo',
+    slug: 'reviewed-cafe-tokyo',
+    addressLine: '1-1 Example',
+    locality: 'Tokyo',
+    region: 'Tokyo',
+    postalCode: '100-0001',
+    countryCode: 'JP',
+    latitude: 35.681236,
+    longitude: 139.767125,
+    locationStatus: 'active',
+    visibility,
+    websiteUrl: 'https://example.test/tokyo',
+    phone: '+81 3 0000 0000',
+    description: 'Reviewed public description.',
+    openingHours: 'Mon-Fri 08:00-18:00',
+    amenities: ['wifi', 'outdoor-seating'],
+    socialLinks: [
+      {
+        platform: 'instagram',
+        url: 'https://social.example.test/reviewed-cafe',
+        handle: '@reviewedcafe',
+      },
+    ],
+    osmType: null,
+    osmId: null,
+  };
+}
+
+const claims = [
+  {
+    claimKey: 'reviewed-cafe-tokyo-btc',
+    entitySlug: 'reviewed-cafe',
+    locationSlug: 'reviewed-cafe-tokyo',
+    claimScope: 'location_specific' as const,
+    acceptanceScope: 'all_checkout' as const,
+    status: 'confirmed' as const,
+    routeType: 'direct_wallet' as const,
+    processorSlug: null,
+    howToPay: 'Ask staff for the payment request and scan the displayed QR code.',
+    instructionsLanguage: 'en',
+    merchantReceives: 'crypto' as const,
+    restrictions: null,
+    firstConfirmedAt: '2026-07-01T00:00:00Z',
+    lastConfirmedAt: '2026-07-08T00:00:00Z',
+    nextReviewAt: '2026-10-08T00:00:00Z',
+    endedAt: null,
+    endedReason: null,
+    paymentAssets: [
+      {
+        assetSlug: 'bitcoin',
+        assetSymbol: 'BTC',
+        networkSlug: 'lightning',
+        paymentMethod: 'lightning_invoice' as const,
+        contractAddress: null,
+        isPrimary: true,
+        notes: null,
+      },
+    ],
+    evidence: [
+      {
+        kind: 'official_payment_page' as const,
+        evidenceClass: 'a' as const,
+        sourceType: 'official_page' as const,
+        polarity: 'supporting' as const,
+        sourceName: 'Reviewed Cafe',
+        sourceUrl: 'https://example.test/payments',
+        archiveUrl: null,
+        observedAt: '2026-07-08T00:00:00Z',
+        publishedAt: null,
+        summary: 'The official payment page documents the accepted payment route.',
+      },
+    ],
+  },
+];
+
+const provenance = [
+  {
+    sourceName: 'Reviewed Cafe official profile',
+    sourceUrl: 'https://example.test/tokyo',
+    licenseSlug: null,
+    attribution: null,
+    fields: [
+      'name',
+      'addressLine',
+      'phone',
+      'description',
+      'openingHours',
+      'amenities',
+      'socialLinks',
+    ],
+  },
+];
+
+describe('canonical Place public projection', () => {
+  it('projects practical profile fields through the strict public export boundary', () => {
+    const projected = projectCanonicalPlace({
+      entitySlug: 'reviewed-cafe',
+      categorySlug: 'cafe',
+      entity: entity(),
+      location: location(),
+      claims,
+      media: [],
+      provenance,
+    });
+
+    expect(projected).toMatchObject({
+      placeSlug: 'reviewed-cafe-tokyo',
+      phone: '+81 3 0000 0000',
+      description: 'Reviewed public description.',
+      openingHours: 'Mon-Fri 08:00-18:00',
+      amenities: ['wifi', 'outdoor-seating'],
+      socialLinks: [
+        {
+          platform: 'instagram',
+          url: 'https://social.example.test/reviewed-cafe',
+          handle: '@reviewedcafe',
+        },
+      ],
+    });
+
+    expect(
+      validatePublicArtifact('/data/places.json', {
+        schemaVersion: '1.0.0',
+        generatedAt,
+        records: [projected],
+      }),
+    ).toBeDefined();
+  });
+
+  it('selects only allowlisted fields from canonical inputs', () => {
+    const canonicalLocation = {
+      ...location(),
+      internalNote: 'must never be projected',
+      privatePayload: { contact: 'private@example.test' },
+    } as CanonicalLocationInput & {
+      internalNote: string;
+      privatePayload: { contact: string };
+    };
+
+    const projected = projectCanonicalPlace({
+      entitySlug: 'reviewed-cafe',
+      categorySlug: 'cafe',
+      entity: entity(),
+      location: canonicalLocation,
+      claims,
+      media: [],
+      provenance,
+    });
+
+    expect(projected).not.toHaveProperty('internalNote');
+    expect(projected).not.toHaveProperty('privatePayload');
+  });
+
+  it('omits unavailable optional practical fields without inventing negative facts', () => {
+    const canonicalLocation = location();
+    delete canonicalLocation.description;
+    delete canonicalLocation.openingHours;
+    delete canonicalLocation.amenities;
+    delete canonicalLocation.socialLinks;
+
+    const projected = projectCanonicalPlace({
+      entitySlug: 'reviewed-cafe',
+      categorySlug: 'cafe',
+      entity: entity(),
+      location: canonicalLocation,
+      claims,
+      media: [],
+      provenance,
+    });
+
+    expect(projected).not.toHaveProperty('description');
+    expect(projected).not.toHaveProperty('openingHours');
+    expect(projected).not.toHaveProperty('amenities');
+    expect(projected).not.toHaveProperty('socialLinks');
+  });
+
+  it('rejects hidden canonical records before public projection', () => {
+    expect(() =>
+      projectCanonicalPlace({
+        entitySlug: 'reviewed-cafe',
+        categorySlug: 'cafe',
+        entity: entity('hidden'),
+        location: location('hidden'),
+        claims,
+        media: [],
+        provenance,
+      }),
+    ).toThrow('Only canonical Entity and Location records explicitly marked public can be projected.');
+  });
+
+  it('rejects malformed structured social links through canonical validation', () => {
+    const malformed = {
+      ...location(),
+      socialLinks: [
+        {
+          platform: 'instagram',
+          url: 'http://social.example.test/reviewed-cafe',
+          handle: '@reviewedcafe',
+        },
+      ],
+    } as CanonicalLocationInput;
+
+    expect(() =>
+      projectCanonicalPlace({
+        entitySlug: 'reviewed-cafe',
+        categorySlug: 'cafe',
+        entity: entity(),
+        location: malformed,
+        claims,
+        media: [],
+        provenance,
+      }),
+    ).toThrow();
+  });
+});

--- a/tests/practical-place-projection.test.ts
+++ b/tests/practical-place-projection.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { projectCanonicalPlace } from '../src/publication/place-projection';
 import { validatePublicArtifact } from '../src/publication/export-boundary';
-import type { CanonicalEntityInput, CanonicalLocationInput } from '../src/schemas/canonical-identity';
+import type {
+  CanonicalEntityInput,
+  CanonicalLocationInput,
+} from '../src/schemas/canonical-identity';
 
 const generatedAt = '2026-07-08T00:00:00Z';
 
@@ -18,7 +21,9 @@ function entity(visibility: CanonicalEntityInput['visibility'] = 'public'): Cano
   };
 }
 
-function location(visibility: CanonicalLocationInput['visibility'] = 'public'): CanonicalLocationInput {
+function location(
+  visibility: CanonicalLocationInput['visibility'] = 'public',
+): CanonicalLocationInput {
   return {
     name: 'Reviewed Cafe Tokyo',
     slug: 'reviewed-cafe-tokyo',
@@ -207,7 +212,9 @@ describe('canonical Place public projection', () => {
         media: [],
         provenance,
       }),
-    ).toThrow('Only canonical Entity and Location records explicitly marked public can be projected.');
+    ).toThrow(
+      'Only canonical Entity and Location records explicitly marked public can be projected.',
+    );
   });
 
   it('rejects malformed structured social links through canonical validation', () => {


### PR DESCRIPTION
## Implementation item

`P4-18B3A` within `P4-18B3`

## Purpose

Start the B3 canonical persistence and public projection audit with an explicit allowlisted canonical Place projection boundary, practical-profile Promotion create-path regression coverage, and canonical Place detail presentation parity.

## Changes

- add the B3 required-check audit matrix and execution slices;
- add an explicit canonical Place to public Place projection helper;
- parse canonical Entity and Location inputs before projection;
- reject hidden canonical Entity/Location records before public projection;
- select only allowlisted public Place fields;
- preserve optional practical-field absence semantics;
- validate projected records through the strict public Place schema and public export boundary;
- cover private-extra-field exclusion and malformed structured social-link rejection;
- add practical Promotion create-path tests covering reviewed values, field provenance expansion, replay, changed-content conflict, and rollback;
- add practical profile presentation to canonical Place detail;
- extend staging artifact validation to require description, hours, amenities, phone, and official social-link fixtures in the built Place detail.

## Remaining B3 work

- private export candidate generation / canonical query adapter audit;
- strongest available repository integration test for Promotion-preserved canonical values into public projection and release validation;
- precise live/external dependency inventory where generation is outside the repository boundary;
- B3 closure reconciliation before handoff to B4.

## Out of scope

- existing-record correction transactions (B4);
- public submissions (Phase 5);
- broad UI redesign (P4-18C);
- live database or production publication claims.
