### PR TITLE
P4-18B3B: integrate practical Place provenance and public projection

### DIFF
--- a/docs/P4_18_B3_AUDIT.md
+++ b/docs/P4_18_B3_AUDIT.md
@@ -1,7 +1,7 @@
 # P4-18B3 canonical persistence and public projection audit
 
 **Implementation item:** P4-18B3  
-**Status:** Active  
+**Status:** Active — B3A merged, B3B in progress  
 **Last updated:** 2026-07-08
 
 ## Purpose
@@ -12,44 +12,94 @@ This audit is bounded to the new-target create path. Existing-record correction 
 
 ## Required check matrix
 
-| Closure requirement | Current repository evidence | B3 action |
+| Closure requirement | Repository evidence | Status |
 |---|---|---|
-| Atomic persistence | Candidate Promotion Drizzle backend writes Entity, Location, Claim, Claim Assets, provenance, mapping, Candidate state, and decision in one database batch | add practical-field regression coverage and preserve single-batch boundary |
-| Replay and conflict behavior | request fingerprint replay and conflict guards already exist in service/backends | extend practical-field regression coverage |
-| Field provenance rows | Drizzle backend expands field assignments into durable provenance rows | verify practical field assignments before backend commit and the durable expansion contract |
-| Public allowlisting | strict `publicPlaceSchema` already includes practical fields | add explicit canonical-to-public Place projection helper that selects only public fields |
-| Strict schema validation | public export schemas use strict Zod contracts | projection helper must parse through `publicPlaceSchema` |
-| Leakage rejection | public export boundary recursively rejects operational keys and non-public URI schemes | projection tests must pass output through `validatePublicArtifact` and prove private extras are not projected |
-| Absence semantics | optional practical public fields already allow omission | projection helper must omit unavailable optional sections rather than invent negative facts |
-| Staging artifact coverage | staging fixture contains phone, description, hours, amenities, social link, and Media | staging artifact check must assert canonical Place detail exposes practical values |
-| Desktop selected panel | already consumes practical public fields | retain existing component coverage |
-| Mobile expanded sheet | already consumes practical public fields | retain existing component coverage |
-| Canonical Place detail | payment, Evidence, freshness, and Media exist; practical profile presentation is incomplete | add practical profile sections and staging artifact assertions |
+| Atomic persistence | Candidate Promotion Drizzle backend writes Entity, Location, Claim, Claim Assets, provenance, mapping, Candidate state, and decision in one database batch; practical rollback coverage is merged through #132 | Repository covered |
+| Replay and conflict behavior | request fingerprint replay and conflict guards plus practical-content replay/conflict coverage are merged through #132 | Repository covered |
+| Field provenance rows | Drizzle backend expands field assignments into durable rows; practical assignment and expansion coverage is merged through #132 | Repository covered |
+| Public allowlisting | explicit `projectCanonicalPlace` allowlists canonical Entity and Location values into strict public Place records | Repository covered through #132 |
+| Strict schema validation | canonical inputs and projected Place records pass strict runtime schemas | Repository covered through #132 |
+| Leakage rejection | projection excludes unlisted canonical extras and public export validation remains active | Repository covered through #132 |
+| Absence semantics | optional practical fields remain absent instead of becoming invented negative facts | Repository covered through #132 |
+| Staging artifact coverage | fixture and built Place detail checks exercise description, hours, amenities, phone, social link, and Media | Repository covered through #132 |
+| Desktop selected panel | consumes practical public fields and retains focused component coverage | Existing repository coverage |
+| Mobile expanded sheet | consumes practical public fields and retains focused component coverage | Existing repository coverage |
+| Canonical Place detail | practical profile section and staging artifact assertions are merged through #132 | Repository covered through #132 |
+| Public provenance metadata | B3B adds a fail-closed builder from resolved source metadata plus field-level provenance rows to public Place provenance entries | B3B active |
+| Promotion-to-public integration | B3B covers Promotion-preserved canonical values, hidden-state rejection, explicit public projection, provenance aggregation, and Place artifact validation | B3B active |
 
-## Execution slices
+## B3A result — merged through #132
 
-### B3A — Practical create path and public Place projection
+B3A established:
 
-- verify normalized field-level Promotion assignments and durable provenance expansion behavior;
-- add practical-field Promotion persistence, replay, conflict, rollback, and provenance regression tests;
-- add explicit allowlisted canonical Place projection helper;
-- validate projected Place output through strict public schema and export leakage boundary;
-- add practical profile presentation to canonical Place detail;
-- assert practical staging fixture values are present in the built Place detail artifact.
+- normalized practical-field Promotion assignments and durable provenance expansion coverage;
+- practical-field persistence, replay, changed-content conflict, and rollback regression tests;
+- explicit allowlisted canonical Place projection;
+- strict canonical and public schema validation;
+- private-extra-field exclusion;
+- optional-field absence semantics;
+- malformed structured social-link rejection;
+- canonical Place practical-profile presentation;
+- built staging Place detail assertions for practical profile values.
 
-### B3B — Projection integration audit
+B3A did not claim a live database-to-release generation pipeline.
 
-- inspect the private export-candidate generation boundary and actual canonical query adapters;
-- connect the explicit Place projection helper where a repository-owned canonical projection path exists;
-- if artifact generation is intentionally external to this repository boundary, record that boundary precisely and add the strongest repository integration test available without fabricating a live database claim;
-- verify practical provenance metadata joins or record the exact remaining environment-specific dependency.
+## B3B — Projection integration and boundary audit
 
-### B3C — B3 closure audit
+### Confirmed repository boundary
 
-- run the complete repository validation set;
-- reconcile the matrix above against merged code and tests;
-- record any live-only checks for P4-18E rather than treating repository tests as live verification;
-- move tracking to P4-18B4 only after all repository B3 requirements are closed.
+The repository release-review path begins from an already generated private export candidate bundle. The release workspace loads that private candidate, revalidates the complete artifact set, summarizes the exact artifacts, and pins decisions to a snapshot digest.
+
+The existing release workspace specification explicitly excluded artifact generation and upload from P3-11C. The general public export boundary also states that P2-12 does not provide database queries that construct projections.
+
+Therefore B3B must not pretend that a repository-owned full canonical database → twelve-artifact private candidate generator already exists.
+
+### B3B repository work
+
+B3B adds the strongest repository-level integration available at the practical Place boundary:
+
+```text
+reviewed Promotion input
+    ↓
+hidden canonical Entity and Location values
+    ↓
+field-level provenance assignments
+    ↓
+hidden-state public projection rejection
+    ↓
+explicit public canonical state
+    ↓
+public provenance aggregation from resolved source metadata
+    ↓
+allowlisted public Place projection
+    ↓
+strict Place artifact validation and leakage boundary
+```
+
+The integration test does not treat the explicit public-state test fixture as evidence that a live Claim transition or publication activation occurred. Those remain separate protected workflows.
+
+### External and live boundary to carry forward
+
+P4-18E must verify the configured environment-specific path that actually:
+
+- queries canonical data for candidate generation;
+- resolves source, source-record, license, and attribution metadata;
+- constructs the complete twelve-artifact candidate set;
+- writes the private candidate bundle to the configured source used by release review;
+- preserves practical Place fields and their public provenance metadata;
+- allows the release workspace to revalidate and pin the intended snapshot.
+
+If that generator/upload path does not exist in the configured environment, P4-18E must record it as an explicit launch blocker or assign implementation to the appropriate launch item. Repository tests must not be labeled as live verification.
+
+## B3C — B3 closure audit
+
+B3C must:
+
+- run and reconcile the complete repository validation set;
+- verify the matrix above against merged code and tests;
+- distinguish repository-complete checks from the environment-specific generator/upload path assigned above;
+- record remaining live checks for P4-18E;
+- move tracking to P4-18B4 only after repository B3 requirements are closed.
 
 ## Non-goals
 

--- a/src/publication/place-provenance.ts
+++ b/src/publication/place-provenance.ts
@@ -1,0 +1,100 @@
+import { publicProvenanceSchema } from '../schemas/public-exports';
+
+const publicEntityFieldPaths = new Set(['name', 'websiteUrl', 'countryCode']);
+const publicLocationFieldPaths = new Set([
+  'name',
+  'addressLine',
+  'locality',
+  'region',
+  'postalCode',
+  'countryCode',
+  'latitude',
+  'longitude',
+  'websiteUrl',
+  'phone',
+  'description',
+  'openingHours',
+  'amenities',
+  'socialLinks',
+]);
+
+export interface PublicPlaceProvenanceSourceRecord {
+  sourceRecordId: string;
+  sourceName: string;
+  sourceUrl: string | null;
+  licenseSlug: string | null;
+  attribution: string | null;
+}
+
+export interface PublicPlaceFieldProvenanceRow {
+  subjectType: 'entity' | 'location' | 'acceptance_claim' | 'claim_asset' | 'evidence' | 'verification_event' | 'media';
+  subjectId: string;
+  fieldPath: string | null;
+  sourceRecordId: string;
+  provenanceRole: 'origin' | 'verification' | 'correction' | 'attribution';
+}
+
+export interface PublicPlaceProvenanceInput {
+  entityId: string;
+  locationId: string;
+  sourceRecords: readonly PublicPlaceProvenanceSourceRecord[];
+  rows: readonly PublicPlaceFieldProvenanceRow[];
+}
+
+export class PublicPlaceProvenanceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PublicPlaceProvenanceError';
+  }
+}
+
+function isPublicPlaceField(row: PublicPlaceFieldProvenanceRow, input: PublicPlaceProvenanceInput) {
+  if (row.fieldPath === null) return false;
+  if (row.subjectType === 'entity' && row.subjectId === input.entityId) {
+    return publicEntityFieldPaths.has(row.fieldPath);
+  }
+  if (row.subjectType === 'location' && row.subjectId === input.locationId) {
+    return publicLocationFieldPaths.has(row.fieldPath);
+  }
+  return false;
+}
+
+export function buildPublicPlaceProvenance(input: PublicPlaceProvenanceInput) {
+  const sources = new Map(input.sourceRecords.map((source) => [source.sourceRecordId, source]));
+  const fieldsBySource = new Map<string, Set<string>>();
+
+  for (const row of input.rows) {
+    if (!isPublicPlaceField(row, input)) continue;
+    const source = sources.get(row.sourceRecordId);
+    if (!source) {
+      throw new PublicPlaceProvenanceError(
+        `Public Place provenance is missing source metadata for ${row.sourceRecordId}.`,
+      );
+    }
+    const fields = fieldsBySource.get(row.sourceRecordId) ?? new Set<string>();
+    fields.add(row.fieldPath as string);
+    fieldsBySource.set(row.sourceRecordId, fields);
+  }
+
+  return [...fieldsBySource.entries()]
+    .map(([sourceRecordId, fields]) => {
+      const source = sources.get(sourceRecordId);
+      if (!source) {
+        throw new PublicPlaceProvenanceError(
+          `Public Place provenance is missing source metadata for ${sourceRecordId}.`,
+        );
+      }
+      return publicProvenanceSchema.parse({
+        sourceName: source.sourceName,
+        sourceUrl: source.sourceUrl,
+        licenseSlug: source.licenseSlug,
+        attribution: source.attribution,
+        fields: [...fields].sort((left, right) => left.localeCompare(right)),
+      });
+    })
+    .sort((left, right) => {
+      const name = left.sourceName.localeCompare(right.sourceName);
+      if (name !== 0) return name;
+      return (left.sourceUrl ?? '').localeCompare(right.sourceUrl ?? '');
+    });
+}

--- a/src/publication/place-provenance.ts
+++ b/src/publication/place-provenance.ts
@@ -27,7 +27,14 @@ export interface PublicPlaceProvenanceSourceRecord {
 }
 
 export interface PublicPlaceFieldProvenanceRow {
-  subjectType: 'entity' | 'location' | 'acceptance_claim' | 'claim_asset' | 'evidence' | 'verification_event' | 'media';
+  subjectType:
+    | 'entity'
+    | 'location'
+    | 'acceptance_claim'
+    | 'claim_asset'
+    | 'evidence'
+    | 'verification_event'
+    | 'media';
   subjectId: string;
   fieldPath: string | null;
   sourceRecordId: string;

--- a/tests/place-public-provenance.test.ts
+++ b/tests/place-public-provenance.test.ts
@@ -115,10 +115,7 @@ describe('public Place provenance builder', () => {
       entityId,
       locationId,
       sourceRecords: sources,
-      rows: [
-        row('location', locationId, 'amenities'),
-        row('location', locationId, 'amenities'),
-      ],
+      rows: [row('location', locationId, 'amenities'), row('location', locationId, 'amenities')],
     });
 
     expect(result[0]?.fields).toEqual(['amenities']);

--- a/tests/place-public-provenance.test.ts
+++ b/tests/place-public-provenance.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPublicPlaceProvenance,
+  PublicPlaceProvenanceError,
+  type PublicPlaceFieldProvenanceRow,
+} from '../src/publication/place-provenance';
+
+const entityId = '10000000-0000-4000-8000-000000000001';
+const locationId = '20000000-0000-4000-8000-000000000001';
+const sourceRecordId = '30000000-0000-4000-8000-000000000001';
+const secondSourceRecordId = '30000000-0000-4000-8000-000000000002';
+
+function row(
+  subjectType: PublicPlaceFieldProvenanceRow['subjectType'],
+  subjectId: string,
+  fieldPath: string,
+  sourceRecord = sourceRecordId,
+): PublicPlaceFieldProvenanceRow {
+  return {
+    subjectType,
+    subjectId,
+    fieldPath,
+    sourceRecordId: sourceRecord,
+    provenanceRole: 'origin',
+  };
+}
+
+const sources = [
+  {
+    sourceRecordId,
+    sourceName: 'Reviewed Cafe official profile',
+    sourceUrl: 'https://example.test/tokyo',
+    licenseSlug: null,
+    attribution: null,
+  },
+  {
+    sourceRecordId: secondSourceRecordId,
+    sourceName: 'Official social account',
+    sourceUrl: 'https://social.example.test/reviewed-cafe',
+    licenseSlug: null,
+    attribution: null,
+  },
+];
+
+describe('public Place provenance builder', () => {
+  it('groups public Entity and Location field paths by resolved source record', () => {
+    const result = buildPublicPlaceProvenance({
+      entityId,
+      locationId,
+      sourceRecords: sources,
+      rows: [
+        row('entity', entityId, 'name'),
+        row('location', locationId, 'description'),
+        row('location', locationId, 'openingHours'),
+        row('location', locationId, 'amenities'),
+        row('location', locationId, 'socialLinks', secondSourceRecordId),
+      ],
+    });
+
+    expect(result).toEqual([
+      {
+        sourceName: 'Official social account',
+        sourceUrl: 'https://social.example.test/reviewed-cafe',
+        licenseSlug: null,
+        attribution: null,
+        fields: ['socialLinks'],
+      },
+      {
+        sourceName: 'Reviewed Cafe official profile',
+        sourceUrl: 'https://example.test/tokyo',
+        licenseSlug: null,
+        attribution: null,
+        fields: ['amenities', 'description', 'name', 'openingHours'],
+      },
+    ]);
+  });
+
+  it('excludes private and unrelated field paths from the public provenance projection', () => {
+    const result = buildPublicPlaceProvenance({
+      entityId,
+      locationId,
+      sourceRecords: sources,
+      rows: [
+        row('location', locationId, 'description'),
+        row('location', locationId, 'privateReviewNote'),
+        row('acceptance_claim', '40000000-0000-4000-8000-000000000001', 'howToPay'),
+        row('location', '50000000-0000-4000-8000-000000000001', 'phone'),
+      ],
+    });
+
+    expect(result).toEqual([
+      {
+        sourceName: 'Reviewed Cafe official profile',
+        sourceUrl: 'https://example.test/tokyo',
+        licenseSlug: null,
+        attribution: null,
+        fields: ['description'],
+      },
+    ]);
+  });
+
+  it('fails closed when a public field row lacks resolved source metadata', () => {
+    expect(() =>
+      buildPublicPlaceProvenance({
+        entityId,
+        locationId,
+        sourceRecords: [],
+        rows: [row('location', locationId, 'openingHours')],
+      }),
+    ).toThrow(PublicPlaceProvenanceError);
+  });
+
+  it('deduplicates repeated field rows before public projection', () => {
+    const result = buildPublicPlaceProvenance({
+      entityId,
+      locationId,
+      sourceRecords: sources,
+      rows: [
+        row('location', locationId, 'amenities'),
+        row('location', locationId, 'amenities'),
+      ],
+    });
+
+    expect(result[0]?.fields).toEqual(['amenities']);
+  });
+});

--- a/tests/practical-place-promotion-to-public-integration.test.ts
+++ b/tests/practical-place-promotion-to-public-integration.test.ts
@@ -241,10 +241,10 @@ const confirmedClaims = [
 describe('practical Place Promotion to public projection integration', () => {
   it('preserves reviewed values, blocks hidden canonical projection, and validates the explicit public projection', async () => {
     const store = promotionBackend();
-    let committedCommand: CandidatePromotionCommand | null = null;
+    const commands: CandidatePromotionCommand[] = [];
     const service = createCandidatePromotionService({
       commitPromotion: async (command) => {
-        committedCommand = command;
+        commands.push(command);
         return store.commitPromotion(command);
       },
     });
@@ -264,6 +264,7 @@ describe('practical Place Promotion to public projection integration', () => {
     const snapshot = store.snapshot();
     const entity = snapshot.entities[0]?.value;
     const location = snapshot.locations[0]?.value;
+    const committedCommand = commands[0];
     if (!entity || !location || !committedCommand) {
       throw new Error('Expected committed practical Place canonical snapshot.');
     }
@@ -286,7 +287,9 @@ describe('practical Place Promotion to public projection integration', () => {
           },
         ],
       }),
-    ).toThrow('Only canonical Entity and Location records explicitly marked public can be projected.');
+    ).toThrow(
+      'Only canonical Entity and Location records explicitly marked public can be projected.',
+    );
 
     const provenanceRows = expandPromotionProvenanceAssignments(
       committedCommand.provenanceAssignments,

--- a/tests/practical-place-promotion-to-public-integration.test.ts
+++ b/tests/practical-place-promotion-to-public-integration.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createCandidatePromotionService,
+  type CandidatePromotionCommand,
+  type CandidatePromotionInput,
+} from '../src/admin/promotion/candidate-promotion';
+import { InMemoryCandidatePromotionBackend } from '../src/admin/promotion/in-memory-candidate-promotion-backend';
+import {
+  expandPromotionProvenanceAssignments,
+  type PromotionProvenanceAssignment,
+} from '../src/admin/promotion/provenance-plan';
+import { validatePublicArtifact } from '../src/publication/export-boundary';
+import { projectCanonicalPlace } from '../src/publication/place-projection';
+import { buildPublicPlaceProvenance } from '../src/publication/place-provenance';
+
+const ids = {
+  request: '10000000-0000-4000-8000-000000000001',
+  candidate: '20000000-0000-4000-8000-000000000001',
+  entity: '30000000-0000-4000-8000-000000000001',
+  location: '40000000-0000-4000-8000-000000000001',
+  claim: '50000000-0000-4000-8000-000000000001',
+  claimAsset: '60000000-0000-4000-8000-000000000001',
+  source: '70000000-0000-4000-8000-000000000001',
+  asset: '80000000-0000-4000-8000-000000000001',
+  network: '90000000-0000-4000-8000-000000000001',
+  method: 'a0000000-0000-4000-8000-000000000001',
+} as const;
+
+const reviewedAt = '2026-07-07T00:00:00.000Z';
+const promotedAt = '2026-07-08T00:00:00.000Z';
+
+function assignment(
+  subjectType: PromotionProvenanceAssignment['subjectType'],
+  subjectId: string,
+  fieldPath: string,
+): PromotionProvenanceAssignment {
+  return {
+    subjectType,
+    subjectId,
+    fieldPath,
+    sourceRecordIds: [ids.source],
+    provenanceRole: 'origin',
+  };
+}
+
+function promotionInput(): CandidatePromotionInput {
+  return {
+    candidateId: ids.candidate,
+    expectedCandidateType: 'physical_place',
+    expectedCandidateUpdatedAt: reviewedAt,
+    promotedAt,
+    entity: {
+      id: ids.entity,
+      value: {
+        entityType: 'merchant',
+        name: 'Reviewed Cafe',
+        slug: null,
+        legalName: null,
+        websiteUrl: null,
+        countryCode: null,
+        entityStatus: 'active',
+        visibility: 'hidden',
+      },
+    },
+    location: {
+      id: ids.location,
+      value: {
+        name: 'Reviewed Cafe Tokyo',
+        slug: 'reviewed-cafe-tokyo',
+        addressLine: null,
+        locality: 'Tokyo',
+        region: null,
+        postalCode: null,
+        countryCode: 'JP',
+        latitude: 35.681236,
+        longitude: 139.767125,
+        locationStatus: 'active',
+        visibility: 'hidden',
+        websiteUrl: null,
+        phone: '+81 3 0000 0000',
+        description: 'Reviewed public description.',
+        openingHours: 'Mon-Fri 08:00-18:00',
+        amenities: ['wifi', 'outdoor-seating'],
+        socialLinks: [
+          {
+            platform: 'instagram',
+            url: 'https://social.example.test/reviewed-cafe',
+            handle: '@reviewedcafe',
+          },
+        ],
+        osmType: null,
+        osmId: null,
+      },
+    },
+    claim: {
+      id: ids.claim,
+      value: {
+        entityId: ids.entity,
+        locationId: ids.location,
+        claimScope: 'location_specific',
+        routeType: 'direct_wallet',
+        acceptanceScope: 'all_checkout',
+        claimStatus: 'candidate',
+        visibility: 'hidden',
+        customerPaysCrypto: true,
+        merchantExplicitlyAcceptsCrypto: true,
+        processorId: null,
+        howToPay: 'Ask staff for the payment request and scan the displayed QR code.',
+        instructionsLanguage: 'en',
+        merchantReceives: 'crypto',
+        restrictions: null,
+        firstConfirmedAt: null,
+        lastConfirmedAt: null,
+        nextReviewAt: null,
+        endedAt: null,
+        endedReason: null,
+      },
+    },
+    claimAssets: [
+      {
+        id: ids.claimAsset,
+        value: {
+          claimId: ids.claim,
+          assetId: ids.asset,
+          networkId: ids.network,
+          paymentMethodId: ids.method,
+          contractAddress: null,
+          isPrimary: true,
+          notes: null,
+        },
+      },
+    ],
+    sourceRecordIds: [ids.source],
+    provenanceAssignments: [
+      assignment('entity', ids.entity, 'name'),
+      ...[
+        'name',
+        'locality',
+        'countryCode',
+        'latitude',
+        'longitude',
+        'phone',
+        'description',
+        'openingHours',
+        'amenities',
+        'socialLinks',
+      ].map((field) => assignment('location', ids.location, field)),
+      ...[
+        'routeType',
+        'acceptanceScope',
+        'customerPaysCrypto',
+        'merchantExplicitlyAcceptsCrypto',
+        'howToPay',
+        'merchantReceives',
+      ].map((field) => assignment('acceptance_claim', ids.claim, field)),
+      ...['assetId', 'networkId', 'paymentMethodId'].map((field) =>
+        assignment('claim_asset', ids.claimAsset, field),
+      ),
+    ],
+  };
+}
+
+function promotionBackend() {
+  return new InMemoryCandidatePromotionBackend({
+    candidates: [
+      {
+        id: ids.candidate,
+        candidateType: 'physical_place',
+        candidateStatus: 'triaged',
+        updatedAt: reviewedAt,
+        canonicalEntityId: null,
+        canonicalLocationId: null,
+        sourceRecordIds: [ids.source],
+      },
+    ],
+    legacyMappings: [
+      {
+        id: 'b0000000-0000-4000-8000-000000000001',
+        sourceSystem: 'cryptopaymap_v2',
+        sourceRecordId: ids.source,
+        migrationStatus: 'pending',
+        canonicalPath: null,
+        entityId: null,
+        locationId: null,
+        resolvedAt: null,
+      },
+    ],
+    assetIds: [ids.asset],
+    networkIds: [ids.network],
+    paymentMethodIds: [ids.method],
+  });
+}
+
+const confirmedClaims = [
+  {
+    claimKey: 'reviewed-cafe-tokyo-btc',
+    entitySlug: 'reviewed-cafe',
+    locationSlug: 'reviewed-cafe-tokyo',
+    claimScope: 'location_specific' as const,
+    acceptanceScope: 'all_checkout' as const,
+    status: 'confirmed' as const,
+    routeType: 'direct_wallet' as const,
+    processorSlug: null,
+    howToPay: 'Ask staff for the payment request and scan the displayed QR code.',
+    instructionsLanguage: 'en',
+    merchantReceives: 'crypto' as const,
+    restrictions: null,
+    firstConfirmedAt: '2026-07-08T00:00:00Z',
+    lastConfirmedAt: '2026-07-08T00:00:00Z',
+    nextReviewAt: '2026-10-08T00:00:00Z',
+    endedAt: null,
+    endedReason: null,
+    paymentAssets: [
+      {
+        assetSlug: 'bitcoin',
+        assetSymbol: 'BTC',
+        networkSlug: 'lightning',
+        paymentMethod: 'lightning_invoice' as const,
+        contractAddress: null,
+        isPrimary: true,
+        notes: null,
+      },
+    ],
+    evidence: [
+      {
+        kind: 'official_payment_page' as const,
+        evidenceClass: 'a' as const,
+        sourceType: 'official_page' as const,
+        polarity: 'supporting' as const,
+        sourceName: 'Reviewed Cafe',
+        sourceUrl: 'https://example.test/payments',
+        archiveUrl: null,
+        observedAt: '2026-07-08T00:00:00Z',
+        publishedAt: null,
+        summary: 'The official payment page documents the accepted payment route.',
+      },
+    ],
+  },
+];
+
+describe('practical Place Promotion to public projection integration', () => {
+  it('preserves reviewed values, blocks hidden canonical projection, and validates the explicit public projection', async () => {
+    const store = promotionBackend();
+    let committedCommand: CandidatePromotionCommand | null = null;
+    const service = createCandidatePromotionService({
+      commitPromotion: async (command) => {
+        committedCommand = command;
+        return store.commitPromotion(command);
+      },
+    });
+
+    await expect(
+      service.promote(
+        {
+          requestId: ids.request,
+          actorId: 'canonical-reviewer',
+          actorType: 'human',
+          capabilities: ['candidate:promote'],
+        },
+        promotionInput(),
+      ),
+    ).resolves.toMatchObject({ state: 'committed', visibility: 'hidden' });
+
+    const snapshot = store.snapshot();
+    const entity = snapshot.entities[0]?.value;
+    const location = snapshot.locations[0]?.value;
+    if (!entity || !location || !committedCommand) {
+      throw new Error('Expected committed practical Place canonical snapshot.');
+    }
+
+    expect(() =>
+      projectCanonicalPlace({
+        entitySlug: 'reviewed-cafe',
+        categorySlug: 'cafe',
+        entity,
+        location,
+        claims: confirmedClaims,
+        media: [],
+        provenance: [
+          {
+            sourceName: 'Reviewed Cafe official profile',
+            sourceUrl: 'https://example.test/tokyo',
+            licenseSlug: null,
+            attribution: null,
+            fields: ['name'],
+          },
+        ],
+      }),
+    ).toThrow('Only canonical Entity and Location records explicitly marked public can be projected.');
+
+    const provenanceRows = expandPromotionProvenanceAssignments(
+      committedCommand.provenanceAssignments,
+      committedCommand.promotedAt,
+    );
+    const provenance = buildPublicPlaceProvenance({
+      entityId: ids.entity,
+      locationId: ids.location,
+      sourceRecords: [
+        {
+          sourceRecordId: ids.source,
+          sourceName: 'Reviewed Cafe official profile',
+          sourceUrl: 'https://example.test/tokyo',
+          licenseSlug: null,
+          attribution: null,
+        },
+      ],
+      rows: provenanceRows,
+    });
+
+    const projected = projectCanonicalPlace({
+      entitySlug: 'reviewed-cafe',
+      categorySlug: 'cafe',
+      entity: { ...entity, visibility: 'public' },
+      location: { ...location, visibility: 'public' },
+      claims: confirmedClaims,
+      media: [],
+      provenance,
+    });
+
+    expect(projected).toMatchObject({
+      placeSlug: 'reviewed-cafe-tokyo',
+      phone: '+81 3 0000 0000',
+      description: 'Reviewed public description.',
+      openingHours: 'Mon-Fri 08:00-18:00',
+      amenities: ['wifi', 'outdoor-seating'],
+      socialLinks: [
+        {
+          platform: 'instagram',
+          url: 'https://social.example.test/reviewed-cafe',
+          handle: '@reviewedcafe',
+        },
+      ],
+    });
+    expect(projected.provenance[0]?.fields).toEqual(
+      expect.arrayContaining(['description', 'openingHours', 'amenities', 'socialLinks']),
+    );
+    expect(projected).not.toHaveProperty('candidateId');
+    expect(projected).not.toHaveProperty('sourceRecordIds');
+
+    expect(
+      validatePublicArtifact('/data/places.json', {
+        schemaVersion: '1.0.0',
+        generatedAt: '2026-07-08T00:00:00Z',
+        records: [projected],
+      }),
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Implementation item

`P4-18B3B` within `P4-18B3`

## Purpose

Close the repository-owned practical Place projection integration boundary without fabricating a full live database-to-release generator that the current release workspace does not own.

## Changes

- add a fail-closed public Place provenance builder;
- aggregate only allowlisted public Entity and Location field paths;
- group public field provenance by resolved source record metadata;
- deduplicate field paths deterministically;
- reject public field rows whose source metadata was not resolved;
- exclude private, unrelated-subject, Claim, and non-public field paths from Place profile provenance;
- add Promotion → hidden canonical snapshot → hidden projection rejection → explicit public projection → public artifact validation integration coverage;
- prove practical values survive the Promotion/canonical boundary into the public Place projection;
- prove field-level Promotion provenance can feed public Place provenance metadata;
- document that the current release-review path begins from an already generated private candidate bundle;
- record artifact generation/upload and canonical query construction as a separate environment-specific boundary instead of claiming live verification.

## Remaining B3 work

- B3C repository closure reconciliation;
- precise P4-18E inventory for the configured canonical query → full candidate generation → private upload → release-review path;
- handoff to P4-18B4 only after B3C closes repository requirements.

## Out of scope

- existing-record correction transactions (B4);
- public submission intake;
- broad UI residual work;
- claiming that repository tests prove a live database, candidate generator, R2 upload, or production publication path.
