### PR TITLE
Docs: close P4-18B3 and hand off to B4

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -128,7 +128,7 @@ Repository-complete components remain subject to the P4-18D operator-journey aud
 | P4-18A | Tracking correction and closure inventory | Completed | P4-17, closure findings | #127 |
 | P4-18B1 | Source and Candidate practical-profile contract | Completed | P4-18A | #128 |
 | P4-18B2 | Promotion editor and field provenance parity | Completed | P4-18B1 | #130 |
-| P4-18B3 | Canonical persistence and public projection integration | Repository completed; closure handoff in progress | P4-18B2 | #132, #133 |
+| P4-18B3 | Canonical persistence and public projection integration | Completed | P4-18B2 | #132, #133, #134 |
 | P4-18B4 | Existing-record practical-profile correction path audit and completion | In progress | P4-18B3 | — |
 | P4-18C | Bounded UI residual closure | Planned | P4-18A, representative screenshot capture | — |
 | P4-18D | Administration workflow integration audit | Planned | P4-18B | — |
@@ -155,7 +155,7 @@ These changes improve observability and baseline UI behavior. They do not comple
 
 ### P4-18B3 repository result
 
-P4-18B3 repository work is completed through #132 and #133. It covers practical-profile canonical persistence, rollback, replay/conflict behavior, field provenance expansion, explicit allowlisted public Place projection, strict validation, leakage and absence semantics, public Place provenance aggregation, Promotion-to-public projection integration coverage, canonical Place detail presentation, selected desktop/mobile consumption, and staging artifact assertions.
+P4-18B3 repository work is completed through #132 and #133, with closure reconciliation and B4 handoff through #134. It covers practical-profile canonical persistence, rollback, replay/conflict behavior, field provenance expansion, explicit allowlisted public Place projection, strict validation, leakage and absence semantics, public Place provenance aggregation, Promotion-to-public projection integration coverage, canonical Place detail presentation, selected desktop/mobile consumption, and staging artifact assertions.
 
 The configured canonical query → complete twelve-artifact candidate generation → private candidate upload → release-review handoff remains an environment-specific verification path. P4-18E must verify it or record an explicit blocker or launch assignment. Repository tests do not prove that live path.
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -128,8 +128,8 @@ Repository-complete components remain subject to the P4-18D operator-journey aud
 | P4-18A | Tracking correction and closure inventory | Completed | P4-17, closure findings | #127 |
 | P4-18B1 | Source and Candidate practical-profile contract | Completed | P4-18A | #128 |
 | P4-18B2 | Promotion editor and field provenance parity | Completed | P4-18B1 | #130 |
-| P4-18B3 | Canonical persistence and public projection integration | In progress | P4-18B2 | — |
-| P4-18B4 | Existing-record practical-profile correction path audit and completion | Planned | P4-18B3 | — |
+| P4-18B3 | Canonical persistence and public projection integration | Repository completed; closure handoff in progress | P4-18B2 | #132, #133 |
+| P4-18B4 | Existing-record practical-profile correction path audit and completion | In progress | P4-18B3 | — |
 | P4-18C | Bounded UI residual closure | Planned | P4-18A, representative screenshot capture | — |
 | P4-18D | Administration workflow integration audit | Planned | P4-18B | — |
 | P4-18E | Live review and Phase 5 handoff audit | Planned | P4-18B, P4-18C, P4-18D | — |
@@ -152,6 +152,12 @@ P4-17A through P4-17F are implemented, validated, and merged through #122. The f
 - #126 — selected Place focus and marker correction plus desktop selected-panel containment.
 
 These changes improve observability and baseline UI behavior. They do not complete P4-18B operational parity, P4-18C residual UI closure, P4-18D administration integration, or P4-18E handoff.
+
+### P4-18B3 repository result
+
+P4-18B3 repository work is completed through #132 and #133. It covers practical-profile canonical persistence, rollback, replay/conflict behavior, field provenance expansion, explicit allowlisted public Place projection, strict validation, leakage and absence semantics, public Place provenance aggregation, Promotion-to-public projection integration coverage, canonical Place detail presentation, selected desktop/mobile consumption, and staging artifact assertions.
+
+The configured canonical query → complete twelve-artifact candidate generation → private candidate upload → release-review handoff remains an environment-specific verification path. P4-18E must verify it or record an explicit blocker or launch assignment. Repository tests do not prove that live path.
 
 ### P4-18 execution order
 

--- a/docs/P4_18_B3_AUDIT.md
+++ b/docs/P4_18_B3_AUDIT.md
@@ -1,7 +1,7 @@
 # P4-18B3 canonical persistence and public projection audit
 
 **Implementation item:** P4-18B3  
-**Status:** Active — B3A merged, B3B in progress  
+**Status:** Repository completed through #132 and #133; closure tracking handoff in progress  
 **Last updated:** 2026-07-08
 
 ## Purpose
@@ -10,25 +10,47 @@ P4-18B3 verifies the new-target practical Place create path from reviewed Promot
 
 This audit is bounded to the new-target create path. Existing-record correction transactions remain P4-18B4.
 
+## Closure result
+
+Repository B3 requirements are complete through #132 and #133.
+
+The repository now covers:
+
+- atomic practical-profile Promotion persistence and rollback behavior;
+- identical replay and changed-content conflict behavior;
+- field-level practical-profile provenance assignment and durable row expansion;
+- explicit allowlisted canonical Place projection;
+- strict canonical and public schema validation;
+- private-extra-field exclusion and leakage checks;
+- optional-field absence semantics;
+- malformed structured social-link rejection;
+- public Place provenance aggregation from resolved source metadata and field-level provenance rows;
+- Promotion-preserved practical values through hidden canonical state, hidden-state projection rejection, explicit public state, provenance aggregation, public Place projection, and Place artifact validation;
+- canonical Place practical-profile presentation;
+- desktop selected-panel and mobile expanded-sheet consumption of public practical profile fields;
+- built staging Place detail coverage for description, hours, amenities, phone, official social link, and Media.
+
+B3 repository completion does not claim that a live canonical database, full candidate generator, private object upload, release approval, or publication activation has been verified.
+
 ## Required check matrix
 
-| Closure requirement | Repository evidence | Status |
+| Closure requirement | Repository evidence | Final status |
 |---|---|---|
-| Atomic persistence | Candidate Promotion Drizzle backend writes Entity, Location, Claim, Claim Assets, provenance, mapping, Candidate state, and decision in one database batch; practical rollback coverage is merged through #132 | Repository covered |
-| Replay and conflict behavior | request fingerprint replay and conflict guards plus practical-content replay/conflict coverage are merged through #132 | Repository covered |
-| Field provenance rows | Drizzle backend expands field assignments into durable rows; practical assignment and expansion coverage is merged through #132 | Repository covered |
+| Atomic persistence | Candidate Promotion Drizzle backend writes Entity, Location, Claim, Claim Assets, provenance, mapping, Candidate state, and decision in one database batch; practical rollback coverage merged through #132 | Repository covered |
+| Replay and conflict behavior | request fingerprint replay and conflict guards plus practical-content replay/conflict coverage merged through #132 | Repository covered |
+| Field provenance rows | Drizzle backend expands field assignments into durable rows; practical assignment and expansion coverage merged through #132 | Repository covered |
 | Public allowlisting | explicit `projectCanonicalPlace` allowlists canonical Entity and Location values into strict public Place records | Repository covered through #132 |
 | Strict schema validation | canonical inputs and projected Place records pass strict runtime schemas | Repository covered through #132 |
-| Leakage rejection | projection excludes unlisted canonical extras and public export validation remains active | Repository covered through #132 |
+| Leakage rejection | projection excludes unlisted canonical extras and public export validation remains active | Repository covered through #132 and #133 |
 | Absence semantics | optional practical fields remain absent instead of becoming invented negative facts | Repository covered through #132 |
 | Staging artifact coverage | fixture and built Place detail checks exercise description, hours, amenities, phone, social link, and Media | Repository covered through #132 |
 | Desktop selected panel | consumes practical public fields and retains focused component coverage | Existing repository coverage |
 | Mobile expanded sheet | consumes practical public fields and retains focused component coverage | Existing repository coverage |
-| Canonical Place detail | practical profile section and staging artifact assertions are merged through #132 | Repository covered through #132 |
-| Public provenance metadata | B3B adds a fail-closed builder from resolved source metadata plus field-level provenance rows to public Place provenance entries | B3B active |
-| Promotion-to-public integration | B3B covers Promotion-preserved canonical values, hidden-state rejection, explicit public projection, provenance aggregation, and Place artifact validation | B3B active |
+| Canonical Place detail | practical profile section and staging artifact assertions merged through #132 | Repository covered |
+| Public provenance metadata | fail-closed builder from resolved source metadata plus field-level provenance rows to public Place provenance entries | Repository covered through #133 |
+| Promotion-to-public integration | Promotion-preserved canonical values, hidden-state rejection, explicit public projection, provenance aggregation, and Place artifact validation | Repository covered through #133 |
 
-## B3A result — merged through #132
+## B3A result — #132
 
 B3A established:
 
@@ -44,19 +66,9 @@ B3A established:
 
 B3A did not claim a live database-to-release generation pipeline.
 
-## B3B — Projection integration and boundary audit
+## B3B result — #133
 
-### Confirmed repository boundary
-
-The repository release-review path begins from an already generated private export candidate bundle. The release workspace loads that private candidate, revalidates the complete artifact set, summarizes the exact artifacts, and pins decisions to a snapshot digest.
-
-The existing release workspace specification explicitly excluded artifact generation and upload from P3-11C. The general public export boundary also states that P2-12 does not provide database queries that construct projections.
-
-Therefore B3B must not pretend that a repository-owned full canonical database → twelve-artifact private candidate generator already exists.
-
-### B3B repository work
-
-B3B adds the strongest repository-level integration available at the practical Place boundary:
+B3B established the strongest repository-level integration available at the practical Place boundary:
 
 ```text
 reviewed Promotion input
@@ -78,7 +90,15 @@ strict Place artifact validation and leakage boundary
 
 The integration test does not treat the explicit public-state test fixture as evidence that a live Claim transition or publication activation occurred. Those remain separate protected workflows.
 
-### External and live boundary to carry forward
+## Confirmed release boundary
+
+The repository release-review path begins from an already generated private export candidate bundle. The release workspace loads that private candidate, revalidates the complete artifact set, summarizes the exact artifacts, and pins decisions to a snapshot digest.
+
+The existing release workspace specification explicitly excluded artifact generation and upload from P3-11C. The general public export boundary also states that P2-12 does not provide database queries that construct projections.
+
+Therefore B3 does not claim that a repository-owned full canonical database → twelve-artifact private candidate generator exists.
+
+## Environment-specific checks assigned to P4-18E
 
 P4-18E must verify the configured environment-specific path that actually:
 
@@ -91,15 +111,14 @@ P4-18E must verify the configured environment-specific path that actually:
 
 If that generator/upload path does not exist in the configured environment, P4-18E must record it as an explicit launch blocker or assign implementation to the appropriate launch item. Repository tests must not be labeled as live verification.
 
-## B3C — B3 closure audit
+## B3C closure decision
 
-B3C must:
+B3C concludes:
 
-- run and reconcile the complete repository validation set;
-- verify the matrix above against merged code and tests;
-- distinguish repository-complete checks from the environment-specific generator/upload path assigned above;
-- record remaining live checks for P4-18E;
-- move tracking to P4-18B4 only after repository B3 requirements are closed.
+1. repository B3 requirements are closed through #132 and #133;
+2. the environment-specific candidate-generation and private-upload path is precisely inventoried above and remains assigned to P4-18E;
+3. repository tests must not be used to claim live database or publication verification;
+4. the next implementation item is P4-18B4 existing-record practical-profile correction path audit and completion.
 
 ## Non-goals
 

--- a/docs/P4_18_B3_AUDIT.md
+++ b/docs/P4_18_B3_AUDIT.md
@@ -1,7 +1,7 @@
 # P4-18B3 canonical persistence and public projection audit
 
 **Implementation item:** P4-18B3  
-**Status:** Repository completed through #132 and #133; closure tracking handoff in progress  
+**Status:** Repository completed through #132 and #133; closure tracking through #134  
 **Last updated:** 2026-07-08
 
 ## Purpose
@@ -12,7 +12,7 @@ This audit is bounded to the new-target create path. Existing-record correction 
 
 ## Closure result
 
-Repository B3 requirements are complete through #132 and #133.
+Repository B3 requirements are complete through #132 and #133, with closure tracking and B4 handoff recorded by #134.
 
 The repository now covers:
 
@@ -111,7 +111,7 @@ P4-18E must verify the configured environment-specific path that actually:
 
 If that generator/upload path does not exist in the configured environment, P4-18E must record it as an explicit launch blocker or assign implementation to the appropriate launch item. Repository tests must not be labeled as live verification.
 
-## B3C closure decision
+## B3C closure decision — #134
 
 B3C concludes:
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -22,7 +22,7 @@ P4-18B4 — Existing-record practical-profile correction path audit and completi
 - P4-18A tracking correction and closure inventory is completed through #127.
 - P4-18B1 source and Candidate practical-profile contract is completed through #128.
 - P4-18B2 Promotion editor and field provenance parity is completed through #130.
-- P4-18B3 canonical persistence and public projection integration repository work is completed through #132 and #133; closure tracking handoff is in progress.
+- P4-18B3 canonical persistence and public projection integration repository work is completed through #132 and #133, with closure tracking and B4 handoff through #134.
 - P4-18B4 is active.
 
 ## Fixed review environment
@@ -67,7 +67,7 @@ For Phase 5 preparation and submission work also read:
 1. P4-18A — tracking correction and closure inventory — Completed through #127
 2. P4-18B1 — source and Candidate practical-profile contract — Completed through #128
 3. P4-18B2 — promotion editor and field provenance parity — Completed through #130
-4. P4-18B3 — canonical persistence and public projection integration — Repository completed through #132 and #133; closure tracking handoff in progress
+4. P4-18B3 — canonical persistence and public projection integration — Completed through #132, #133, and #134
 5. P4-18B4 — existing-record practical-profile correction path audit and completion — In progress
 6. P4-18C — bounded UI residual closure — Planned
 7. P4-18D — administration workflow integration audit — Planned

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 4 — Public core / MVP-A closure
 
 ## Current implementation item
 
-P4-18B3 — Canonical persistence and public projection integration
+P4-18B4 — Existing-record practical-profile correction path audit and completion
 
 ## Current repository state
 
@@ -22,7 +22,8 @@ P4-18B3 — Canonical persistence and public projection integration
 - P4-18A tracking correction and closure inventory is completed through #127.
 - P4-18B1 source and Candidate practical-profile contract is completed through #128.
 - P4-18B2 Promotion editor and field provenance parity is completed through #130.
-- P4-18B3 is active.
+- P4-18B3 canonical persistence and public projection integration repository work is completed through #132 and #133; closure tracking handoff is in progress.
+- P4-18B4 is active.
 
 ## Fixed review environment
 
@@ -44,8 +45,9 @@ For P4-18B practical Place profile work also read:
 
 1. `docs/PLACE_PUBLIC_PROFILE.md`;
 2. `docs/PRACTICAL_PROFILE_DATA_MODEL_EXTENSION.md`;
-3. `docs/DATA_MODEL.md`;
-4. `docs/SOURCE_AND_LICENSE_POLICY.md`.
+3. `docs/P4_18_B3_AUDIT.md` for the completed new-target projection boundary;
+4. `docs/DATA_MODEL.md`;
+5. `docs/SOURCE_AND_LICENSE_POLICY.md`.
 
 For Places UI work also read:
 
@@ -65,8 +67,8 @@ For Phase 5 preparation and submission work also read:
 1. P4-18A — tracking correction and closure inventory — Completed through #127
 2. P4-18B1 — source and Candidate practical-profile contract — Completed through #128
 3. P4-18B2 — promotion editor and field provenance parity — Completed through #130
-4. P4-18B3 — canonical persistence and public projection integration — In progress
-5. P4-18B4 — existing-record practical-profile correction path audit and completion — Planned
+4. P4-18B3 — canonical persistence and public projection integration — Repository completed through #132 and #133; closure tracking handoff in progress
+5. P4-18B4 — existing-record practical-profile correction path audit and completion — In progress
 6. P4-18C — bounded UI residual closure — Planned
 7. P4-18D — administration workflow integration audit — Planned
 8. P4-18E — live review and Phase 5 handoff audit — Planned
@@ -117,22 +119,51 @@ P4-18B2 connected the B1 practical profile review data to the protected new-targ
 - Promotion continues to create hidden records without automatic verification or publication;
 - existing-target linking remains bounded and does not become a practical-profile correction operation.
 
-## P4-18B3 active boundary
+## P4-18B3 completed boundary
 
-P4-18B3 must audit and complete the end-to-end new-target path from approved Promotion values through canonical persistence and validated public projection.
+P4-18B3 closed the repository-owned new-target practical Place path through canonical persistence and validated public Place projection.
 
-At minimum verify and, where required, extend:
+Repository coverage now includes:
 
-- canonical Location persistence for phone, description, opening hours, amenities, and structured social links;
-- transaction replay and rollback behavior for the practical profile fields;
-- field-level provenance persistence and audit history for those canonical writes;
-- canonical-to-public projection allowlists and schemas;
-- approved public Place detail, selected desktop panel, and expanded mobile sheet consumption of projected values;
-- public/private leakage boundaries;
-- malformed or noncanonical structured values failing closed before publication;
-- regression coverage proving source review → Promotion → canonical write → public projection without bypassing verification or publication activation controls.
+- atomic practical-profile persistence and rollback behavior;
+- replay and changed-content conflict behavior;
+- field-level practical-profile provenance expansion;
+- explicit allowlisted canonical Place projection;
+- strict canonical and public runtime validation;
+- private-extra-field exclusion and leakage checks;
+- optional-field absence semantics;
+- malformed structured social-link rejection;
+- public Place provenance aggregation from resolved source metadata and field-level provenance rows;
+- Promotion-preserved practical values through hidden canonical state, hidden projection rejection, explicit public state, public provenance aggregation, public Place projection, and Place artifact validation;
+- practical profile presentation on canonical Place detail;
+- practical profile consumption by desktop selected panel and mobile expanded sheet;
+- built staging Place detail coverage for description, hours, amenities, phone, official social link, and Media.
 
-B3 must not broaden into the B4 existing-record correction transaction path.
+The repository release-review path begins from an already generated private candidate bundle. The configured canonical query → complete candidate generation → private upload → release-review path is an environment-specific verification item assigned precisely to P4-18E. Repository tests do not prove that live path.
+
+## P4-18B4 active boundary
+
+P4-18B4 must audit and complete how already canonical Place records receive reviewed practical-profile corrections without abusing existing-target Candidate linking.
+
+At minimum audit and, where required, implement:
+
+- address and locality correction;
+- phone addition, replacement, and removal;
+- website addition, replacement, and removal;
+- description correction and removal semantics;
+- opening-hours correction and removal;
+- amenities addition, removal, and complete replacement;
+- official social-link addition, removal, replacement, and handle change;
+- exact current canonical version or state guards;
+- explicit field-level before/after diff;
+- correction provenance tied to reviewed source records;
+- reviewer decision and audit record;
+- idempotent replay for an identical accepted operation;
+- conflict on stale expected canonical state;
+- atomic rollback on failure;
+- no public mutation outside the normal validated export and release boundary.
+
+The current existing-target linking operation is not treated as a correction transaction merely because it can attribute Candidate sources to an existing identity. B4 must inspect the actual write path and implement the missing correction boundary where necessary.
 
 ## P4-18C bounded UI residual scope
 
@@ -165,11 +196,13 @@ Planned Phase 5 order:
 
 ## Next
 
-Complete P4-18B3 canonical persistence and public projection integration. Move to P4-18B4 only after B3 is merged and tracking is updated.
+Audit and complete P4-18B4 existing-record practical-profile correction behavior. Do not move to P4-18C until B4 is merged and tracking is updated.
 
 ## Blocked
 
 No known repository blocker.
+
+P4-18E must explicitly verify or classify the configured canonical query, full candidate generation, private candidate upload, and release-review handoff path recorded by the B3 audit. If that path is absent, it must be treated as an explicit launch blocker or assigned launch work rather than hidden by generic deferred-verification language.
 
 P4-18D and P4-18E must replace broad deferred-verification language with a precise inventory of environment-specific checks that were completed, could not be completed, or remain assigned to launch work.
 


### PR DESCRIPTION
## Implementation item

`P4-18B3C` closure handoff

## Purpose

Reconcile the completed B3 repository work through #132 and #133, preserve the exact environment-specific generator/upload checks for P4-18E, and make P4-18B4 the active implementation item.

## Changes

- mark B3 repository requirements complete through #132 and #133;
- reconcile the B3 audit matrix and closure decision;
- record the environment-specific canonical query → complete candidate generation → private upload → release-review path for P4-18E;
- move PROJECT_STATUS to P4-18B4;
- activate B4 in IMPLEMENTATION_PLAN;
- define the existing-record correction boundary without treating existing-target linking as a correction transaction.

## Out of scope

- implementing B4 correction transactions;
- P4-18C UI residual work;
- live environment verification;
- Phase 5 submissions.

## Completion criteria

- B3 repository completion is unambiguous;
- live/external dependencies are precise and assigned;
- B4 is the only active practical-profile implementation item;
- Phase 5 remains blocked on the P4-18E handoff gate.
