### PR TITLE
P4-18B4A: add guarded Location correction contract

### DIFF
--- a/docs/P4_18_B4_AUDIT.md
+++ b/docs/P4_18_B4_AUDIT.md
@@ -1,0 +1,132 @@
+# P4-18B4 existing-record practical profile correction audit
+
+**Implementation item:** P4-18B4  
+**Status:** Active — B4A contract implementation in progress  
+**Last updated:** 2026-07-08
+
+## Purpose
+
+P4-18B4 audits and completes the guarded correction path for practical profile fields on already canonical Places.
+
+The work is separate from Candidate existing-target linking. Existing-target linking reuses an identity and creates a new hidden Claim; it does not edit canonical Entity or Location profile fields.
+
+## Audit finding
+
+The current repository does not contain a dedicated existing canonical Location practical-profile correction transaction that satisfies the P4-18B4 requirements.
+
+The existing-target Candidate link path explicitly does not update Entity or Location values. It creates a hidden Claim and Claim Assets, adds attribution/origin provenance, updates Candidate and legacy mapping state, and records a replay receipt.
+
+Therefore B4 requires an explicit correction operation rather than widening existing-target linking.
+
+## Required field scope
+
+The bounded B4 practical profile correction scope is:
+
+- `addressLine`;
+- `locality`;
+- `region`;
+- `postalCode`;
+- `websiteUrl`;
+- `phone`;
+- `description`;
+- `openingHours`;
+- `amenities`;
+- `socialLinks`.
+
+Name, category, coordinates, country reassignment, Claim state, Evidence, and Media remain outside this bounded correction operation unless a later audit finds a direct dependency that cannot be separated safely.
+
+## Required semantics
+
+### Scalar fields
+
+Scalar corrections distinguish:
+
+- unchanged — field absent from the change plan;
+- set — assign a reviewed value;
+- clear — explicitly remove the current optional value.
+
+An empty form value must never silently mean clear.
+
+### Amenities
+
+Amenities corrections distinguish:
+
+- add reviewed values;
+- remove reviewed values;
+- replace the complete set;
+- clear the complete set;
+- unchanged when omitted from the change plan.
+
+### Social links
+
+Social-link corrections distinguish:
+
+- add reviewed official links;
+- remove links by stable `platform + url` identity;
+- replace the complete set, including URL or handle corrections;
+- clear the complete set;
+- unchanged when omitted from the change plan.
+
+Duplicate canonical `platform + url` pairs remain invalid.
+
+## Provenance boundary
+
+Every changed field requires an explicit correction provenance assignment.
+
+The correction request contains:
+
+- the complete reviewed source-record set available to the operation;
+- one field assignment for every changed field;
+- one or more source-record IDs for each changed field;
+- no assignment to unchanged fields;
+- no source reference outside the exact reviewed source-record set.
+
+B4 persistence must record correction provenance at field level and preserve an auditable decision receipt. Clear operations still require reviewed correction provenance even when the resulting canonical field has no current value.
+
+## Execution slices
+
+### B4A — Correction contract and atomic semantics
+
+- define strict mutation context and capability boundary;
+- define explicit scalar and structured change operations;
+- validate exact field-provenance coverage;
+- normalize deterministic request fingerprints;
+- implement canonical patch application;
+- implement copy-on-write in-memory backend;
+- cover committed replay, changed-content conflict, stale-version conflict, source-set validation, structured add/remove/replace/clear behavior, and rollback.
+
+### B4B — Durable correction persistence
+
+- add durable correction decision storage;
+- preserve before/after field-level diff and reviewed source IDs;
+- add exact Location version guard;
+- add source-record existence guard;
+- update the Location and correction provenance atomically;
+- preserve deterministic request replay and stale-state conflict behavior;
+- add production Drizzle persistence coverage.
+
+### B4C — Protected operator path
+
+- add protected correction workspace/read model;
+- expose current canonical values and bounded reviewed source choices;
+- add field diff and correction provenance controls;
+- add protected API authorization and idempotency boundary;
+- add reviewer-visible set/clear and structured list operation controls;
+- keep publication separate.
+
+### B4D — Audit integration and closure
+
+- normalize durable correction decisions into protected Audit history;
+- verify operator reachability and failure/retry states;
+- reconcile the B4 completion matrix;
+- record any environment-specific checks for P4-18D/E;
+- move tracking to P4-18C only after B4 repository requirements are closed.
+
+## Non-goals
+
+- changing Claim verification status;
+- directly publishing corrected values;
+- accepting public submissions;
+- widening existing-target Candidate linking into a profile edit operation;
+- broad Place identity or coordinate editing;
+- Media correction.

--- a/src/admin/location-correction/decision.ts
+++ b/src/admin/location-correction/decision.ts
@@ -1,0 +1,468 @@
+import { z } from 'zod';
+import {
+  canonicalLocationSchema,
+  canonicalLocationSocialLinkSchema,
+  type CanonicalLocationInput,
+  type CanonicalLocationSocialLink,
+} from '../../schemas/canonical-identity';
+import { httpsUrlSchema } from '../../schemas/core';
+
+export const locationCorrectionCapabilityValues = ['location:correct'] as const;
+
+export const practicalLocationCorrectionFieldValues = [
+  'addressLine',
+  'locality',
+  'region',
+  'postalCode',
+  'websiteUrl',
+  'phone',
+  'description',
+  'openingHours',
+  'amenities',
+  'socialLinks',
+] as const;
+
+export type PracticalLocationCorrectionField =
+  (typeof practicalLocationCorrectionFieldValues)[number];
+
+const reasonCodeSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(96)
+  .regex(/^[a-z0-9]+(?:_[a-z0-9]+)*$/);
+
+const uniqueUuidArraySchema = z
+  .array(z.uuid())
+  .min(1)
+  .max(100)
+  .superRefine((values, context) => {
+    if (new Set(values).size !== values.length) {
+      context.addIssue({ code: 'custom', message: 'Source record IDs must be unique.' });
+    }
+  });
+
+function nullableTextChangeSchema(maxLength: number) {
+  return z.discriminatedUnion('operation', [
+    z
+      .object({
+        operation: z.literal('set'),
+        value: z.string().trim().min(1).max(maxLength),
+      })
+      .strict(),
+    z.object({ operation: z.literal('clear') }).strict(),
+  ]);
+}
+
+const nullableUrlChangeSchema = z.discriminatedUnion('operation', [
+  z.object({ operation: z.literal('set'), value: httpsUrlSchema }).strict(),
+  z.object({ operation: z.literal('clear') }).strict(),
+]);
+
+const amenitySchema = z.string().trim().min(1).max(80);
+const amenityValuesSchema = z
+  .array(amenitySchema)
+  .min(1)
+  .max(100)
+  .superRefine((values, context) => {
+    if (new Set(values).size !== values.length) {
+      context.addIssue({ code: 'custom', message: 'Amenity values must be unique.' });
+    }
+  });
+
+const amenitiesChangeSchema = z.discriminatedUnion('operation', [
+  z.object({ operation: z.literal('add'), values: amenityValuesSchema }).strict(),
+  z.object({ operation: z.literal('remove'), values: amenityValuesSchema }).strict(),
+  z.object({ operation: z.literal('replace'), values: amenityValuesSchema }).strict(),
+  z.object({ operation: z.literal('clear') }).strict(),
+]);
+
+const socialLinkIdentitySchema = canonicalLocationSocialLinkSchema.pick({
+  platform: true,
+  url: true,
+});
+
+function uniqueSocialLinksSchema(minimum: number) {
+  return z
+    .array(canonicalLocationSocialLinkSchema)
+    .min(minimum)
+    .max(30)
+    .superRefine((links, context) => {
+      const keys = links.map((link) => `${link.platform}:${link.url}`);
+      if (new Set(keys).size !== keys.length) {
+        context.addIssue({ code: 'custom', message: 'Social links must be unique.' });
+      }
+    });
+}
+
+const uniqueSocialLinkIdentitiesSchema = z
+  .array(socialLinkIdentitySchema)
+  .min(1)
+  .max(30)
+  .superRefine((links, context) => {
+    const keys = links.map((link) => `${link.platform}:${link.url}`);
+    if (new Set(keys).size !== keys.length) {
+      context.addIssue({ code: 'custom', message: 'Social-link identities must be unique.' });
+    }
+  });
+
+const socialLinksChangeSchema = z.discriminatedUnion('operation', [
+  z.object({ operation: z.literal('add'), values: uniqueSocialLinksSchema(1) }).strict(),
+  z.object({ operation: z.literal('remove'), values: uniqueSocialLinkIdentitiesSchema }).strict(),
+  z.object({ operation: z.literal('replace'), values: uniqueSocialLinksSchema(1) }).strict(),
+  z.object({ operation: z.literal('clear') }).strict(),
+]);
+
+export const locationCorrectionChangesSchema = z
+  .object({
+    addressLine: nullableTextChangeSchema(500).optional(),
+    locality: nullableTextChangeSchema(120).optional(),
+    region: nullableTextChangeSchema(120).optional(),
+    postalCode: nullableTextChangeSchema(32).optional(),
+    websiteUrl: nullableUrlChangeSchema.optional(),
+    phone: nullableTextChangeSchema(64).optional(),
+    description: nullableTextChangeSchema(5_000).optional(),
+    openingHours: nullableTextChangeSchema(2_000).optional(),
+    amenities: amenitiesChangeSchema.optional(),
+    socialLinks: socialLinksChangeSchema.optional(),
+  })
+  .strict()
+  .superRefine((changes, context) => {
+    if (Object.values(changes).every((change) => change === undefined)) {
+      context.addIssue({ code: 'custom', message: 'At least one Location field change is required.' });
+    }
+  });
+
+export const locationCorrectionProvenanceAssignmentSchema = z
+  .object({
+    fieldPath: z.enum(practicalLocationCorrectionFieldValues),
+    sourceRecordIds: uniqueUuidArraySchema,
+  })
+  .strict();
+
+export const locationCorrectionMutationContextSchema = z
+  .object({
+    requestId: z.uuid(),
+    actorId: z.string().trim().min(1).max(200),
+    actorType: z.enum(['human', 'system']),
+    capabilities: z.array(z.enum(locationCorrectionCapabilityValues)).min(1),
+  })
+  .strict();
+
+export const locationCorrectionDecisionInputSchema = z
+  .object({
+    locationId: z.uuid(),
+    expectedLocationUpdatedAt: z.iso.datetime({ offset: true }),
+    decidedAt: z.iso.datetime({ offset: true }),
+    changes: locationCorrectionChangesSchema,
+    sourceRecordIds: uniqueUuidArraySchema,
+    provenanceAssignments: z.array(locationCorrectionProvenanceAssignmentSchema).min(1).max(10),
+    reasonCode: reasonCodeSchema,
+    publicSummary: z.string().trim().min(1).max(1_000).nullable(),
+    internalNote: z.string().trim().min(1).max(2_000).nullable(),
+  })
+  .strict()
+  .superRefine((input, context) => {
+    if (Date.parse(input.decidedAt) < Date.parse(input.expectedLocationUpdatedAt)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['decidedAt'],
+        message: 'The correction decision cannot precede the reviewed Location version.',
+      });
+    }
+    if (input.publicSummary === null && input.internalNote === null) {
+      context.addIssue({
+        code: 'custom',
+        path: ['internalNote'],
+        message: 'A correction decision requires a public summary or internal note.',
+      });
+    }
+
+    const changedFields = new Set(
+      practicalLocationCorrectionFieldValues.filter((field) => input.changes[field] !== undefined),
+    );
+    const assignmentFields = new Set<PracticalLocationCorrectionField>();
+    const reviewedSources = new Set(input.sourceRecordIds);
+
+    input.provenanceAssignments.forEach((assignment, index) => {
+      if (assignmentFields.has(assignment.fieldPath)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['provenanceAssignments', index, 'fieldPath'],
+          message: 'Each changed field accepts exactly one provenance assignment.',
+        });
+      }
+      assignmentFields.add(assignment.fieldPath);
+      if (!changedFields.has(assignment.fieldPath)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['provenanceAssignments', index, 'fieldPath'],
+          message: 'Provenance cannot be assigned to an unchanged field.',
+        });
+      }
+      assignment.sourceRecordIds.forEach((sourceRecordId) => {
+        if (!reviewedSources.has(sourceRecordId)) {
+          context.addIssue({
+            code: 'custom',
+            path: ['provenanceAssignments', index, 'sourceRecordIds'],
+            message: 'Correction provenance references a source outside the reviewed source set.',
+          });
+        }
+      });
+    });
+
+    for (const field of changedFields) {
+      if (!assignmentFields.has(field)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['provenanceAssignments'],
+          message: `${field} requires explicit correction provenance.`,
+        });
+      }
+    }
+  });
+
+export type LocationCorrectionChanges = z.infer<typeof locationCorrectionChangesSchema>;
+export type LocationCorrectionProvenanceAssignment = z.infer<
+  typeof locationCorrectionProvenanceAssignmentSchema
+>;
+export type LocationCorrectionMutationContext = z.infer<
+  typeof locationCorrectionMutationContextSchema
+>;
+export type LocationCorrectionDecisionInput = z.infer<typeof locationCorrectionDecisionInputSchema>;
+
+export interface LocationCorrectionDecisionCommand {
+  requestId: string;
+  actorId: string;
+  actorType: 'human' | 'system';
+  locationId: string;
+  expectedLocationUpdatedAt: Date;
+  decidedAt: Date;
+  changes: LocationCorrectionChanges;
+  sourceRecordIds: string[];
+  provenanceAssignments: LocationCorrectionProvenanceAssignment[];
+  reasonCode: string;
+  publicSummary: string | null;
+  internalNote: string | null;
+  requestFingerprint: string;
+}
+
+export interface LocationCorrectionDecisionReceipt {
+  requestId: string;
+  locationId: string;
+  appliedFieldPaths: PracticalLocationCorrectionField[];
+  decidedAt: string;
+  updatedAt: string;
+  state: 'committed' | 'replayed';
+}
+
+export interface LocationCorrectionDecisionBackend {
+  commitCorrection(
+    command: LocationCorrectionDecisionCommand,
+  ): Promise<LocationCorrectionDecisionReceipt>;
+}
+
+export type LocationCorrectionDecisionErrorCode =
+  | 'unauthorized'
+  | 'invalid_decision'
+  | 'not_found'
+  | 'conflict'
+  | 'backend_failure';
+
+export class LocationCorrectionDecisionError extends Error {
+  readonly code: LocationCorrectionDecisionErrorCode;
+  readonly issues: readonly string[];
+
+  constructor(
+    code: LocationCorrectionDecisionErrorCode,
+    message: string,
+    issues: readonly string[] = [],
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'LocationCorrectionDecisionError';
+    this.code = code;
+    this.issues = issues;
+  }
+}
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, stable(child)]),
+    );
+  }
+  return value;
+}
+
+export function changedLocationCorrectionFields(
+  changes: LocationCorrectionChanges,
+): PracticalLocationCorrectionField[] {
+  return practicalLocationCorrectionFieldValues.filter((field) => changes[field] !== undefined);
+}
+
+function applyNullableChange<T>(current: T | null, change: { operation: 'set'; value: T } | { operation: 'clear' }) {
+  return change.operation === 'set' ? change.value : null;
+}
+
+function socialLinkKey(link: Pick<CanonicalLocationSocialLink, 'platform' | 'url'>): string {
+  return `${link.platform}:${link.url}`;
+}
+
+export function applyLocationCorrectionChanges(
+  current: CanonicalLocationInput,
+  changes: LocationCorrectionChanges,
+): CanonicalLocationInput {
+  const next: CanonicalLocationInput = {
+    ...current,
+    ...(current.amenities === undefined ? {} : { amenities: [...current.amenities] }),
+    ...(current.socialLinks === undefined
+      ? {}
+      : { socialLinks: current.socialLinks.map((link) => ({ ...link })) }),
+  };
+
+  for (const field of [
+    'addressLine',
+    'locality',
+    'region',
+    'postalCode',
+    'websiteUrl',
+    'phone',
+    'description',
+    'openingHours',
+  ] as const) {
+    const change = changes[field];
+    if (change !== undefined) {
+      next[field] = applyNullableChange(next[field] ?? null, change);
+    }
+  }
+
+  const amenitiesChange = changes.amenities;
+  if (amenitiesChange !== undefined) {
+    const currentAmenities = next.amenities ?? [];
+    if (amenitiesChange.operation === 'add') {
+      next.amenities = [...new Set([...currentAmenities, ...amenitiesChange.values])];
+    } else if (amenitiesChange.operation === 'remove') {
+      const removed = new Set(amenitiesChange.values);
+      next.amenities = currentAmenities.filter((value) => !removed.has(value));
+    } else if (amenitiesChange.operation === 'replace') {
+      next.amenities = [...amenitiesChange.values];
+    } else {
+      next.amenities = [];
+    }
+  }
+
+  const socialLinksChange = changes.socialLinks;
+  if (socialLinksChange !== undefined) {
+    const currentLinks = next.socialLinks ?? [];
+    if (socialLinksChange.operation === 'add') {
+      next.socialLinks = [...currentLinks, ...socialLinksChange.values.map((link) => ({ ...link }))];
+    } else if (socialLinksChange.operation === 'remove') {
+      const removed = new Set(socialLinksChange.values.map(socialLinkKey));
+      next.socialLinks = currentLinks.filter((link) => !removed.has(socialLinkKey(link)));
+    } else if (socialLinksChange.operation === 'replace') {
+      next.socialLinks = socialLinksChange.values.map((link) => ({ ...link }));
+    } else {
+      next.socialLinks = [];
+    }
+  }
+
+  const result = canonicalLocationSchema.safeParse(next);
+  if (!result.success) {
+    throw new LocationCorrectionDecisionError(
+      'invalid_decision',
+      'The correction would produce an invalid canonical Location.',
+      result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+    );
+  }
+  return result.data;
+}
+
+function normalizedAssignments(assignments: LocationCorrectionProvenanceAssignment[]) {
+  return assignments
+    .map((assignment) => ({
+      fieldPath: assignment.fieldPath,
+      sourceRecordIds: [...assignment.sourceRecordIds].sort(),
+    }))
+    .sort((left, right) => left.fieldPath.localeCompare(right.fieldPath));
+}
+
+function buildCommand(
+  context: LocationCorrectionMutationContext,
+  input: LocationCorrectionDecisionInput,
+): LocationCorrectionDecisionCommand {
+  const sourceRecordIds = [...input.sourceRecordIds].sort();
+  const provenanceAssignments = normalizedAssignments(input.provenanceAssignments);
+  const requestFingerprint = JSON.stringify(
+    stable({
+      requestId: context.requestId,
+      actorId: context.actorId,
+      actorType: context.actorType,
+      ...input,
+      sourceRecordIds,
+      provenanceAssignments,
+    }),
+  );
+
+  return {
+    requestId: context.requestId,
+    actorId: context.actorId,
+    actorType: context.actorType,
+    locationId: input.locationId,
+    expectedLocationUpdatedAt: new Date(input.expectedLocationUpdatedAt),
+    decidedAt: new Date(input.decidedAt),
+    changes: input.changes,
+    sourceRecordIds,
+    provenanceAssignments,
+    reasonCode: input.reasonCode,
+    publicSummary: input.publicSummary,
+    internalNote: input.internalNote,
+    requestFingerprint,
+  };
+}
+
+export function createLocationCorrectionDecisionService(backend: LocationCorrectionDecisionBackend) {
+  return {
+    async correct(
+      context: LocationCorrectionMutationContext,
+      input: LocationCorrectionDecisionInput,
+    ): Promise<LocationCorrectionDecisionReceipt> {
+      const contextResult = locationCorrectionMutationContextSchema.safeParse(context);
+      if (!contextResult.success || !context.capabilities.includes('location:correct')) {
+        throw new LocationCorrectionDecisionError(
+          'unauthorized',
+          'The actor is not authorized to correct canonical Location profiles.',
+          contextResult.success
+            ? []
+            : contextResult.error.issues.map(
+                (issue) => `${issue.path.join('.')}: ${issue.message}`,
+              ),
+        );
+      }
+
+      const inputResult = locationCorrectionDecisionInputSchema.safeParse(input);
+      if (!inputResult.success) {
+        throw new LocationCorrectionDecisionError(
+          'invalid_decision',
+          'The Location correction decision is invalid.',
+          inputResult.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+        );
+      }
+
+      try {
+        return await backend.commitCorrection(buildCommand(contextResult.data, inputResult.data));
+      } catch (error) {
+        if (error instanceof LocationCorrectionDecisionError) throw error;
+        throw new LocationCorrectionDecisionError(
+          'backend_failure',
+          'The Location correction decision was not committed.',
+          [],
+          { cause: error },
+        );
+      }
+    },
+  };
+}

--- a/src/admin/location-correction/decision.ts
+++ b/src/admin/location-correction/decision.ts
@@ -129,7 +129,10 @@ export const locationCorrectionChangesSchema = z
   .strict()
   .superRefine((changes, context) => {
     if (Object.values(changes).every((change) => change === undefined)) {
-      context.addIssue({ code: 'custom', message: 'At least one Location field change is required.' });
+      context.addIssue({
+        code: 'custom',
+        message: 'At least one Location field change is required.',
+      });
     }
   });
 
@@ -304,7 +307,9 @@ export function changedLocationCorrectionFields(
   return practicalLocationCorrectionFieldValues.filter((field) => changes[field] !== undefined);
 }
 
-function applyNullableChange<T>(current: T | null, change: { operation: 'set'; value: T } | { operation: 'clear' }) {
+function applyNullableChange<T>(
+  change: { operation: 'set'; value: T } | { operation: 'clear' },
+): T | null {
   return change.operation === 'set' ? change.value : null;
 }
 
@@ -336,7 +341,7 @@ export function applyLocationCorrectionChanges(
   ] as const) {
     const change = changes[field];
     if (change !== undefined) {
-      next[field] = applyNullableChange(next[field] ?? null, change);
+      next[field] = applyNullableChange(change);
     }
   }
 
@@ -359,7 +364,10 @@ export function applyLocationCorrectionChanges(
   if (socialLinksChange !== undefined) {
     const currentLinks = next.socialLinks ?? [];
     if (socialLinksChange.operation === 'add') {
-      next.socialLinks = [...currentLinks, ...socialLinksChange.values.map((link) => ({ ...link }))];
+      next.socialLinks = [
+        ...currentLinks,
+        ...socialLinksChange.values.map((link) => ({ ...link })),
+      ];
     } else if (socialLinksChange.operation === 'remove') {
       const removed = new Set(socialLinksChange.values.map(socialLinkKey));
       next.socialLinks = currentLinks.filter((link) => !removed.has(socialLinkKey(link)));
@@ -424,7 +432,9 @@ function buildCommand(
   };
 }
 
-export function createLocationCorrectionDecisionService(backend: LocationCorrectionDecisionBackend) {
+export function createLocationCorrectionDecisionService(
+  backend: LocationCorrectionDecisionBackend,
+) {
   return {
     async correct(
       context: LocationCorrectionMutationContext,

--- a/src/admin/location-correction/in-memory-backend.ts
+++ b/src/admin/location-correction/in-memory-backend.ts
@@ -1,0 +1,188 @@
+import type { CanonicalLocationInput } from '../../schemas/canonical-identity';
+import {
+  applyLocationCorrectionChanges,
+  changedLocationCorrectionFields,
+  LocationCorrectionDecisionError,
+  type LocationCorrectionDecisionBackend,
+  type LocationCorrectionDecisionCommand,
+  type LocationCorrectionDecisionReceipt,
+  type PracticalLocationCorrectionField,
+} from './decision';
+
+export interface InMemoryCorrectionLocation {
+  id: string;
+  updatedAt: string;
+  value: CanonicalLocationInput;
+}
+
+export interface InMemoryCorrectionProvenanceRow {
+  locationId: string;
+  fieldPath: PracticalLocationCorrectionField;
+  sourceRecordId: string;
+  provenanceRole: 'correction';
+  effectiveFrom: string;
+}
+
+export interface InMemoryCorrectionDiffRow {
+  fieldPath: PracticalLocationCorrectionField;
+  beforeValue: unknown;
+  afterValue: unknown;
+}
+
+export interface InMemoryCorrectionDecisionRecord {
+  requestId: string;
+  locationId: string;
+  actorId: string;
+  actorType: 'human' | 'system';
+  expectedLocationUpdatedAt: string;
+  decidedAt: string;
+  reasonCode: string;
+  publicSummary: string | null;
+  internalNote: string | null;
+  sourceRecordIds: string[];
+  diff: InMemoryCorrectionDiffRow[];
+  requestFingerprint: string;
+  receipt: LocationCorrectionDecisionReceipt;
+}
+
+export interface InMemoryLocationCorrectionBackendOptions {
+  locations?: InMemoryCorrectionLocation[];
+  sourceRecordIds?: string[];
+  failBeforeCommit?: (command: LocationCorrectionDecisionCommand) => boolean;
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function valueAt(location: CanonicalLocationInput, field: PracticalLocationCorrectionField): unknown {
+  return (location as unknown as Record<string, unknown>)[field];
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export class InMemoryLocationCorrectionBackend implements LocationCorrectionDecisionBackend {
+  private readonly locations = new Map<string, InMemoryCorrectionLocation>();
+  private readonly sourceRecordIds: Set<string>;
+  private readonly decisions = new Map<string, InMemoryCorrectionDecisionRecord>();
+  private readonly provenanceRows: InMemoryCorrectionProvenanceRow[] = [];
+  private readonly failBeforeCommit: (command: LocationCorrectionDecisionCommand) => boolean;
+
+  constructor(options: InMemoryLocationCorrectionBackendOptions = {}) {
+    for (const location of options.locations ?? []) {
+      this.locations.set(location.id, clone(location));
+    }
+    this.sourceRecordIds = new Set(options.sourceRecordIds ?? []);
+    this.failBeforeCommit = options.failBeforeCommit ?? (() => false);
+  }
+
+  async commitCorrection(
+    command: LocationCorrectionDecisionCommand,
+  ): Promise<LocationCorrectionDecisionReceipt> {
+    const existing = this.decisions.get(command.requestId);
+    if (existing !== undefined) {
+      if (existing.requestFingerprint !== command.requestFingerprint) {
+        throw new LocationCorrectionDecisionError(
+          'conflict',
+          'The correction request ID was reused with different content.',
+        );
+      }
+      return { ...clone(existing.receipt), state: 'replayed' };
+    }
+
+    const current = this.locations.get(command.locationId);
+    if (current === undefined) {
+      throw new LocationCorrectionDecisionError('not_found', 'The canonical Location was not found.');
+    }
+    if (Date.parse(current.updatedAt) !== command.expectedLocationUpdatedAt.getTime()) {
+      throw new LocationCorrectionDecisionError(
+        'conflict',
+        'The canonical Location changed after the correction was reviewed.',
+      );
+    }
+
+    for (const sourceRecordId of command.sourceRecordIds) {
+      if (!this.sourceRecordIds.has(sourceRecordId)) {
+        throw new LocationCorrectionDecisionError(
+          'conflict',
+          'The correction references an unavailable source record.',
+        );
+      }
+    }
+
+    const after = applyLocationCorrectionChanges(current.value, command.changes);
+    const appliedFieldPaths = changedLocationCorrectionFields(command.changes);
+    const diff = appliedFieldPaths.map((fieldPath) => ({
+      fieldPath,
+      beforeValue: clone(valueAt(current.value, fieldPath)),
+      afterValue: clone(valueAt(after, fieldPath)),
+    }));
+    const noOp = diff.find((row) => sameValue(row.beforeValue, row.afterValue));
+    if (noOp !== undefined) {
+      throw new LocationCorrectionDecisionError(
+        'invalid_decision',
+        `The ${noOp.fieldPath} correction does not change the canonical value.`,
+      );
+    }
+
+    const provenanceRows = command.provenanceAssignments.flatMap((assignment) =>
+      assignment.sourceRecordIds.map(
+        (sourceRecordId): InMemoryCorrectionProvenanceRow => ({
+          locationId: command.locationId,
+          fieldPath: assignment.fieldPath,
+          sourceRecordId,
+          provenanceRole: 'correction',
+          effectiveFrom: command.decidedAt.toISOString(),
+        }),
+      ),
+    );
+
+    if (this.failBeforeCommit(command)) {
+      throw new Error('Injected Location correction failure before atomic commit.');
+    }
+
+    const updatedAt = command.decidedAt.toISOString();
+    const receipt: LocationCorrectionDecisionReceipt = {
+      requestId: command.requestId,
+      locationId: command.locationId,
+      appliedFieldPaths,
+      decidedAt: command.decidedAt.toISOString(),
+      updatedAt,
+      state: 'committed',
+    };
+
+    this.locations.set(command.locationId, {
+      id: current.id,
+      updatedAt,
+      value: clone(after),
+    });
+    this.provenanceRows.push(...clone(provenanceRows));
+    this.decisions.set(command.requestId, {
+      requestId: command.requestId,
+      locationId: command.locationId,
+      actorId: command.actorId,
+      actorType: command.actorType,
+      expectedLocationUpdatedAt: command.expectedLocationUpdatedAt.toISOString(),
+      decidedAt: command.decidedAt.toISOString(),
+      reasonCode: command.reasonCode,
+      publicSummary: command.publicSummary,
+      internalNote: command.internalNote,
+      sourceRecordIds: [...command.sourceRecordIds],
+      diff: clone(diff),
+      requestFingerprint: command.requestFingerprint,
+      receipt: clone(receipt),
+    });
+
+    return clone(receipt);
+  }
+
+  snapshot() {
+    return {
+      locations: [...this.locations.values()].map(clone),
+      provenanceRows: this.provenanceRows.map(clone),
+      decisions: [...this.decisions.values()].map(clone),
+    };
+  }
+}

--- a/src/admin/location-correction/in-memory-backend.ts
+++ b/src/admin/location-correction/in-memory-backend.ts
@@ -55,7 +55,10 @@ function clone<T>(value: T): T {
   return structuredClone(value);
 }
 
-function valueAt(location: CanonicalLocationInput, field: PracticalLocationCorrectionField): unknown {
+function valueAt(
+  location: CanonicalLocationInput,
+  field: PracticalLocationCorrectionField,
+): unknown {
   return (location as unknown as Record<string, unknown>)[field];
 }
 
@@ -94,7 +97,10 @@ export class InMemoryLocationCorrectionBackend implements LocationCorrectionDeci
 
     const current = this.locations.get(command.locationId);
     if (current === undefined) {
-      throw new LocationCorrectionDecisionError('not_found', 'The canonical Location was not found.');
+      throw new LocationCorrectionDecisionError(
+        'not_found',
+        'The canonical Location was not found.',
+      );
     }
     if (Date.parse(current.updatedAt) !== command.expectedLocationUpdatedAt.getTime()) {
       throw new LocationCorrectionDecisionError(

--- a/tests/location-correction-decision.test.ts
+++ b/tests/location-correction-decision.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createLocationCorrectionDecisionService,
+  type LocationCorrectionDecisionInput,
+} from '../src/admin/location-correction/decision';
+import { InMemoryLocationCorrectionBackend } from '../src/admin/location-correction/in-memory-backend';
+import type { CanonicalLocationInput } from '../src/schemas/canonical-identity';
+
+const locationId = '10000000-0000-4000-8000-000000000001';
+const sourceRecordId = '20000000-0000-4000-8000-000000000001';
+const otherSourceRecordId = '20000000-0000-4000-8000-000000000002';
+const requestId = '30000000-0000-4000-8000-000000000001';
+const secondRequestId = '30000000-0000-4000-8000-000000000002';
+const reviewedAt = '2026-07-07T00:00:00.000Z';
+const decidedAt = '2026-07-08T00:00:00.000Z';
+
+const currentLocation: CanonicalLocationInput = {
+  name: 'Reviewed Cafe Tokyo',
+  slug: 'reviewed-cafe-tokyo',
+  addressLine: '1-1 Example',
+  locality: 'Tokyo',
+  region: 'Tokyo',
+  postalCode: '100-0001',
+  countryCode: 'JP',
+  latitude: 35.681236,
+  longitude: 139.767125,
+  locationStatus: 'active',
+  visibility: 'hidden',
+  websiteUrl: 'https://example.test/tokyo',
+  phone: '+81 3 1111 1111',
+  description: 'Old reviewed description.',
+  openingHours: 'Mon-Fri 09:00-17:00',
+  amenities: ['wifi', 'parking'],
+  socialLinks: [
+    {
+      platform: 'instagram',
+      url: 'https://social.example.test/reviewed-cafe-old',
+      handle: '@oldreviewedcafe',
+    },
+    {
+      platform: 'x',
+      url: 'https://social.example.test/reviewed-cafe-x',
+      handle: '@reviewedcafe',
+    },
+  ],
+  osmType: null,
+  osmId: null,
+};
+
+function backend(failBeforeCommit = false) {
+  return new InMemoryLocationCorrectionBackend({
+    locations: [{ id: locationId, updatedAt: reviewedAt, value: currentLocation }],
+    sourceRecordIds: [sourceRecordId, otherSourceRecordId],
+    failBeforeCommit: () => failBeforeCommit,
+  });
+}
+
+function context(id = requestId) {
+  return {
+    requestId: id,
+    actorId: 'admin:profile-reviewer',
+    actorType: 'human' as const,
+    capabilities: ['location:correct' as const],
+  };
+}
+
+function input(): LocationCorrectionDecisionInput {
+  return {
+    locationId,
+    expectedLocationUpdatedAt: reviewedAt,
+    decidedAt,
+    changes: {
+      phone: { operation: 'set', value: '+81 3 2222 2222' },
+      description: { operation: 'clear' },
+      openingHours: { operation: 'set', value: 'Mon-Sun 08:00-20:00' },
+      amenities: { operation: 'add', values: ['outdoor-seating'] },
+      socialLinks: {
+        operation: 'replace',
+        values: [
+          {
+            platform: 'instagram',
+            url: 'https://social.example.test/reviewed-cafe',
+            handle: '@reviewedcafe',
+          },
+          {
+            platform: 'x',
+            url: 'https://social.example.test/reviewed-cafe-x',
+            handle: '@reviewedcafe',
+          },
+        ],
+      },
+    },
+    sourceRecordIds: [sourceRecordId],
+    provenanceAssignments: [
+      'phone',
+      'description',
+      'openingHours',
+      'amenities',
+      'socialLinks',
+    ].map((fieldPath) => ({
+      fieldPath: fieldPath as
+        | 'phone'
+        | 'description'
+        | 'openingHours'
+        | 'amenities'
+        | 'socialLinks',
+      sourceRecordIds: [sourceRecordId],
+    })),
+    reasonCode: 'reviewed_profile_correction',
+    publicSummary: 'Updated practical information from the reviewed official source.',
+    internalNote: null,
+  };
+}
+
+describe('Location correction decision contract', () => {
+  it('applies scalar set/clear and structured replace/add changes atomically with field provenance', async () => {
+    const store = backend();
+    const receipt = await createLocationCorrectionDecisionService(store).correct(context(), input());
+
+    expect(receipt).toMatchObject({
+      locationId,
+      state: 'committed',
+      updatedAt: decidedAt,
+    });
+    expect(receipt.appliedFieldPaths).toEqual([
+      'phone',
+      'description',
+      'openingHours',
+      'amenities',
+      'socialLinks',
+    ]);
+
+    const snapshot = store.snapshot();
+    expect(snapshot.locations[0]?.value).toMatchObject({
+      phone: '+81 3 2222 2222',
+      description: null,
+      openingHours: 'Mon-Sun 08:00-20:00',
+      amenities: ['wifi', 'parking', 'outdoor-seating'],
+      socialLinks: [
+        {
+          platform: 'instagram',
+          url: 'https://social.example.test/reviewed-cafe',
+          handle: '@reviewedcafe',
+        },
+        {
+          platform: 'x',
+          url: 'https://social.example.test/reviewed-cafe-x',
+          handle: '@reviewedcafe',
+        },
+      ],
+    });
+    expect(snapshot.provenanceRows.map((row) => row.fieldPath)).toEqual([
+      'phone',
+      'description',
+      'openingHours',
+      'amenities',
+      'socialLinks',
+    ]);
+    expect(snapshot.provenanceRows.every((row) => row.provenanceRole === 'correction')).toBe(true);
+    expect(snapshot.decisions[0]?.diff.map((row) => row.fieldPath)).toEqual(
+      receipt.appliedFieldPaths,
+    );
+  });
+
+  it('supports explicit remove and clear operations for structured and scalar fields', async () => {
+    const store = backend();
+    const correction = input();
+    correction.changes = {
+      websiteUrl: { operation: 'clear' },
+      amenities: { operation: 'remove', values: ['parking'] },
+      socialLinks: {
+        operation: 'remove',
+        values: [
+          {
+            platform: 'x',
+            url: 'https://social.example.test/reviewed-cafe-x',
+          },
+        ],
+      },
+    };
+    correction.provenanceAssignments = ['websiteUrl', 'amenities', 'socialLinks'].map(
+      (fieldPath) => ({
+        fieldPath: fieldPath as 'websiteUrl' | 'amenities' | 'socialLinks',
+        sourceRecordIds: [sourceRecordId],
+      }),
+    );
+
+    await createLocationCorrectionDecisionService(store).correct(context(), correction);
+    expect(store.snapshot().locations[0]?.value).toMatchObject({
+      websiteUrl: null,
+      amenities: ['wifi'],
+      socialLinks: [
+        {
+          platform: 'instagram',
+          url: 'https://social.example.test/reviewed-cafe-old',
+          handle: '@oldreviewedcafe',
+        },
+      ],
+    });
+
+    const secondStore = backend();
+    const clear = input();
+    clear.changes = {
+      amenities: { operation: 'clear' },
+      socialLinks: { operation: 'clear' },
+    };
+    clear.provenanceAssignments = ['amenities', 'socialLinks'].map((fieldPath) => ({
+      fieldPath: fieldPath as 'amenities' | 'socialLinks',
+      sourceRecordIds: [sourceRecordId],
+    }));
+
+    await createLocationCorrectionDecisionService(secondStore).correct(context(), clear);
+    expect(secondStore.snapshot().locations[0]?.value.amenities).toEqual([]);
+    expect(secondStore.snapshot().locations[0]?.value.socialLinks).toEqual([]);
+  });
+
+  it('requires exact provenance coverage for every changed field', async () => {
+    const correction = input();
+    correction.provenanceAssignments = correction.provenanceAssignments.filter(
+      (assignment) => assignment.fieldPath !== 'description',
+    );
+
+    await expect(
+      createLocationCorrectionDecisionService(backend()).correct(context(), correction),
+    ).rejects.toMatchObject({
+      code: 'invalid_decision',
+      issues: expect.arrayContaining([
+        expect.stringContaining('description requires explicit correction provenance'),
+      ]),
+    });
+  });
+
+  it('rejects provenance references outside the reviewed source set', async () => {
+    const correction = input();
+    correction.provenanceAssignments[0] = {
+      fieldPath: 'phone',
+      sourceRecordIds: [otherSourceRecordId],
+    };
+
+    await expect(
+      createLocationCorrectionDecisionService(backend()).correct(context(), correction),
+    ).rejects.toMatchObject({
+      code: 'invalid_decision',
+      issues: expect.arrayContaining([
+        expect.stringContaining('outside the reviewed source set'),
+      ]),
+    });
+  });
+
+  it('replays identical requests and conflicts when the same request ID carries changed content', async () => {
+    const store = backend();
+    const service = createLocationCorrectionDecisionService(store);
+
+    await expect(service.correct(context(), input())).resolves.toMatchObject({ state: 'committed' });
+    await expect(service.correct(context(), input())).resolves.toMatchObject({ state: 'replayed' });
+
+    const changed = input();
+    changed.changes.phone = { operation: 'set', value: '+81 3 3333 3333' };
+    await expect(service.correct(context(), changed)).rejects.toMatchObject({ code: 'conflict' });
+  });
+
+  it('conflicts when the canonical Location changed after review', async () => {
+    const correction = input();
+    correction.expectedLocationUpdatedAt = '2026-07-06T00:00:00.000Z';
+
+    await expect(
+      createLocationCorrectionDecisionService(backend()).correct(
+        context(secondRequestId),
+        correction,
+      ),
+    ).rejects.toMatchObject({ code: 'conflict' });
+  });
+
+  it('rejects correction operations that do not change the canonical field value', async () => {
+    const correction = input();
+    correction.changes = {
+      phone: { operation: 'set', value: '+81 3 1111 1111' },
+    };
+    correction.provenanceAssignments = [
+      { fieldPath: 'phone', sourceRecordIds: [sourceRecordId] },
+    ];
+
+    await expect(
+      createLocationCorrectionDecisionService(backend()).correct(context(), correction),
+    ).rejects.toMatchObject({ code: 'invalid_decision' });
+  });
+
+  it('rolls back Location, provenance, and decision state when the atomic backend fails', async () => {
+    const store = backend(true);
+    const before = store.snapshot();
+
+    await expect(
+      createLocationCorrectionDecisionService(store).correct(context(), input()),
+    ).rejects.toMatchObject({ code: 'backend_failure' });
+    expect(store.snapshot()).toEqual(before);
+  });
+});

--- a/tests/location-correction-decision.test.ts
+++ b/tests/location-correction-decision.test.ts
@@ -91,21 +91,17 @@ function input(): LocationCorrectionDecisionInput {
       },
     },
     sourceRecordIds: [sourceRecordId],
-    provenanceAssignments: [
-      'phone',
-      'description',
-      'openingHours',
-      'amenities',
-      'socialLinks',
-    ].map((fieldPath) => ({
-      fieldPath: fieldPath as
-        | 'phone'
-        | 'description'
-        | 'openingHours'
-        | 'amenities'
-        | 'socialLinks',
-      sourceRecordIds: [sourceRecordId],
-    })),
+    provenanceAssignments: ['phone', 'description', 'openingHours', 'amenities', 'socialLinks'].map(
+      (fieldPath) => ({
+        fieldPath: fieldPath as
+          | 'phone'
+          | 'description'
+          | 'openingHours'
+          | 'amenities'
+          | 'socialLinks',
+        sourceRecordIds: [sourceRecordId],
+      }),
+    ),
     reasonCode: 'reviewed_profile_correction',
     publicSummary: 'Updated practical information from the reviewed official source.',
     internalNote: null,
@@ -115,7 +111,10 @@ function input(): LocationCorrectionDecisionInput {
 describe('Location correction decision contract', () => {
   it('applies scalar set/clear and structured replace/add changes atomically with field provenance', async () => {
     const store = backend();
-    const receipt = await createLocationCorrectionDecisionService(store).correct(context(), input());
+    const receipt = await createLocationCorrectionDecisionService(store).correct(
+      context(),
+      input(),
+    );
 
     expect(receipt).toMatchObject({
       locationId,
@@ -150,10 +149,10 @@ describe('Location correction decision contract', () => {
       ],
     });
     expect(snapshot.provenanceRows.map((row) => row.fieldPath)).toEqual([
-      'phone',
+      'amenities',
       'description',
       'openingHours',
-      'amenities',
+      'phone',
       'socialLinks',
     ]);
     expect(snapshot.provenanceRows.every((row) => row.provenanceRole === 'correction')).toBe(true);
@@ -241,9 +240,7 @@ describe('Location correction decision contract', () => {
       createLocationCorrectionDecisionService(backend()).correct(context(), correction),
     ).rejects.toMatchObject({
       code: 'invalid_decision',
-      issues: expect.arrayContaining([
-        expect.stringContaining('outside the reviewed source set'),
-      ]),
+      issues: expect.arrayContaining([expect.stringContaining('outside the reviewed source set')]),
     });
   });
 
@@ -251,7 +248,9 @@ describe('Location correction decision contract', () => {
     const store = backend();
     const service = createLocationCorrectionDecisionService(store);
 
-    await expect(service.correct(context(), input())).resolves.toMatchObject({ state: 'committed' });
+    await expect(service.correct(context(), input())).resolves.toMatchObject({
+      state: 'committed',
+    });
     await expect(service.correct(context(), input())).resolves.toMatchObject({ state: 'replayed' });
 
     const changed = input();

--- a/tests/location-correction-decision.test.ts
+++ b/tests/location-correction-decision.test.ts
@@ -275,9 +275,7 @@ describe('Location correction decision contract', () => {
     correction.changes = {
       phone: { operation: 'set', value: '+81 3 1111 1111' },
     };
-    correction.provenanceAssignments = [
-      { fieldPath: 'phone', sourceRecordIds: [sourceRecordId] },
-    ];
+    correction.provenanceAssignments = [{ fieldPath: 'phone', sourceRecordIds: [sourceRecordId] }];
 
     await expect(
       createLocationCorrectionDecisionService(backend()).correct(context(), correction),


### PR DESCRIPTION
## Implementation item

`P4-18B4A`

## Purpose

Establish an explicit guarded correction operation for practical profile fields on already canonical Places, without widening existing-target Candidate linking into a profile mutation path.

## Changes

- add the B4 audit finding and four-slice execution plan;
- define a dedicated `location:correct` mutation capability contract;
- define explicit scalar `set` / `clear` operations;
- define Amenities `add` / `remove` / `replace` / `clear` operations;
- define Social Link `add` / `remove` / `replace` / `clear` operations;
- keep omitted fields unchanged and reject empty change plans;
- require exact field-level correction provenance coverage for every changed field;
- reject provenance sources outside the reviewed source set;
- normalize request fingerprints for deterministic replay checks;
- add canonical patch application through the strict Location schema;
- add a copy-on-write in-memory backend with exact `updatedAt` guard, source availability guard, no-op rejection, replay, conflict, correction provenance rows, decision diff receipt, and rollback;
- add focused coverage for scalar and structured operations, provenance validation, replay, stale state, no-op rejection, and rollback.

## Remaining B4 work

- B4B durable correction decision storage and atomic Drizzle persistence;
- B4C protected workspace, API authorization, and operator controls;
- B4D Audit history integration and closure reconciliation.

## Out of scope

- Claim verification changes;
- direct publication;
- public submission intake;
- identity or coordinate correction;
- Media correction.
