### PR TITLE
P4-18C3: close bounded UI residual audit and hand off to P4-18D

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -130,8 +130,8 @@ Repository-complete components remain subject to the P4-18D operator-journey aud
 | P4-18B2 | Promotion editor and field provenance parity | Completed | P4-18B1 | #130 |
 | P4-18B3 | Canonical persistence and public projection integration | Completed | P4-18B2 | #132, #133, #134 |
 | P4-18B4 | Existing-record practical-profile correction path audit and completion | Completed | P4-18B3 | #135, #136, #137, #138 |
-| P4-18C | Bounded UI residual closure | In progress | P4-18A, representative screenshot capture | — |
-| P4-18D | Administration workflow integration audit | Planned | P4-18B | — |
+| P4-18C | Bounded UI residual closure | Completed | P4-18A, representative screenshot capture | #139, #141, #142 |
+| P4-18D | Administration workflow integration audit | In progress | P4-18B | — |
 | P4-18E | Live review and Phase 5 handoff audit | Planned | P4-18B, P4-18C, P4-18D | — |
 
 ### P4-17 Places recovery result
@@ -151,7 +151,7 @@ P4-17A through P4-17F are implemented, validated, and merged through #122. The f
 - #125 — representative desktop/mobile screenshot capture, interactive-state capture, legacy Place field parity baseline, and practical profile staging fixture coverage;
 - #126 — selected Place focus and marker correction plus desktop selected-panel containment.
 
-These changes improve observability and baseline UI behavior. They do not complete P4-18C residual UI closure, P4-18D administration integration, or P4-18E handoff.
+These changes improve observability and baseline UI behavior. They do not complete P4-18D administration integration or P4-18E handoff.
 
 ### P4-18B3 repository result
 
@@ -164,6 +164,20 @@ The configured canonical query → complete twelve-artifact candidate generation
 P4-18B4 repository work is completed through #135–#138. It establishes bounded existing-Location correction semantics, exact correction provenance, replay/conflict/rollback behavior, durable decision and diff history, atomic Drizzle persistence, protected operator workspace and API, separate existing-target navigation, and protected Audit history normalization.
 
 Environment-specific migration application, Access allowlist configuration, representative live correction, live Audit appearance, and corrected-value release flow remain assigned to P4-18D/E. Repository tests do not prove those live conditions.
+
+### P4-18C repository and visual result
+
+P4-18C is completed through #139, #141, and #142.
+
+The bounded closure covers:
+
+- compact Mobile Places List cards with payment/freshness information retained;
+- bounded Mobile Menu density with focus, Escape, overlay, body-scroll, and active-page behavior preserved;
+- payment-first information ordering in the expanded mobile Place sheet;
+- explicit Mobile Filters completion with live result count while retaining Clear and zero-result recovery paths;
+- direct final-artifact inspection across List, Menu, expanded sheet, Filters, and representative Methodology long-form output.
+
+No material horizontal overflow, hidden primary interaction, or unresolved density defect remained in the fixed five-item scope. Screenshot capture success was not used as a substitute for image inspection. The durable closure record is `docs/P4_18_C_UI_AUDIT.md`.
 
 ### P4-18 execution order
 
@@ -180,7 +194,9 @@ Execution order:
 7. P4-18D — administration workflow integration audit;
 8. P4-18E — live review and Phase 5 handoff audit.
 
-P4-18 is a bounded closure term. P4-18C must not become an unlimited redesign cycle. P4-18B is a prerequisite for public submission work because external corrections must not arrive before the operator can safely review, provenance, apply, and publish the same field classes.
+P4-18 is a bounded closure term. P4-18B is a prerequisite for public submission work because external corrections must not arrive before the operator can safely review, provenance, apply, and publish the same field classes.
+
+P4-18D is now active. It must audit operator journeys and cross-workspace boundaries from Candidate intake through duplicate review, Promotion, existing-target linking, Location correction, Evidence, reconfirmation, Media, export controls, Audit history, and rollback/retry behavior. Environment-specific checks must be classified precisely rather than hidden under broad deferred-verification language.
 
 ## Phase 5 — Public submissions / MVP-B
 

--- a/docs/P4_18_C_UI_AUDIT.md
+++ b/docs/P4_18_C_UI_AUDIT.md
@@ -1,20 +1,34 @@
 # P4-18C bounded UI residual audit
 
 **Implementation item:** P4-18C  
-**Status:** Active — C1 visually accepted; C2 planned next  
+**Status:** Repository and visual review complete through C1 and C2; C3 closure reconciliation complete  
 **Last updated:** 2026-07-08
 
 ## Purpose
 
-P4-18C closes only material UI residuals already visible in representative screenshot review. It does not reopen Phase 4 as an unlimited redesign cycle.
+P4-18C closes only material UI residuals visible in representative screenshot review. It does not reopen Phase 4 as an unlimited redesign cycle.
 
-## Visual review source
+## Visual review sources
 
-The representative screenshot artifact generated from the post-B4 main state was inspected directly. A successful screenshot workflow is treated only as capture evidence; visual acceptance is recorded here from image review.
+The representative screenshot artifact generated from the post-B4 main state was inspected directly. A successful screenshot workflow was treated only as capture evidence; visual acceptance was recorded only after image review.
 
-C1 was also reviewed directly from the representative screenshot artifact generated from the formatted final C1 head. The affected Mobile Places List and open Mobile Menu images were inspected rather than inferred from the capture workflow result.
+C1 was reviewed directly from the representative screenshot artifact generated from the formatted final C1 head. The affected Mobile Places List and open Mobile Menu images were inspected rather than inferred from the capture workflow result.
 
-## Material findings
+C2 was reviewed directly from the representative screenshot artifact generated from the final C2 head. The expanded Place sheet, Filters-open state, Mobile Places List, open Mobile Menu, and representative Methodology page were inspected from the same artifact set before C3 closure.
+
+## Closure result
+
+The fixed five-item P4-18C scope is closed:
+
+1. Mobile Places List compactness and scanability — closed by C1;
+2. Mobile Menu density — closed by C1;
+3. expanded-sheet information order and access to payment-critical information — closed by C2;
+4. Filters completion, clear, zero-result recovery, and shared Map/List state behavior — closed by C2 plus existing shared discovery-state coverage;
+5. material density or layout defects on representative long-form public pages — no material defect found in direct review.
+
+No material horizontal overflow, hidden primary interaction, or unresolved density defect was found in the final C2 artifact review. Small future visual preferences may be handled as bounded follow-up fixes and do not keep P4-18C open.
+
+## Material findings and results
 
 ### C-UI-01 — Mobile Places List card density
 
@@ -24,7 +38,7 @@ Original issue:
 
 - realistic multi-result lists required excessive scrolling;
 - each card repeated four payment/freshness blocks in a single-column mobile definition list;
-- 80px Media or placeholder, four vertical metadata blocks, and two actions created an unnecessarily tall result card.
+- large Media or placeholder blocks, four vertical metadata blocks, and two actions created an unnecessarily tall result card.
 
 C1 result:
 
@@ -33,7 +47,7 @@ C1 result:
 - mobile thumbnails/placeholders are reduced while wider-breakpoint sizing remains;
 - Assets, Networks, Routes, and Last confirmed use a compact two-column mobile summary;
 - action controls retain minimum touch target height;
-- direct review of the C1 Mobile Places List screenshot confirms materially better scan density without information loss or horizontal overflow.
+- direct final-artifact review confirms materially better scan density without information loss or horizontal overflow.
 
 ### C-UI-02 — Mobile Menu uses excessive screen area
 
@@ -49,28 +63,30 @@ C1 result:
 - overlay dismissal, Escape handling, focus trap, close-button focus, trigger focus restoration, body scroll lock, and active-page state remain covered;
 - the menu is now a bounded top-right panel;
 - six primary links are presented as a three-row, two-column grid with minimum touch targets;
-- direct review of the C1 open-menu screenshot confirms the previous full-height empty-area problem is removed and navigation remains readable.
+- direct final-artifact review confirms the previous full-height empty-area problem is removed and navigation remains readable.
 
 ### C-UI-03 — Expanded Place sheet delays payment-critical information
 
-**Status:** Material — C2 planned
+**Status:** Closed by C2 visual acceptance
 
-Observed issue:
+Original issue:
 
-The expanded mobile sheet currently renders Location, Navigate, About, Hours, Amenities, Contact/official links, and Gallery before `How to pay` and payment metadata. Payment instructions can therefore sit well below the first viewport even though payment usability is a primary responsibility of the product.
+The expanded mobile sheet rendered Location, Navigate, About, Hours, Amenities, Contact/official links, and Gallery before `How to pay` and payment metadata. Payment instructions could therefore sit well below the first viewport even though payment usability is a primary responsibility of the product.
 
-Required correction:
+C2 result:
 
-- keep the selected-place identity header concise;
-- place `How to pay` and core payment metadata before long practical-profile sections and Gallery;
-- preserve Location and navigation access near the top;
-- avoid duplicating the complete canonical Place detail page.
+- Location and navigation remain near the top;
+- `How to pay` follows Location and Navigate directly;
+- Networks, Payment routes, Payment methods, Processor, Merchant receives, and Restrictions remain grouped with the payment context;
+- About, Hours, Amenities, Contact/official links, and Gallery follow payment-critical information;
+- the complete practical profile and detail/report exits remain available;
+- direct final-artifact review confirms payment-critical information is visible before long practical-profile content without horizontal overflow or hidden actions.
 
 ### C-UI-04 — Mobile Filters lack an explicit completion affordance
 
-**Status:** Material interaction residual — C2 planned
+**Status:** Closed by C2 visual acceptance and interaction coverage
 
-Current code already provides:
+The existing implementation already provided:
 
 - immediate filter application;
 - Clear;
@@ -80,26 +96,23 @@ Current code already provides:
 - Online Services and Suggest a Place exits;
 - Map/List state preservation through shared discovery URL state.
 
-Remaining issue:
+C2 result:
 
-- the mobile filter sheet can be dismissed through close X or backdrop, but has no explicit bottom completion action after changing filters;
-- the long facet sheet therefore lacks a clear task-completion endpoint.
-
-Required correction:
-
-- add a mobile-only sticky completion footer showing current result count;
-- retain immediate application, Clear, zero-result guidance, and existing close/backdrop behavior;
-- keep desktop filter panel behavior unchanged.
+- a mobile-only sticky completion footer now shows the live result count;
+- the completion action closes the filter sheet explicitly;
+- the completion action participates in the mobile focus trap;
+- immediate application, Clear, zero-result guidance, Widen area, Include Stale, existing backdrop/close behavior, and desktop filter behavior remain unchanged;
+- direct final-artifact review confirms the completion action is visible and readable without horizontal overflow.
 
 ### C-UI-05 — Representative long-form public pages
 
-**Status:** No material defect found in current review
+**Status:** Closed with no material defect found
 
-The representative Methodology mobile screenshot was inspected. It is long by content volume, but no material horizontal overflow, hidden interaction, or broken density/layout defect was observed. P4-18C will not churn this page without new material evidence.
+The representative Methodology mobile screenshot was inspected again from the final C2 artifact set. It is long by content volume, but no material horizontal overflow, hidden interaction, or broken density/layout defect was observed. P4-18C therefore does not churn this page without new material evidence.
 
 ## Execution slices
 
-### C1 — Compact Mobile List and Menu — Visually accepted
+### C1 — Compact Mobile List and Menu — Completed and visually accepted
 
 Completed result:
 
@@ -109,21 +122,36 @@ Completed result:
 - focused tests and representative screenshots completed successfully;
 - affected screenshots were directly inspected and accepted.
 
-### C2 — Expanded sheet payment order and Filters completion
+### C2 — Expanded sheet payment order and Filters completion — Completed and visually accepted
 
-- move payment-critical information ahead of long practical-profile content in expanded sheet;
-- retain Location/navigation near the top;
-- add explicit mobile Filters completion footer with result count;
-- verify Clear, zero-result, widen-area, Include Stale, and Map/List behavior;
-- run focused tests and inspect affected screenshots.
+Completed result:
 
-### C3 — Visual closure reconciliation
+- payment-critical information is placed ahead of long practical-profile content in expanded sheet;
+- Location/navigation remain near the top;
+- mobile Filters include an explicit completion footer with live result count;
+- Clear, zero-result recovery, Widen area, Include Stale, and shared Map/List state behavior remain covered;
+- focused tests and representative screenshots completed successfully;
+- expanded-sheet and Filters-open screenshots were directly inspected and accepted.
 
-- inspect the latest affected mobile screenshots directly;
-- verify no material horizontal overflow or hidden interactive surface;
-- reconcile the five fixed P4-18C scope items;
-- record small non-material preferences as later bounded follow-ups rather than keeping C open;
-- move tracking to P4-18D only after material residuals are closed.
+### C3 — Visual closure reconciliation — Completed
+
+C3 directly inspected the latest representative artifact across:
+
+- Mobile Places List;
+- open Mobile Menu;
+- expanded Place sheet;
+- Filters-open state;
+- representative Methodology long-form page.
+
+No material residual remained in the fixed P4-18C scope. P4-18C is closed and tracking may move to P4-18D.
+
+## Closure decision
+
+P4-18C is complete.
+
+The next implementation item is P4-18D — Administration workflow integration audit.
+
+P4-18D must audit real operator journeys across Candidate, duplicate, Promotion, existing-target linking, Location correction, Evidence, reconfirmation, Media, export, Audit history, and rollback/retry boundaries. Environment-specific checks must be classified precisely as completed, unavailable, or assigned to P4-18E/launch work; repository tests must not be described as live verification.
 
 ## Non-goals
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 4 — Public core / MVP-A closure
 
 ## Current implementation item
 
-P4-18C — Bounded UI residual closure
+P4-18D — Administration workflow integration audit
 
 ## Current repository state
 
@@ -24,7 +24,8 @@ P4-18C — Bounded UI residual closure
 - P4-18B2 Promotion editor and field provenance parity is completed through #130.
 - P4-18B3 canonical persistence and public projection integration repository work is completed through #132 and #133, with closure tracking and B4 handoff through #134.
 - P4-18B4 existing-record practical-profile correction path is repository-complete through #135, #136, #137, and #138.
-- P4-18C is active.
+- P4-18C bounded UI residual closure is completed through #139, #141, and #142, with direct final-artifact visual review recorded in `docs/P4_18_C_UI_AUDIT.md`.
+- P4-18D is active.
 
 ## Fixed review environment
 
@@ -55,7 +56,8 @@ For Places UI work read:
 
 1. `docs/PLACES_UX_ACCEPTANCE.md`;
 2. `docs/PLACES_RECOVERY_PLAN.md`;
-3. `docs/PLACES_UX_FINAL_AUDIT.md`.
+3. `docs/PLACES_UX_FINAL_AUDIT.md`;
+4. `docs/P4_18_C_UI_AUDIT.md` for the completed bounded residual closure.
 
 For Phase 5 preparation and submission work also read:
 
@@ -71,8 +73,8 @@ For Phase 5 preparation and submission work also read:
 3. P4-18B2 — promotion editor and field provenance parity — Completed through #130
 4. P4-18B3 — canonical persistence and public projection integration — Completed through #132, #133, and #134
 5. P4-18B4 — existing-record practical-profile correction path audit and completion — Completed through #135, #136, #137, and #138
-6. P4-18C — bounded UI residual closure — In progress
-7. P4-18D — administration workflow integration audit — Planned
+6. P4-18C — bounded UI residual closure — Completed through #139, #141, and #142
+7. P4-18D — administration workflow integration audit — In progress
 8. P4-18E — live review and Phase 5 handoff audit — Planned
 
 The authoritative scope and completion criteria are in `docs/PHASE4_CLOSURE_PLAN.md`.
@@ -141,7 +143,7 @@ Repository coverage includes:
 - practical profile consumption by desktop selected panel and mobile expanded sheet;
 - built staging Place detail coverage for description, hours, amenities, phone, official social link, and Media.
 
-The repository release-review path begins from an already generated private candidate bundle. The configured canonical query → complete candidate generation → private upload → release-review path is an environment-specific verification item assigned precisely to P4-18E. Repository tests do not prove that live path.
+The repository release-review path begins from an already generated private candidate bundle. The configured canonical query → complete twelve-artifact candidate generation → private upload → release-review path is an environment-specific verification item assigned precisely to P4-18E. Repository tests do not prove that live path.
 
 ## P4-18B4 completed boundary
 
@@ -165,19 +167,36 @@ Repository coverage includes:
 
 Live migration application, Access allowlist configuration, representative live correction, live protected Audit appearance, and configured corrected-value release flow remain environment-specific P4-18D/E verification items. Repository tests do not prove those live conditions.
 
-## P4-18C active scope
+## P4-18C completed boundary
 
-P4-18C is bounded to:
+P4-18C closed the fixed UI residual scope through C1, C2, and direct C3 final-artifact reconciliation:
 
-- Mobile Places List compactness and scanability;
-- Mobile Menu density;
-- expanded-sheet information order and access to payment-critical information;
-- Filters completion, clear, zero-result, and Map/List behavior;
-- only material density or layout defects on representative long-form public pages.
+- Mobile Places List cards were compacted while retaining status, category, locality, payment assets, networks, routes, freshness, map selection, and payment-detail access;
+- the Mobile Menu moved from a sparse full-height drawer to a bounded two-column navigation panel while preserving focus, Escape, overlay, body-scroll, and active-page behavior;
+- expanded mobile Place information now presents Location and Navigate followed immediately by `How to pay` and core payment metadata before long practical-profile content;
+- Mobile Filters now include an explicit sticky completion action with live result count while retaining immediate application, Clear, zero-result recovery, Widen area, Include Stale, and existing desktop behavior;
+- representative Methodology long-form mobile output was directly inspected with no material overflow, hidden interaction, or broken density/layout defect found;
+- final direct review of the same latest artifact set found no material horizontal overflow or hidden primary interaction across the fixed five-item scope.
 
-Representative screenshot capture is a standard review instrument. A successful capture job does not replace image inspection.
+Screenshot workflow success was not used as a substitute for image inspection. The closure record is `docs/P4_18_C_UI_AUDIT.md`.
 
-P4-18C must not become an unlimited redesign cycle. Small later visual findings may be handled as bounded fixes and do not keep P4-18C open indefinitely.
+## P4-18D active scope
+
+P4-18D audits real operator journeys and cross-workspace integration across:
+
+- Candidate queue and detail;
+- duplicate review and identity resolution;
+- new-target Promotion;
+- existing-target linking;
+- separate Location correction;
+- Evidence review and Claim decisions;
+- reconfirmation queue and expiration behavior;
+- Media review;
+- export candidate, release decision, activation, history, and restore boundaries;
+- protected Audit history coverage;
+- conflict, retry, replay, rollback, and operator-reachability behavior.
+
+P4-18D must distinguish repository evidence from environment-specific verification. Every live-only check must be classified precisely as completed, unavailable, or assigned to P4-18E/launch work. Broad deferred-verification language is not sufficient.
 
 ## Phase 5 handoff
 
@@ -196,7 +215,7 @@ Planned Phase 5 order:
 
 ## Next
 
-Execute the bounded P4-18C UI residual audit and fixes. Do not move to P4-18D until P4-18C repository work is closed and tracking is updated.
+Execute P4-18D administration workflow integration audit. Do not move to P4-18E until operator journeys, cross-workspace boundaries, retry/conflict behavior, Audit coverage, and environment-specific check inventory are reconciled.
 
 ## Blocked
 


### PR DESCRIPTION
## Implementation item

`P4-18C3`

## Purpose

Close the bounded P4-18C UI residual term after direct latest-artifact review across the fixed five-item scope, record visual acceptance, and hand the project to P4-18D administration workflow integration audit.

## Closure basis

The final C2 representative screenshot artifact was directly inspected across:

- Mobile Places List;
- open Mobile Menu;
- expanded Place sheet;
- Filters-open state;
- representative Methodology long-form page.

A successful capture workflow is not treated as visual acceptance by itself.

## Result

- C1 compact Mobile Places List remains accepted;
- C1 bounded Mobile Menu remains accepted;
- C2 payment-first expanded sheet is accepted;
- C2 explicit Mobile Filters completion action is accepted;
- Clear, zero-result recovery, Widen area, Include Stale, and shared Map/List state behavior remain covered;
- no material long-form mobile layout defect was found;
- no material horizontal overflow or hidden primary interaction remains in the fixed P4-18C scope.

## Tracking

- close P4-18C;
- move PROJECT_STATUS current item to P4-18D;
- mark P4-18C completed in IMPLEMENTATION_PLAN;
- preserve P4-18E as the live review and Phase 5 handoff gate.

## Out of scope

- additional visual redesign;
- live environment verification;
- P4-18D operator-journey audit itself;
- P4-18E live review and Phase 5 handoff.
