### PR TITLE
P4-18D5: close Admin integration audit and hand off to P4-18E

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # CryptoPayMap implementation plan
 
 **Status:** Active  
-**Last updated:** 2026-07-08
+**Last updated:** 2026-07-09
 
 This file tracks repository implementation work. GitHub `main`, merged pull requests, and actual CI results are authoritative when this file differs from repository reality.
 
@@ -50,7 +50,7 @@ This file tracks repository implementation work. GitHub `main`, merged pull requ
 | P1-09 | PWA manifest and installability baseline | Completed | #19 |
 | P1-10 | Accessibility baseline | Completed | #20 |
 | P1-11 | Public Roadmap and Changelog loaders | Completed | #21 |
-| P1-12 | Integration and quality audit | Repository completed | #22, #23 |
+| P1-12 | Integration and quality audit | Repository completed; old live-check draft superseded | #22; #23 closed superseded |
 
 ## Phase 2 — Data core
 
@@ -76,7 +76,7 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 
 ## Phase 3 — Administration and review
 
-**Status:** Repository completed; P4-18D/E will reconcile remaining integration and environment checks
+**Status:** Repository completed; P4-18E will reconcile remaining configured-environment checks before Phase 5 handoff
 
 | ID | Item | Status | Depends on | Pull request |
 |---|---|---|---|---|
@@ -95,11 +95,11 @@ Phase 2 keeps imported records private, preserves source and license provenance,
 
 Phase 3 established protected Candidate review, duplicate resolution, new-target promotion, existing-target linking, field-level provenance, Evidence decisions, Claim transitions, reconfirmation queues, Media review, export release decisions, publication activation, release history, restore boundaries, and cross-domain Audit history.
 
-Repository-complete components remain subject to the P4-18D operator-journey audit and P4-18E environment-specific handoff checks. Repository tests must not be described as live environment verification.
+Repository-complete components have been reconciled by P4-18D. P4-18E owns the configured-environment handoff checks. Repository tests must not be described as live environment verification.
 
 ## Phase 4 — Public core / MVP-A and closure
 
-**Status:** MVP-A public surfaces are merged; P4-18 closure is active
+**Status:** MVP-A public surfaces are merged; P4-18E live review and Phase 5 handoff is active
 
 | ID | Item | Status | Depends on | Pull request |
 |---|---|---|---|---|
@@ -131,8 +131,8 @@ Repository-complete components remain subject to the P4-18D operator-journey aud
 | P4-18B3 | Canonical persistence and public projection integration | Completed | P4-18B2 | #132, #133, #134 |
 | P4-18B4 | Existing-record practical-profile correction path audit and completion | Completed | P4-18B3 | #135, #136, #137, #138 |
 | P4-18C | Bounded UI residual closure | Completed | P4-18A, representative screenshot capture | #139, #141, #142 |
-| P4-18D | Administration workflow integration audit | In progress | P4-18B | — |
-| P4-18E | Live review and Phase 5 handoff audit | Planned | P4-18B, P4-18C, P4-18D | — |
+| P4-18D | Administration workflow integration audit | Completed | P4-18B | #143–#147 |
+| P4-18E | Live review and Phase 5 handoff audit | In progress | P4-18B, P4-18C, P4-18D | — |
 
 ### P4-17 Places recovery result
 
@@ -151,7 +151,7 @@ P4-17A through P4-17F are implemented, validated, and merged through #122. The f
 - #125 — representative desktop/mobile screenshot capture, interactive-state capture, legacy Place field parity baseline, and practical profile staging fixture coverage;
 - #126 — selected Place focus and marker correction plus desktop selected-panel containment.
 
-These changes improve observability and baseline UI behavior. They do not complete P4-18D administration integration or P4-18E handoff.
+These changes improve observability and baseline UI behavior. They do not complete the P4-18E handoff.
 
 ### P4-18B3 repository result
 
@@ -163,7 +163,7 @@ The configured canonical query → complete twelve-artifact candidate generation
 
 P4-18B4 repository work is completed through #135–#138. It establishes bounded existing-Location correction semantics, exact correction provenance, replay/conflict/rollback behavior, durable decision and diff history, atomic Drizzle persistence, protected operator workspace and API, separate existing-target navigation, and protected Audit history normalization.
 
-Environment-specific migration application, Access allowlist configuration, representative live correction, live Audit appearance, and corrected-value release flow remain assigned to P4-18D/E. Repository tests do not prove those live conditions.
+Environment-specific migration application, Access allowlist configuration, representative live correction, live Audit appearance, and corrected-value release flow remain assigned to P4-18E. Repository tests do not prove those live conditions.
 
 ### P4-18C repository and visual result
 
@@ -178,6 +178,25 @@ The bounded closure covers:
 - direct final-artifact inspection across List, Menu, expanded sheet, Filters, and representative Methodology long-form output.
 
 No material horizontal overflow, hidden primary interaction, or unresolved density defect remained in the fixed five-item scope. Screenshot capture success was not used as a substitute for image inspection. The durable closure record is `docs/P4_18_C_UI_AUDIT.md`.
+
+### P4-18D repository result
+
+P4-18D is completed through D1 #143, D2 #144, D3 #145, D4 #146, and D5 #147.
+
+The audit established:
+
+- coherent operator route reachability and accurate capability copy;
+- explicit raw Access subject versus normalized actor-ID authorization mapping;
+- reachable mutation UI idempotency coverage;
+- exact Evidence confirmation payment-set and prerequisite guards;
+- Reconfirmation connectivity failure recovery;
+- release decision versus publication capability separation;
+- explicit non-UI classification for publication activation and release history;
+- accurate repository-only classification for restore contracts and workflow;
+- explicit Launch work ownership for production restore persistence, invocation, R2 wiring, durable restore Audit source, reconciliation runbook, and drills;
+- precise P4-18E ownership for configured-environment verification.
+
+The closure inventory is `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md`.
 
 ### P4-18 execution order
 
@@ -196,7 +215,7 @@ Execution order:
 
 P4-18 is a bounded closure term. P4-18B is a prerequisite for public submission work because external corrections must not arrive before the operator can safely review, provenance, apply, and publish the same field classes.
 
-P4-18D is now active. It must audit operator journeys and cross-workspace boundaries from Candidate intake through duplicate review, Promotion, existing-target linking, Location correction, Evidence, reconfirmation, Media, export controls, Audit history, and rollback/retry behavior. Environment-specific checks must be classified precisely rather than hidden under broad deferred-verification language.
+P4-18D repository work is complete. P4-18E is active and must verify or precisely classify the configured-environment checks assigned by D5 before the project may move to P5-01.
 
 ## Phase 5 — Public submissions / MVP-B
 

--- a/docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md
+++ b/docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md
@@ -1,0 +1,137 @@
+# P4-18D5 closure and environment-specific inventory
+
+**Implementation item:** P4-18D5  
+**Status:** Active  
+**Last updated:** 2026-07-09
+
+## Purpose
+
+P4-18D5 closes the repository administration integration audit after D1 through D4 and assigns every remaining environment-dependent check precisely.
+
+The allowed classifications are:
+
+- `P4-18E` — must be verified or explicitly recorded unavailable during the live review and Phase 5 handoff audit;
+- `Launch work` — production capability or drill that is not required to pretend repository closure and must remain explicit before launch criteria can be claimed;
+- `Completed repository boundary` — verified by current main, merged pull requests, and green CI only;
+- `Unavailable` — may be used only when P4-18E attempts a configured-environment check and records the missing environment or capability precisely.
+
+Generic deferred-verification wording is prohibited.
+
+## 1. D1–D4 closure summary
+
+| Slice | Result | Closure basis |
+|---|---|---|
+| D1 | Completed | route reachability, accurate Admin capability copy, Claim workflow index, nested navigation ownership |
+| D2 | Completed | subject/actor-ID policy mapping, fail-closed authorization identity forms, UI/API compatibility, Idempotency-Key contract |
+| D3 | Completed | exact confirmation payment set guard, current payment prerequisite validation, atomic transaction-time recheck, Reconfirmation network retry recovery |
+| D4 | Completed | release/publish capability separation, publication and history non-UI classification, restore repository-versus-production boundary, Audit source coverage, reconfirmation attribution classification |
+
+No open repository finding remains from D1–D4.
+
+## 2. Operator journey closure matrix
+
+| Journey stage | Repository result | Remaining environment assignment |
+|---|---|---|
+| Admin overview and navigation | reachable and accurate | P4-18E Access/deployment verification |
+| Candidate queue/detail | reachable protected UI/API | P4-18E configured Access and live data check |
+| Duplicate review | reachable when applicable | P4-18E only when representative configured data exists |
+| New-target Promotion | guarded reachable operation | P4-18E configured database/operator path |
+| Existing-target linking | guarded reachable operation | P4-18E configured database/operator path |
+| Existing-Location correction | separate guarded operation with durable Audit source | P4-18E representative live correction and Audit appearance |
+| Evidence review/confirmation | exact Evidence and Claim Asset set guards, payment prerequisites, atomic recheck | P4-18E representative configured confirmation path |
+| Reconfirmation | protected UI/API plus scheduled repository boundary; retry recovery present | P4-18E configured actor identity and representative protected path |
+| Media review | reachable protected UI/API | P4-18E configured environment review when supported |
+| Export candidate/release decision | reachable protected UI/API | P4-18E configured candidate generation/upload/review handoff |
+| Publication activation | explicit non-UI protected `export:publish` operation | P4-18E review-environment activation if configured; production drill is Launch work |
+| Release history | explicit non-UI protected read API/model | P4-18E configured durable history read when available |
+| Restore preparation/execution | repository contract/workflow only; not production-operational | Launch work |
+| Audit history | reachable protected UI/API with durable source aggregation | P4-18E configured live source appearance checks |
+| Submissions | intentional future boundary | Phase 5, not a P4-18D gap |
+
+## 3. P4-18E assigned checks
+
+P4-18E must verify or precisely mark unavailable:
+
+1. fixed review deployment receipt matches the intended `main` commit;
+2. Cloudflare Access protects the intended Admin surfaces in the configured review environment;
+3. configured subject-based and actor-ID-based allowlists accept the intended operator identity forms;
+4. deployed Functions receive the required environment configuration without exposing values publicly;
+5. verified Access identity claims produce the intended normalized subject and actor ID behavior;
+6. configured Neon environment has the required migration state for the repository head used by the review environment;
+7. representative Candidate queue/detail reachability with configured data;
+8. representative Location correction, durable decision, and protected Audit appearance when the environment supports the path;
+9. representative Evidence confirmation against the current payment combination set and prerequisite display when configured data supports the path;
+10. representative Reconfirmation protected path and retry/conflict behavior to the extent supported by the environment;
+11. configured canonical query → complete twelve-artifact candidate generation → private upload → release-review handoff;
+12. private export candidate review and release decision path;
+13. review-environment publication activation through the intended non-UI protected boundary when the publication adapter is configured;
+14. deployment receipt and public artifact state after review-environment activation;
+15. configured release history read and export Audit appearance;
+16. corrected canonical value → candidate generation → release review → public activation path when the environment supports the complete chain;
+17. staging artifact validation and representative screenshot capture plus direct image inspection;
+18. precise classification of every unavailable check rather than treating absence as success.
+
+P4-18E may not downgrade an unavailable environment into repository proof.
+
+## 4. Launch work assignments
+
+The following are not closed by repository tests and are not silently required to block the start of Phase 5 unless P4-18E discovers a direct MVP-B dependency. They remain explicit launch work:
+
+### Production restore capability
+
+1. durable production restore execution table and migration;
+2. concrete production persistence backend;
+3. concrete R2 pointer inspection and conditional replacement adapter;
+4. protected restore invocation boundary using `export:publish` and idempotency identity;
+5. durable restore execution Audit source registration;
+6. post-switch persistence reconciliation procedure using preserved switch receipts;
+7. operator runbook for partial switch and post-switch persistence failure;
+8. live production restore drill;
+9. replay verification proving repeated restore requests do not repeat pointer mutation.
+
+### Production release readiness
+
+10. production publication drill;
+11. production R2 conditional-write verification;
+12. production Access and allowlist verification for release/publish roles;
+13. production backup and restoration drill required by launch criteria;
+14. incident rollback runbook validation.
+
+These items remain visible in launch preparation. Their assignment does not permit launch criteria to be claimed before they are complete.
+
+## 5. Repository closure findings
+
+P4-18D repository closure is supported by:
+
+- D1 route and navigation reconciliation through #143;
+- D2 Access identity mapping and API compatibility through #144;
+- D3 confirmation payment guards and retry recovery through #145;
+- D4 publication, restore, and Audit classification through #146;
+- green Foundation validation and Migration drift for the merged D slices;
+- explicit non-UI classification for publication activation and release history;
+- explicit Launch work classification for missing production restore persistence, invocation, R2 wiring, durable restore Audit source, and drills;
+- preserved separation between repository proof and environment verification.
+
+## 6. P4-18D closure decision
+
+P4-18D may close when this D5 inventory is green because:
+
+- every implemented operation is reachable through an accurate protected operator path or classified as an explicit non-UI boundary;
+- repository guard, replay, conflict, retry, and failure findings found by D3 are corrected;
+- publication/release/restore/Audit boundaries are accurately classified;
+- no repository-only test is represented as live verification;
+- all environment-specific work has a concrete P4-18E or Launch work owner;
+- no generic deferred bucket remains.
+
+P4-18D closure does not mean P4-18E is complete and does not authorize Phase 5 before the P4-18E handoff gate.
+
+## 7. Handoff
+
+After D5 is green and merged:
+
+1. mark P4-18D completed through #143–#147;
+2. move `docs/PROJECT_STATUS.md` current item to P4-18E;
+3. run P4-18E live review and Phase 5 handoff audit;
+4. verify or classify the P4-18E assigned checks above;
+5. keep Launch work assignments visible for launch preparation;
+6. move to P5-01 only after the P4-18E gate is explicitly completed.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # CryptoPayMap project status
 
-**Last verified:** 2026-07-08
+**Last verified:** 2026-07-09
 
 ## Current phase
 
@@ -8,7 +8,7 @@ Phase 4 — Public core / MVP-A closure
 
 ## Current implementation item
 
-P4-18D — Administration workflow integration audit
+P4-18E — Live review and Phase 5 handoff audit
 
 ## Current repository state
 
@@ -25,7 +25,8 @@ P4-18D — Administration workflow integration audit
 - P4-18B3 canonical persistence and public projection integration repository work is completed through #132 and #133, with closure tracking and B4 handoff through #134.
 - P4-18B4 existing-record practical-profile correction path is repository-complete through #135, #136, #137, and #138.
 - P4-18C bounded UI residual closure is completed through #139, #141, and #142, with direct final-artifact visual review recorded in `docs/P4_18_C_UI_AUDIT.md`.
-- P4-18D is active.
+- P4-18D administration workflow integration audit is repository-complete through D1 #143, D2 #144, D3 #145, D4 #146, and D5 closure inventory in the current handoff change.
+- P4-18E is the active handoff gate before Phase 5.
 
 ## Fixed review environment
 
@@ -37,11 +38,14 @@ The deployment receipt must be checked whenever review-environment state matters
 
 ## Required current references
 
-Before starting or reviewing P4-18 work, read:
+Before starting or reviewing P4-18E work, read:
 
 1. `docs/IMPLEMENTATION_PLAN.md`;
 2. `docs/PHASE4_CLOSURE_PLAN.md`;
-3. the public specification documents relevant to the active item.
+3. `docs/P4_18_D_ADMIN_INTEGRATION_AUDIT.md`;
+4. `docs/P4_18_D4_PUBLICATION_RESTORE_AUDIT.md`;
+5. `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md`;
+6. the public specification documents relevant to the live path under review.
 
 For practical Place profile work also read:
 
@@ -74,10 +78,10 @@ For Phase 5 preparation and submission work also read:
 4. P4-18B3 — canonical persistence and public projection integration — Completed through #132, #133, and #134
 5. P4-18B4 — existing-record practical-profile correction path audit and completion — Completed through #135, #136, #137, and #138
 6. P4-18C — bounded UI residual closure — Completed through #139, #141, and #142
-7. P4-18D — administration workflow integration audit — In progress
-8. P4-18E — live review and Phase 5 handoff audit — Planned
+7. P4-18D — administration workflow integration audit — Completed through #143, #144, #145, #146, and the D5 handoff change
+8. P4-18E — live review and Phase 5 handoff audit — In progress
 
-The authoritative scope and completion criteria are in `docs/PHASE4_CLOSURE_PLAN.md`.
+The authoritative scope and completion criteria are in `docs/PHASE4_CLOSURE_PLAN.md`. The environment-specific assignment matrix is in `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md`.
 
 ## P4-18B1 completed boundary
 
@@ -165,7 +169,7 @@ Repository coverage includes:
 - operator reachability, conflict, unavailable, and retry recovery coverage;
 - built artifact checks for the correction admin page and server-only marker leakage.
 
-Live migration application, Access allowlist configuration, representative live correction, live protected Audit appearance, and configured corrected-value release flow remain environment-specific P4-18D/E verification items. Repository tests do not prove those live conditions.
+Live migration application, Access allowlist configuration, representative live correction, live protected Audit appearance, and configured corrected-value release flow remain P4-18E verification items. Repository tests do not prove those live conditions.
 
 ## P4-18C completed boundary
 
@@ -180,9 +184,9 @@ P4-18C closed the fixed UI residual scope through C1, C2, and direct C3 final-ar
 
 Screenshot workflow success was not used as a substitute for image inspection. The closure record is `docs/P4_18_C_UI_AUDIT.md`.
 
-## P4-18D active scope
+## P4-18D completed boundary
 
-P4-18D audits real operator journeys and cross-workspace integration across:
+P4-18D closed the repository administration integration audit across:
 
 - Candidate queue and detail;
 - duplicate review and identity resolution;
@@ -196,7 +200,19 @@ P4-18D audits real operator journeys and cross-workspace integration across:
 - protected Audit history coverage;
 - conflict, retry, replay, rollback, and operator-reachability behavior.
 
-P4-18D must distinguish repository evidence from environment-specific verification. Every live-only check must be classified precisely as completed, unavailable, or assigned to P4-18E/launch work. Broad deferred-verification language is not sufficient.
+D1 through D4 resolved or classified repository findings. D5 assigns every remaining environment-dependent check to P4-18E or explicit Launch work. Publication activation and release history are explicit non-UI protected boundaries. Restore contracts and workflow exist in the repository, but production restore persistence, invocation, R2 adapter wiring, durable restore Audit source, reconciliation runbook, and drills remain explicit Launch work and are not described as production-operational.
+
+## P4-18E handoff
+
+P4-18E is the active gate. It must use `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md` and:
+
+- verify the fixed review deployment receipt against intended `main`;
+- verify or precisely mark unavailable the configured Access, allowlist, Functions environment, Neon migration, representative Admin path, candidate generation/upload/review, publication activation, release history, and Audit checks;
+- run staging artifact validation;
+- run representative screenshot capture and inspect the relevant images directly;
+- classify every unavailable environment check precisely;
+- keep Launch work assignments visible rather than treating them as repository-complete;
+- confirm Phase 5 prerequisites before moving to P5-01.
 
 ## Phase 5 handoff
 
@@ -215,17 +231,15 @@ Planned Phase 5 order:
 
 ## Next
 
-Execute P4-18D administration workflow integration audit. Do not move to P4-18E until operator journeys, cross-workspace boundaries, retry/conflict behavior, Audit coverage, and environment-specific check inventory are reconciled.
+Execute P4-18E live review and Phase 5 handoff audit. Do not move to P5-01 until the D5-assigned live-review checks are verified or precisely classified and the Phase 5 handoff gate is explicitly completed.
 
 ## Blocked
 
 No known repository blocker.
 
-P4-18D/E must verify or classify the environment-specific B4 checks recorded in `docs/P4_18_B4_AUDIT.md`.
+Phase 5 remains blocked on P4-18E completion.
 
-P4-18E must explicitly verify or classify the configured canonical query, full candidate generation, private candidate upload, and release-review handoff path recorded by the B3 audit. If that path is absent, it must be treated as an explicit launch blocker or assigned launch work rather than hidden by generic deferred-verification language.
-
-P4-18D and P4-18E must replace broad deferred-verification language with a precise inventory of environment-specific checks that were completed, could not be completed, or remain assigned to launch work.
+Production restore persistence, protected invocation, concrete R2 restore adapter wiring, durable restore Audit source, post-switch reconciliation runbook, and production restore drills remain explicit Launch work. They must not be represented as complete by repository tests.
 
 ## Verification rule
 


### PR DESCRIPTION
## Implementation item

`P4-18D5`

## Purpose

Close the P4-18D repository administration integration audit after D1–D4 and assign every remaining environment-dependent check precisely to P4-18E or explicit Launch work.

## Changes

- add `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md`;
- reconcile D1–D4 closure results;
- classify the full operator journey by repository result and remaining environment owner;
- assign configured review-environment checks to P4-18E;
- assign missing production restore persistence, invocation, R2 adapter wiring, durable restore Audit source, reconciliation runbook, and drills to Launch work;
- update `docs/PROJECT_STATUS.md` to P4-18E;
- update `docs/IMPLEMENTATION_PLAN.md` to close P4-18D and activate P4-18E;
- record PR #23 as a superseded historical Phase 1 draft rather than an open live gate.

## Closure rule

P4-18D closure means repository findings are resolved or explicitly assigned. It does not mean live verification is complete and does not permit P5-01 before P4-18E completes the handoff gate.

## Out of scope

- executing live Access/Neon/R2 checks;
- implementing production restore capability;
- P4-18E live review results;
- Phase 5 implementation.
