### PR TITLE
P4-18E: close live review and Phase 5 handoff audit

### DIFF
--- a/docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md
+++ b/docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md
@@ -1,0 +1,195 @@
+# P4-18E live review and Phase 5 handoff audit
+
+**Implementation item:** P4-18E  
+**Status:** Active  
+**Last updated:** 2026-07-09
+
+## Purpose
+
+P4-18E closes the Phase 4 handoff gate by reconciling repository validation, the fixed review deployment receipt, staging artifacts, representative visual review, configured-environment availability, and the explicit Launch work inventory.
+
+This audit does not treat an unavailable live check as success and does not treat repository CI as live Cloudflare Access, Neon, or R2 verification.
+
+## 1. Handoff result summary
+
+| Check | Result | Evidence or assignment |
+|---|---|---|
+| Intended `main` commit | Verified | `667b2687e2e70be34f5e7ae955e9c4ffd4eba7f2`, P4-18D5 #147 |
+| Fixed review deployment receipt | Verified | receipt status `deployed`, commit exactly matches intended `main`, fixed review URL recorded |
+| Staging review artifact validation | Verified repository artifact | latest relevant public/runtime change validation completed successfully |
+| Representative screenshot capture | Verified | latest relevant capture workflow completed successfully |
+| Direct screenshot inspection | Verified | representative desktop/mobile and interactive-state images directly inspected; no material blocking defect found |
+| Public UI changes after inspected artifact | None | D4/D5 changes after the inspected artifact affect docs and bounded regression coverage, not `src/**` or `public/**` |
+| Public projection/leakage repository checks | Verified repository boundary | Foundation validation and staging validation green on the reviewed implementation line |
+| Live fixed-URL HTTP response from this audit environment | Unavailable | direct external HTTP retrieval could not be performed from this audit environment; deployment receipt is not substituted for this check |
+| Live Cloudflare Access policy behavior | Unavailable | assigned to Launch work/configured-environment verification |
+| Actual subject and actor-ID allowlist values | Unavailable | assigned to Launch work/configured-environment verification |
+| Deployed Functions environment propagation | Unavailable | assigned to Launch work/configured-environment verification |
+| Live Access identity claim values | Unavailable | assigned to Launch work/configured-environment verification |
+| Live Neon migration application | Unavailable | assigned to Launch work/configured-environment verification; repository Migration drift remains green |
+| Representative live Candidate/Admin data journey | Unavailable | assigned to Launch work/configured-environment verification |
+| Live Location correction and Audit appearance | Unavailable | assigned to Launch work/configured-environment verification |
+| Live Evidence confirmation against current payment prerequisites | Unavailable | assigned to Launch work/configured-environment verification |
+| Live Reconfirmation protected path | Unavailable | assigned to Launch work/configured-environment verification |
+| Canonical query → complete candidate generation → private upload → release review | Unavailable | assigned to Launch work and remains a launch blocker if absent at cutover |
+| Review-environment publication activation | Unavailable | assigned to Launch work/configured-environment verification |
+| Live release-history and export Audit appearance | Unavailable | assigned to Launch work/configured-environment verification |
+| Corrected canonical value → candidate → release → activation chain | Unavailable | assigned to Launch work and must be verified before launch readiness |
+| Production restore persistence/invocation/R2 wiring/Audit source/drills | Not implemented as production capability | explicit Launch work from P4-18D4/D5; not a P5-01 start blocker, but required before launch readiness |
+
+## 2. Deployment receipt verification
+
+The fixed review deployment workflow records deployment status, deployed commit, URL, and generation time, publishes the receipt to the `staging-review` branch, and fails the deployment workflow when credentials or deployment fail.
+
+The current receipt records:
+
+```text
+status: deployed
+commit: 667b2687e2e70be34f5e7ae955e9c4ffd4eba7f2
+url: https://review.cryptopaymap-staging.pages.dev
+generatedAt: 2026-07-09T11:07:48.167Z
+```
+
+The receipt commit exactly matches the P4-18D5 merge commit used as the P4-18E audit baseline.
+
+D5 and later handoff-only changes do not weaken the deployment receipt rule: repository merge state and deployed receipt state must continue to be compared explicitly whenever review-environment state matters.
+
+## 3. Staging artifact and repository validation
+
+The latest relevant staging review line before D4/D5 handoff-only changes completed:
+
+- Staging review validation — success;
+- Migration drift — success;
+- Foundation validation — success;
+- representative screenshot capture — success.
+
+P4-18D4 and D5 subsequently changed only audit/status/implementation documentation and bounded D4 regression coverage. The compare boundary from the inspected implementation baseline through the D5 handoff contains no `src/**` or `public/**` change.
+
+Therefore the inspected staging and visual artifacts remain representative of the public UI state at P4-18E handoff.
+
+## 4. Direct visual review result
+
+The screenshot artifact was directly inspected rather than accepted merely because capture completed.
+
+Representative checks included:
+
+### Desktop
+
+- Home;
+- Places with selected Place panel;
+- selected map/Place containment.
+
+### Mobile
+
+- Places List;
+- bounded Menu open state;
+- Filters open state and completion action;
+- expanded Place sheet;
+- long-form Methodology output;
+- Gallery lightbox.
+
+### Findings
+
+No material Phase 5 handoff blocker was found in the inspected set:
+
+- no material horizontal overflow was visible;
+- no primary interaction was materially hidden;
+- the desktop selected Place panel remained contained in the intended layout;
+- mobile List remained scanable with payment/freshness information present;
+- mobile Menu used a bounded navigation panel rather than a sparse full-height drawer;
+- mobile Filters exposed an explicit completion action and result count;
+- expanded mobile Place information presented Location/Navigate and payment-critical information before long practical-profile content;
+- Methodology long-form content showed no material layout break;
+- Gallery lightbox controls and caption remained reachable.
+
+This visual result applies to the captured public UI state. It does not prove live Access, database, or R2 behavior.
+
+## 5. Practical profile handoff result
+
+P4-18B repository paths satisfy the Phase 5 prerequisite that practical Place data can be reviewed, provenance-assigned, written atomically, corrected through a separate guarded operation, projected through an allowlisted public boundary, and consumed by public Place surfaces.
+
+P4-18E does not have access to a configured live environment that can prove the complete new-target or correction flow end to end. Those live checks remain explicit Launch work/configured-environment verification.
+
+This absence does not reopen P4-18B or block P5-01 because Phase 5 implementation can proceed on the reviewed repository contracts. It does prevent launch readiness from being claimed until configured-environment validation is complete.
+
+## 6. Administration handoff result
+
+P4-18D completed the repository administration journey audit through D1–D5:
+
+- route reachability and accurate capability copy;
+- subject versus actor-ID policy mapping;
+- protected UI/API compatibility and idempotency boundaries;
+- guard, replay, conflict, retry, and failure-state reconciliation;
+- exact Evidence confirmation payment-set and payment-prerequisite guards;
+- release decision versus publication capability separation;
+- non-UI classification of publication activation and release history;
+- accurate repository-only classification of restore contracts;
+- explicit environment and Launch work ownership.
+
+P4-18E could not execute configured live Admin mutations because the required live identity, allowlist values, environment bindings, database state, and representative review data are not available to this audit environment.
+
+These checks are recorded as unavailable rather than passed.
+
+## 7. Launch work retained after Phase 4
+
+The following remain explicit Launch work and must not disappear when Phase 5 begins:
+
+### Configured-environment verification
+
+- fixed review/production URL direct HTTP validation from an environment allowed to reach the URL;
+- Cloudflare Access route protection and identity claims;
+- actual subject and actor-ID allowlist values;
+- deployed Functions environment propagation;
+- live Neon migration state;
+- representative protected Candidate, Location correction, Evidence, Reconfirmation, Media, release, history, and Audit journeys;
+- configured canonical query → twelve-artifact generation → private upload → release-review handoff;
+- corrected canonical value → generation → release → activation flow;
+- concrete R2 publication conditional-write behavior.
+
+### Production restore capability
+
+- durable production restore execution persistence;
+- concrete production restore backend;
+- concrete R2 pointer inspection and conditional replacement adapter;
+- protected restore invocation boundary using `export:publish` and idempotency identity;
+- durable restore execution Audit source;
+- post-switch persistence reconciliation procedure and runbook;
+- production restore drill and replay verification.
+
+Starting Phase 5 does not waive any Launch work item.
+
+## 8. Phase 5 prerequisite decision
+
+The P4-18E handoff gate may close when this audit is green because:
+
+1. P4-18B practical profile repository parity is complete;
+2. P4-18C bounded UI residual closure is complete;
+3. P4-18D repository administration integration findings are resolved or explicitly assigned;
+4. the fixed review deployment receipt matches the intended handoff `main` commit;
+5. staging validation and representative screenshot capture are successful;
+6. relevant images were inspected directly;
+7. no material visual Phase 5 blocker was found;
+8. every unavailable environment check is explicitly recorded;
+9. production restore gaps remain visible Launch work rather than hidden repository completion;
+10. there is no known repository blocker to P5-01.
+
+## 9. Closure decision
+
+After this audit and tracking update merge green:
+
+- Phase 4 P4-18 closure is complete for Phase 5 handoff purposes;
+- P4-18E is completed;
+- Phase 5 may begin at P5-01 Shared submission foundation;
+- launch readiness is **not** claimed;
+- configured-environment and production restore Launch work remain mandatory before production launch criteria can be claimed.
+
+## Next
+
+Move repository tracking to:
+
+```text
+Phase 5 — Public submissions / MVP-B
+P5-01 — Shared submission foundation
+```
+
+P5-01 must establish common submission envelope, opaque public reference, private follow-up secret handling, workflow state, contact privacy boundary, abuse controls, safe parsing, idempotency, and audit foundation before individual public submission forms are implemented.


### PR DESCRIPTION
## Implementation item

`P4-18E`

## Purpose

Close the Phase 4 live-review and Phase 5 handoff audit without converting unavailable configured-environment checks into false passes.

## Verified

- fixed review deployment receipt records `deployed` and matches the intended P4-18D5 main commit;
- latest relevant staging review validation succeeded;
- latest relevant Foundation validation and Migration drift succeeded;
- representative screenshot capture succeeded;
- representative desktop/mobile and interactive-state images were directly inspected;
- no material visual Phase 5 handoff blocker was found;
- no `src/**` or `public/**` change occurred after the inspected public UI artifact through the D5 handoff baseline.

## Precisely unavailable in this audit environment

- direct external HTTP response verification of the fixed review URL;
- live Cloudflare Access policy and identity claims;
- actual allowlist values and deployed Functions environment propagation;
- live Neon migration application;
- representative live protected Admin mutations and Audit appearance;
- configured canonical query → twelve-artifact candidate generation → private upload → release-review handoff;
- live review-environment publication activation and release-history checks;
- corrected canonical value → generation → release → activation chain.

These checks remain explicit configured-environment/Launch work. Production restore persistence, invocation, R2 wiring, durable restore Audit source, reconciliation runbook, and drills remain explicit Launch work and are not mislabeled as repository-complete.

## Change

- add `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md` with evidence, unavailable checks, Launch work inventory, direct visual findings, Phase 5 prerequisite decision, and closure rule.

## Handoff

After this audit is green and merged, a separate tracking handoff change will move `PROJECT_STATUS` and `IMPLEMENTATION_PLAN` from P4-18E to P5-01.
