### PR TITLE
Tracking: move CryptoPayMap to Phase 5 P5-01

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -9,221 +9,139 @@ This file tracks repository implementation work. GitHub `main`, merged pull requ
 
 - Implementation item IDs are independent of pull request numbers.
 - Candidate, canonical, and public-export layers remain separate.
+- Public intake never mutates canonical or public data directly.
 - Each pull request has one primary responsibility and explicit completion checks.
-- Live environment verification may be deferred only when the exact deferred check is recorded.
+- Live environment verification may be deferred only when the exact check and owner are recorded.
 - Public product Roadmap and repository implementation status are separate documents.
-- Phase 4 closure work must read `docs/PHASE4_CLOSURE_PLAN.md`.
-- Places work must read `docs/PLACES_UX_ACCEPTANCE.md`, `docs/PLACES_RECOVERY_PLAN.md`, and `docs/PLACES_UX_FINAL_AUDIT.md` before implementation or review.
-- Practical Place profile work must also read `docs/PLACE_PUBLIC_PROFILE.md`, `docs/PRACTICAL_PROFILE_DATA_MODEL_EXTENSION.md`, `docs/P4_18_B3_AUDIT.md`, and `docs/P4_18_B4_AUDIT.md`.
-- A narrow pull-request description does not supersede the complete Places acceptance or active closure contract.
-- Phase 5 implementation does not begin before the P4-18E handoff gate is complete.
+- Phase 5 work must read `docs/PHASE5_IMPLEMENTATION_SEQUENCE.md`, `docs/SUBMISSION_WORKFLOW.md`, `docs/DATA_MODEL.md`, and `docs/SECURITY_AND_PRIVACY.md`.
+- Media intake work must also read `docs/MEDIA_POLICY.md`.
+- Phase 4 handoff evidence and retained Launch work are governed by `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
 
 ## Phase 0 — Public specifications and development control
 
 **Status:** Completed
 
-| ID | Item | Pull request |
-|---|---|---|
-| P0-01 | Development control | #1 |
-| P0-02 | Product constitution | #3 |
-| P0-03 | Information architecture | #4 |
-| P0-04 | Data architecture | #5 |
-| P0-05 | Verification, sources, and licenses | #6 |
-| P0-06 | Submission and media policies | #7 |
-| P0-07 | Technical, UX, security, and privacy architecture | #8 |
-| P0-08 | Operations, migration, launch, and public roadmap | #9 |
+P0-01 through P0-08 established repository control, product constitution, information architecture, data architecture, verification/source/license rules, submission and Media policy, technical/security/privacy architecture, operations, migration, launch criteria, and public Roadmap boundaries.
+
+Completed through #1–#9.
 
 ## Phase 1 — Foundation
 
-**Status:** Repository work completed; remaining live checks are tracked by later integration and launch items
+**Status:** Repository completed
 
-| ID | Item | Status | Pull request |
-|---|---|---|---|
-| P1-01 | Repository and application foundation | Completed | #11 |
-| P1-02 | Design tokens and responsive application shell | Completed | #12 |
-| P1-03 | Reusable UI primitives and interaction states | Completed | #13 |
-| P1-04 | Motion and reduced-motion behavior | Completed | #14 |
-| P1-05 | Query, UI, and URL-state boundaries | Completed | #15 |
-| P1-06 | Runtime schemas and migration foundation | Completed | #16 |
-| P1-07 | CI and test foundation | Completed | #17 |
-| P1-08 | Cloudflare staging contract | Completed | #18 |
-| P1-09 | PWA manifest and installability baseline | Completed | #19 |
-| P1-10 | Accessibility baseline | Completed | #20 |
-| P1-11 | Public Roadmap and Changelog loaders | Completed | #21 |
-| P1-12 | Integration and quality audit | Repository completed; old live-check draft superseded | #22; #23 closed superseded |
+P1-01 through P1-12 established:
+
+- application foundation and responsive shell;
+- design tokens and reusable interaction primitives;
+- motion and reduced-motion behavior;
+- query/UI/URL state boundaries;
+- runtime schema and migration foundation;
+- CI and test foundation;
+- Cloudflare staging contract;
+- PWA and accessibility baselines;
+- public Roadmap and Changelog loaders;
+- integration and quality audit.
+
+Completed through #11–#23. The historical #23 live-check draft was closed as superseded after later fixed review deployment and deployment-receipt work.
 
 ## Phase 2 — Data core
 
 **Status:** Completed
 
-| ID | Item | Pull request |
-|---|---|---|
-| P2-01 / P2-02 | Asset and network registries | #24 |
-| P2-03 | Payment method and route registries | #25 |
-| P2-04 | Entity and location schema | #26 |
-| P2-05 | Acceptance claim schema and status rules | #29 |
-| P2-06 | Claim asset and network combinations | #30 |
-| P2-07 | Evidence schema and source capture | #31 |
-| P2-08 | Verification event history | #32 |
-| P2-09 | Source candidates, provenance, and duplicate boundaries | #34 |
-| P2-10 | Media metadata and legacy identifiers | #35, #37 |
-| P2-11 | Public export schemas | #36 |
-| P2-12 | Export allowlist and leakage validator | #38 |
-| P2-13 | Physical-place candidate importer | #39 |
-| P2-14 | Online-service importer and Phase 2 audit | #40 |
+P2-01 through P2-14 established:
 
-Phase 2 keeps imported records private, preserves source and license provenance, produces no automatic Confirmed records, and only allows reviewed eligible data into validated public artifacts.
+- Asset, Network, Payment Method, and Route registries;
+- Entity and Location schema;
+- Acceptance Claim status rules;
+- Claim Asset/Network/Method combinations;
+- Evidence and Source capture;
+- Verification Event history;
+- Candidate, provenance, and duplicate boundaries;
+- Media metadata and legacy identifiers;
+- public export schemas;
+- public allowlist and leakage validation;
+- physical Place and Online Service private importers;
+- Phase 2 integration audit.
+
+Completed through #24–#40.
+
+Imported records remain private until reviewed. Candidate data is not public truth and does not automatically create Confirmed Claims.
 
 ## Phase 3 — Administration and review
 
-**Status:** Repository completed; P4-18E will reconcile remaining configured-environment checks before Phase 5 handoff
+**Status:** Repository completed and reconciled by P4-18D
 
-| ID | Item | Status | Depends on | Pull request |
-|---|---|---|---|---|
-| P3-01 | Admin data-access and transaction foundation | Completed | Phase 2 | #41 |
-| P3-02 | Protected admin shell and access contract | Completed | P3-01 | #42 |
-| P3-03 | Dashboard and operational queue summaries | Completed | P3-01, P3-02 | #43 |
-| P3-04 | Candidate queue | Completed | P3-01, P3-02 | #44 |
-| P3-05 | Candidate detail and provenance review | Completed | P3-04 | #45 |
-| P3-06 | Duplicate review and identity resolution | Completed | P3-05 | #46, #47 |
-| P3-07 | Claim editor and canonical promotion | Completed | P3-05, P3-06 | #48, #49, #51–#58 |
-| P3-08 | Evidence review and verification decisions | Completed | P3-07 | #59, #60, #62, #63 |
-| P3-09 | Status transitions and reconfirmation queue | Completed | P3-07, P3-08 | #64–#67 |
-| P3-10 | Media review | Completed | P3-02, P2-10 | #69–#74 |
-| P3-11 | Export controls and release workflow | Repository completed | P3-07 through P3-10 | #75–#87 |
-| P3-12 | Audit history and Phase 3 integration audit | Completed | P3-01 through P3-11 | #88, #89, #92–#95 |
+P3-01 through P3-12 established:
 
-Phase 3 established protected Candidate review, duplicate resolution, new-target promotion, existing-target linking, field-level provenance, Evidence decisions, Claim transitions, reconfirmation queues, Media review, export release decisions, publication activation, release history, restore boundaries, and cross-domain Audit history.
+- Admin data-access and transaction foundation;
+- protected Admin shell and Access contract;
+- dashboard and queue summaries;
+- Candidate queue, detail, provenance, duplicate review, and identity resolution;
+- new-target Promotion and existing-target linking;
+- Evidence review and verification decisions;
+- status transitions and Reconfirmation;
+- Media review;
+- export release decision, publication activation, release history, and restore repository boundaries;
+- cross-domain protected Audit history.
 
-Repository-complete components have been reconciled by P4-18D. P4-18E owns the configured-environment handoff checks. Repository tests must not be described as live environment verification.
+Completed through #41–#95.
 
-## Phase 4 — Public core / MVP-A and closure
+P4-18D later reconciled route reachability, Access identity mapping, UI/API compatibility, guard/replay/conflict/retry behavior, publication capability separation, and repository-versus-production restore classification.
 
-**Status:** MVP-A public surfaces are merged; P4-18E live review and Phase 5 handoff is active
+## Phase 4 — Public core / MVP-A closure
 
-| ID | Item | Status | Depends on | Pull request |
-|---|---|---|---|---|
-| P4-01 | Place detail | Completed | Phase 3 | #96 |
-| P4-02 | PlacesApp shell | Completed | P4-01 | #97 |
-| P4-03 | MapLibre map | Completed | P4-02 | #98, #100 |
-| P4-04 | Result list | Completed | P4-02 | #101 |
-| P4-05 | Pin and list synchronization | Completed | P4-03, P4-04 | #102 |
-| P4-06 | Filters and bounded result updates | Completed | P4-02 | #103, #104 |
-| P4-07 | URL state and back restoration | Completed | P4-05, P4-06 | #105 |
-| P4-08 | Mobile bottom sheet | Completed; recovery completed by P4-17D/F | P4-05 | #106, #122 |
-| P4-09 | Online Services discovery and detail | Completed | public data layer | #107 |
-| P4-10 | Home | Completed | public discovery surfaces | #108 |
-| P4-11 | Stats | Completed | public stats export | #109 |
-| P4-12 | Updates | Completed | public updates export | #115 |
-| P4-13 | Public Roadmap and Changelog release surfaces | Completed | content loaders | #116 |
-| P4-14 | Trust, data, legal, and sustainability pages | Completed | public specifications | #117, #118 |
-| P4-15 | Public media integration | Completed; selected-surface recovery completed by P4-17E/F | P3-10, P4-01 | #119, #122 |
-| P4-16 | MVP-A integration and quality audit | Completed | P4-01 through P4-15 | #120, #121, #122 |
-| P4-17A | Places contract and tracking correction | Completed | P4-16 findings | #122 |
-| P4-17B | Map presentation foundation recovery | Completed | P4-17A | #122 |
-| P4-17C | Place information and public projection recovery | Completed | P4-17A | #122 |
-| P4-17D | Desktop selected panel and mobile sheet recovery | Completed | P4-17B, P4-17C | #122 |
-| P4-17E | Gallery, image enlargement, and external navigation | Completed | P4-17C, P4-17D | #122 |
-| P4-17F | State, responsive, accessibility, and final 17-point acceptance audit | Completed | P4-17B through P4-17E | #122 |
-| P4-18A | Tracking correction and closure inventory | Completed | P4-17, closure findings | #127 |
-| P4-18B1 | Source and Candidate practical-profile contract | Completed | P4-18A | #128 |
-| P4-18B2 | Promotion editor and field provenance parity | Completed | P4-18B1 | #130 |
-| P4-18B3 | Canonical persistence and public projection integration | Completed | P4-18B2 | #132, #133, #134 |
-| P4-18B4 | Existing-record practical-profile correction path audit and completion | Completed | P4-18B3 | #135, #136, #137, #138 |
-| P4-18C | Bounded UI residual closure | Completed | P4-18A, representative screenshot capture | #139, #141, #142 |
-| P4-18D | Administration workflow integration audit | Completed | P4-18B | #143–#147 |
-| P4-18E | Live review and Phase 5 handoff audit | In progress | P4-18B, P4-18C, P4-18D | — |
+**Status:** Completed for Phase 5 handoff
 
-### P4-17 Places recovery result
+### Public core
 
-P4-17 fixed the 17-point recovery set documented in:
+P4-01 through P4-16 implemented:
 
-- `docs/PLACES_UX_ACCEPTANCE.md`;
-- `docs/PLACES_RECOVERY_PLAN.md`;
-- `docs/PLACES_UX_FINAL_AUDIT.md`.
+- Place detail;
+- PlacesApp shell;
+- MapLibre map;
+- result list and map/list synchronization;
+- filters and bounded result updates;
+- URL state and back restoration;
+- mobile bottom sheet;
+- Online Services discovery and detail;
+- Home;
+- Stats;
+- Updates;
+- public Roadmap and Changelog surfaces;
+- trust, data, legal, and sustainability pages;
+- public Media integration;
+- MVP-A integration and quality audit.
 
-P4-17A through P4-17F are implemented, validated, and merged through #122. The final audit matrix remains the durable interaction boundary for future Places changes.
+Completed through #96–#122.
 
-### P4-18 closure groundwork already merged
+### P4-17 Places recovery
 
-- #123 — review deployment follows `main` and updates the fixed review URL;
-- #124 — observable deployment receipt records the deployed `main` commit;
-- #125 — representative desktop/mobile screenshot capture, interactive-state capture, legacy Place field parity baseline, and practical profile staging fixture coverage;
-- #126 — selected Place focus and marker correction plus desktop selected-panel containment.
+**Status:** Completed through #122
 
-These changes improve observability and baseline UI behavior. They do not complete the P4-18E handoff.
+P4-17A through P4-17F reconciled the durable Places UX acceptance boundary, including map presentation, Place information, public projection, selected desktop panel, mobile sheet, Gallery/lightbox, external navigation, responsive behavior, accessibility, and final 17-point acceptance.
 
-### P4-18B3 repository result
+### P4-18 Phase 4 closure
 
-P4-18B3 repository work is completed through #132 and #133, with closure reconciliation and B4 handoff through #134. It covers practical-profile canonical persistence, rollback, replay/conflict behavior, field provenance expansion, explicit allowlisted public Place projection, strict validation, leakage and absence semantics, public Place provenance aggregation, Promotion-to-public projection integration coverage, canonical Place detail presentation, selected desktop/mobile consumption, and staging artifact assertions.
+| ID | Item | Status | Pull request |
+|---|---|---|---|
+| P4-18A | Tracking correction and closure inventory | Completed | #127 |
+| P4-18B1 | Source and Candidate practical-profile contract | Completed | #128 |
+| P4-18B2 | Promotion editor and field provenance parity | Completed | #130 |
+| P4-18B3 | Canonical persistence and public projection integration | Completed | #132–#134 |
+| P4-18B4 | Existing-record practical-profile correction path | Completed | #135–#138 |
+| P4-18C | Bounded UI residual closure | Completed | #139, #141, #142 |
+| P4-18D | Administration workflow integration audit | Completed | #143–#147 |
+| P4-18E | Live review and Phase 5 handoff audit | Completed | #148 |
 
-The configured canonical query → complete twelve-artifact candidate generation → private candidate upload → release-review handoff remains an environment-specific verification path. P4-18E must verify it or record an explicit blocker or launch assignment. Repository tests do not prove that live path.
-
-### P4-18B4 repository result
-
-P4-18B4 repository work is completed through #135–#138. It establishes bounded existing-Location correction semantics, exact correction provenance, replay/conflict/rollback behavior, durable decision and diff history, atomic Drizzle persistence, protected operator workspace and API, separate existing-target navigation, and protected Audit history normalization.
-
-Environment-specific migration application, Access allowlist configuration, representative live correction, live Audit appearance, and corrected-value release flow remain assigned to P4-18E. Repository tests do not prove those live conditions.
-
-### P4-18C repository and visual result
-
-P4-18C is completed through #139, #141, and #142.
-
-The bounded closure covers:
-
-- compact Mobile Places List cards with payment/freshness information retained;
-- bounded Mobile Menu density with focus, Escape, overlay, body-scroll, and active-page behavior preserved;
-- payment-first information ordering in the expanded mobile Place sheet;
-- explicit Mobile Filters completion with live result count while retaining Clear and zero-result recovery paths;
-- direct final-artifact inspection across List, Menu, expanded sheet, Filters, and representative Methodology long-form output.
-
-No material horizontal overflow, hidden primary interaction, or unresolved density defect remained in the fixed five-item scope. Screenshot capture success was not used as a substitute for image inspection. The durable closure record is `docs/P4_18_C_UI_AUDIT.md`.
-
-### P4-18D repository result
-
-P4-18D is completed through D1 #143, D2 #144, D3 #145, D4 #146, and D5 #147.
-
-The audit established:
-
-- coherent operator route reachability and accurate capability copy;
-- explicit raw Access subject versus normalized actor-ID authorization mapping;
-- reachable mutation UI idempotency coverage;
-- exact Evidence confirmation payment-set and prerequisite guards;
-- Reconfirmation connectivity failure recovery;
-- release decision versus publication capability separation;
-- explicit non-UI classification for publication activation and release history;
-- accurate repository-only classification for restore contracts and workflow;
-- explicit Launch work ownership for production restore persistence, invocation, R2 wiring, durable restore Audit source, reconciliation runbook, and drills;
-- precise P4-18E ownership for configured-environment verification.
-
-The closure inventory is `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md`.
-
-### P4-18 execution order
-
-The authoritative closure details and completion criteria are in `docs/PHASE4_CLOSURE_PLAN.md`.
-
-Execution order:
-
-1. P4-18A — tracking correction and closure inventory;
-2. P4-18B1 — source and Candidate practical-profile contract;
-3. P4-18B2 — promotion editor and field provenance parity;
-4. P4-18B3 — canonical persistence and public projection integration;
-5. P4-18B4 — existing-record correction path audit and completion;
-6. P4-18C — bounded UI residual closure;
-7. P4-18D — administration workflow integration audit;
-8. P4-18E — live review and Phase 5 handoff audit.
-
-P4-18 is a bounded closure term. P4-18B is a prerequisite for public submission work because external corrections must not arrive before the operator can safely review, provenance, apply, and publish the same field classes.
-
-P4-18D repository work is complete. P4-18E is active and must verify or precisely classify the configured-environment checks assigned by D5 before the project may move to P5-01.
+P4-18E closed the Phase 5 handoff gate while preserving unavailable configured-environment checks and production restore completion as explicit Launch work. Phase 5 may proceed; launch readiness is not claimed.
 
 ## Phase 5 — Public submissions / MVP-B
 
-**Status:** Planned; blocked on P4-18E handoff
+**Status:** Active
 
 | ID | Item | Status | Depends on |
 |---|---|---|---|
-| P5-01 | Shared submission foundation | Planned | P4-18E |
+| P5-01 | Shared submission foundation | In progress | P4-18E |
 | P5-02 | Suggest Place and Online Service | Planned | P5-01 |
 | P5-03 | Payment and problem reports | Planned | P5-01, P5-02 target conventions |
 | P5-04 | Business and service claims | Planned | P5-01, practical-profile correction path |
@@ -234,7 +152,52 @@ P4-18D repository work is complete. P4-18E is active and must verify or precisel
 
 ### P5-01 — Shared submission foundation
 
-Provide the common submission envelope, opaque public reference, private follow-up secret handling, workflow status, contact privacy boundary, abuse controls, safe parsing, idempotency, and audit foundation used by later submission types.
+P5-01 establishes common private submission infrastructure before individual public forms exist.
+
+Required work:
+
+1. define the common submission envelope and stable identifiers;
+2. define opaque public reference behavior that reveals no private submission payload;
+3. define private follow-up secret generation, storage representation, and verification boundary;
+4. implement submission workflow status and allowed transitions needed by later intake types;
+5. implement contact privacy boundaries and non-public defaults;
+6. implement strict runtime parsing, payload limits, normalization, and fail-closed rejection;
+7. define abuse-control and Turnstile verification boundary without coupling domain logic to one provider response shape;
+8. implement idempotent intake semantics and changed-content conflict behavior;
+9. establish durable private submission persistence and metadata-only audit foundation;
+10. prove that intake cannot directly mutate Candidate, canonical, Evidence, Media review, verification, export, or public artifacts;
+11. add focused schema, persistence, idempotency, privacy, and integration coverage;
+12. document exactly which live environment checks remain for later configured-environment verification.
+
+P5-01 should be divided into bounded slices rather than one large pull request.
+
+Recommended slice order:
+
+```text
+P5-01A — submission contract and privacy model
+    ↓
+P5-01B — persistence and workflow-state foundation
+    ↓
+P5-01C — idempotent private intake service
+    ↓
+P5-01D — abuse-control / Turnstile boundary
+    ↓
+P5-01E — audit integration and Phase 5 foundation audit
+```
+
+P5-01 completion criteria:
+
+- one shared submission contract can support later suggestion, report, claim, and Media intake families;
+- all new submissions remain private by default;
+- public reference and follow-up secret boundaries reveal no contact or payload data;
+- identical retries are deterministic;
+- reused idempotency identity with changed content fails conflict;
+- contact data never enters public exports or metadata-only Audit output;
+- abuse-control failure cannot create a durable accepted intake;
+- intake cannot directly mutate canonical/public state;
+- migration and schema checks are green;
+- focused unit/integration tests and full repository validation are green;
+- no later submission type is implemented prematurely inside the foundation item.
 
 ### P5-02 — Suggest Place and Online Service
 
@@ -258,7 +221,7 @@ Add reviewer diffs, information requests, time-bounded holds, partial approval, 
 
 ### P5-07 — Canonical application transactions and retention
 
-Apply approved field decisions through explicit guarded canonical transactions, preserve correction provenance and audit history, run normal export/publication validation, and enforce private submission retention and deletion rules.
+Apply approved field decisions through explicit guarded canonical transactions, preserve correction provenance and Audit history, run normal export/publication validation, and enforce private submission retention and deletion rules.
 
 ### P5-08 — MVP-B integration audit
 
@@ -268,10 +231,38 @@ Verify each submission type from public intake through private status, protected
 
 **Status:** Planned
 
-Data, license, privacy, mobile, accessibility, performance, security, redirect, sitemap, migration, backup, monitoring, and rollback checks before production cutover.
+Required areas include:
+
+- data and source/license validation;
+- privacy and retention checks;
+- mobile, accessibility, and performance validation;
+- security review;
+- redirects and sitemap;
+- migration state;
+- backup and monitoring;
+- publication and rollback drills;
+- retained configured-environment checks;
+- production restore completion and drill.
+
+Phase 6 must not claim launch readiness until retained P4-18D/E Launch work is complete or explicitly resolved by a later approved decision.
 
 ## Phase 7 — Stabilization
 
 **Status:** Planned
 
 Verify production errors, redirects, indexing, submissions, exports, mobile behavior, and migration completeness before retiring the legacy implementation.
+
+## Retained Launch work
+
+Starting Phase 5 does not waive:
+
+- live Cloudflare Access and identity verification;
+- actual allowlist and deployed Functions environment verification;
+- live Neon migration-state verification;
+- configured protected Admin journeys with representative data;
+- canonical query → complete candidate generation → private upload → release-review handoff;
+- corrected canonical value → generation → release → activation flow;
+- concrete R2 publication conditional-write verification;
+- production restore persistence, protected invocation, R2 adapter wiring, durable restore Audit source, post-switch reconciliation runbook, and production restore/replay drills.
+
+The durable handoff record is `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.

--- a/docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md
+++ b/docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md
@@ -1,7 +1,7 @@
 # P4-18E live review and Phase 5 handoff audit
 
 **Implementation item:** P4-18E  
-**Status:** Active  
+**Status:** Completed through #148  
 **Last updated:** 2026-07-09
 
 ## Purpose
@@ -41,7 +41,7 @@ This audit does not treat an unavailable live check as success and does not trea
 
 The fixed review deployment workflow records deployment status, deployed commit, URL, and generation time, publishes the receipt to the `staging-review` branch, and fails the deployment workflow when credentials or deployment fail.
 
-The current receipt records:
+The audited receipt records:
 
 ```text
 status: deployed
@@ -52,7 +52,7 @@ generatedAt: 2026-07-09T11:07:48.167Z
 
 The receipt commit exactly matches the P4-18D5 merge commit used as the P4-18E audit baseline.
 
-D5 and later handoff-only changes do not weaken the deployment receipt rule: repository merge state and deployed receipt state must continue to be compared explicitly whenever review-environment state matters.
+Later handoff-only changes do not weaken the deployment receipt rule: repository merge state and deployed receipt state must continue to be compared explicitly whenever review-environment state matters.
 
 ## 3. Staging artifact and repository validation
 
@@ -108,7 +108,7 @@ This visual result applies to the captured public UI state. It does not prove li
 
 P4-18B repository paths satisfy the Phase 5 prerequisite that practical Place data can be reviewed, provenance-assigned, written atomically, corrected through a separate guarded operation, projected through an allowlisted public boundary, and consumed by public Place surfaces.
 
-P4-18E does not have access to a configured live environment that can prove the complete new-target or correction flow end to end. Those live checks remain explicit Launch work/configured-environment verification.
+P4-18E did not have access to a configured live environment that could prove the complete new-target or correction flow end to end. Those live checks remain explicit Launch work/configured-environment verification.
 
 This absence does not reopen P4-18B or block P5-01 because Phase 5 implementation can proceed on the reviewed repository contracts. It does prevent launch readiness from being claimed until configured-environment validation is complete.
 
@@ -126,7 +126,7 @@ P4-18D completed the repository administration journey audit through D1–D5:
 - accurate repository-only classification of restore contracts;
 - explicit environment and Launch work ownership.
 
-P4-18E could not execute configured live Admin mutations because the required live identity, allowlist values, environment bindings, database state, and representative review data are not available to this audit environment.
+P4-18E could not execute configured live Admin mutations because the required live identity, allowlist values, environment bindings, database state, and representative review data were not available to this audit environment.
 
 These checks are recorded as unavailable rather than passed.
 
@@ -160,36 +160,40 @@ Starting Phase 5 does not waive any Launch work item.
 
 ## 8. Phase 5 prerequisite decision
 
-The P4-18E handoff gate may close when this audit is green because:
+The P4-18E handoff gate is closed because:
 
 1. P4-18B practical profile repository parity is complete;
 2. P4-18C bounded UI residual closure is complete;
 3. P4-18D repository administration integration findings are resolved or explicitly assigned;
-4. the fixed review deployment receipt matches the intended handoff `main` commit;
-5. staging validation and representative screenshot capture are successful;
+4. the fixed review deployment receipt matched the intended handoff `main` commit;
+5. staging validation and representative screenshot capture were successful;
 6. relevant images were inspected directly;
 7. no material visual Phase 5 blocker was found;
 8. every unavailable environment check is explicitly recorded;
 9. production restore gaps remain visible Launch work rather than hidden repository completion;
-10. there is no known repository blocker to P5-01.
+10. there is no known repository blocker to P5-01;
+11. #148 merged green.
 
 ## 9. Closure decision
 
-After this audit and tracking update merge green:
+P4-18E is completed through #148.
+
+The tracking handoff moves repository state to:
+
+```text
+Phase 5 — Public submissions / MVP-B
+P5-01 — Shared submission foundation
+```
+
+The resulting interpretation is:
 
 - Phase 4 P4-18 closure is complete for Phase 5 handoff purposes;
-- P4-18E is completed;
 - Phase 5 may begin at P5-01 Shared submission foundation;
 - launch readiness is **not** claimed;
 - configured-environment and production restore Launch work remain mandatory before production launch criteria can be claimed.
 
 ## Next
 
-Move repository tracking to:
-
-```text
-Phase 5 — Public submissions / MVP-B
-P5-01 — Shared submission foundation
-```
+Execute P5-01 Shared submission foundation.
 
 P5-01 must establish common submission envelope, opaque public reference, private follow-up secret handling, workflow state, contact privacy boundary, abuse controls, safe parsing, idempotency, and audit foundation before individual public submission forms are implemented.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -4,29 +4,26 @@
 
 ## Current phase
 
-Phase 4 — Public core / MVP-A closure
+Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P4-18E — Live review and Phase 5 handoff audit
+P5-01 — Shared submission foundation
 
 ## Current repository state
 
+- Phase 0 public specifications and development control are complete.
+- Phase 1 foundation repository work is complete.
+- Phase 2 data core is complete.
 - Phase 3 administration and review repository work is complete through P3-12.
 - Phase 4 public MVP-A surfaces are implemented.
-- P4-17A through P4-17F Places recovery is completed, validated, and merged through pull request #122.
-- Review deployment now follows `main` and updates the fixed review URL after merge through #123.
-- Deployment receipts record the deployed `main` commit through #124.
-- Representative desktop/mobile and interactive-state screenshot capture is merged through #125.
-- Selected Place focus, marker presentation, and desktop selected-panel containment corrections are merged through #126.
-- P4-18A tracking correction and closure inventory is completed through #127.
-- P4-18B1 source and Candidate practical-profile contract is completed through #128.
-- P4-18B2 Promotion editor and field provenance parity is completed through #130.
-- P4-18B3 canonical persistence and public projection integration repository work is completed through #132 and #133, with closure tracking and B4 handoff through #134.
-- P4-18B4 existing-record practical-profile correction path is repository-complete through #135, #136, #137, and #138.
-- P4-18C bounded UI residual closure is completed through #139, #141, and #142, with direct final-artifact visual review recorded in `docs/P4_18_C_UI_AUDIT.md`.
-- P4-18D administration workflow integration audit is repository-complete through D1 #143, D2 #144, D3 #145, D4 #146, and D5 closure inventory in the current handoff change.
-- P4-18E is the active handoff gate before Phase 5.
+- P4-17 Places recovery is complete through #122.
+- P4-18A tracking and closure inventory is complete through #127.
+- P4-18B practical Place operational parity is complete through #128–#138.
+- P4-18C bounded UI residual closure and direct visual acceptance are complete through #139, #141, and #142.
+- P4-18D administration workflow integration audit is complete through #143–#147.
+- P4-18E live review and Phase 5 handoff audit is complete through #148.
+- Phase 5 is active at P5-01.
 
 ## Fixed review environment
 
@@ -34,215 +31,99 @@ Review URL:
 
 `https://review.cryptopaymap-staging.pages.dev`
 
-The deployment receipt must be checked whenever review-environment state matters. Do not assume that a repository merge is visible at the fixed URL until the receipt records the intended `main` commit.
+Deployment receipt state must be checked whenever review-environment state matters. A repository merge must not be assumed visible at the fixed URL until the receipt records the intended `main` commit.
 
 ## Required current references
 
-Before starting or reviewing P4-18E work, read:
+Before P5-01 implementation or review, read:
 
 1. `docs/IMPLEMENTATION_PLAN.md`;
-2. `docs/PHASE4_CLOSURE_PLAN.md`;
-3. `docs/P4_18_D_ADMIN_INTEGRATION_AUDIT.md`;
-4. `docs/P4_18_D4_PUBLICATION_RESTORE_AUDIT.md`;
-5. `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md`;
-6. the public specification documents relevant to the live path under review.
-
-For practical Place profile work also read:
-
-1. `docs/PLACE_PUBLIC_PROFILE.md`;
-2. `docs/PRACTICAL_PROFILE_DATA_MODEL_EXTENSION.md`;
-3. `docs/P4_18_B3_AUDIT.md` for the completed new-target projection boundary;
-4. `docs/P4_18_B4_AUDIT.md` for the completed existing-record correction boundary;
-5. `docs/DATA_MODEL.md`;
-6. `docs/SOURCE_AND_LICENSE_POLICY.md`.
-
-For Places UI work read:
-
-1. `docs/PLACES_UX_ACCEPTANCE.md`;
-2. `docs/PLACES_RECOVERY_PLAN.md`;
-3. `docs/PLACES_UX_FINAL_AUDIT.md`;
-4. `docs/P4_18_C_UI_AUDIT.md` for the completed bounded residual closure.
-
-For Phase 5 preparation and submission work also read:
-
-1. `docs/SUBMISSION_WORKFLOW.md`;
 2. `docs/PHASE5_IMPLEMENTATION_SEQUENCE.md`;
-3. `docs/DATA_MODEL.md`;
-4. `docs/MEDIA_POLICY.md` when Media intake or review is affected.
+3. `docs/SUBMISSION_WORKFLOW.md`;
+4. `docs/DATA_MODEL.md`;
+5. `docs/SECURITY_AND_PRIVACY.md`;
+6. `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md`;
+7. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
 
-## Active closure sequence
+Media work must also read `docs/MEDIA_POLICY.md`.
 
-1. P4-18A — tracking correction and closure inventory — Completed through #127
-2. P4-18B1 — source and Candidate practical-profile contract — Completed through #128
-3. P4-18B2 — promotion editor and field provenance parity — Completed through #130
-4. P4-18B3 — canonical persistence and public projection integration — Completed through #132, #133, and #134
-5. P4-18B4 — existing-record practical-profile correction path audit and completion — Completed through #135, #136, #137, and #138
-6. P4-18C — bounded UI residual closure — Completed through #139, #141, and #142
-7. P4-18D — administration workflow integration audit — Completed through #143, #144, #145, #146, and the D5 handoff change
-8. P4-18E — live review and Phase 5 handoff audit — In progress
+## Phase 5 sequence
 
-The authoritative scope and completion criteria are in `docs/PHASE4_CLOSURE_PLAN.md`. The environment-specific assignment matrix is in `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md`.
+1. P5-01 — Shared submission foundation — In progress
+2. P5-02 — Suggest Place and Online Service — Planned
+3. P5-03 — Payment and problem reports — Planned
+4. P5-04 — Business and service claims — Planned
+5. P5-05 — Photo and Media submission intake — Planned
+6. P5-06 — Review workflow extensions — Planned
+7. P5-07 — Canonical application transactions and retention — Planned
+8. P5-08 — MVP-B integration audit — Planned
 
-## P4-18B1 completed boundary
+## P5-01 active scope
 
-P4-18B1 closed the private source-to-review path for supported practical Place fields:
+P5-01 establishes the common private submission foundation before individual public submission forms are implemented.
 
-```text
-legacy or supported source value
-    ↓
-strict source-row validation
-    ↓
-raw and normalized source separation
-    ↓
-private Candidate review data
-    ↓
-allowlisted Candidate source snapshot
-    ↓
-protected Admin source review
-```
+Required boundaries include:
 
-The completed contract includes:
+- common submission envelope;
+- opaque public reference;
+- private follow-up secret handling;
+- workflow status model;
+- contact privacy boundary;
+- source submission privacy and non-public defaults;
+- abuse-control contract and Turnstile boundary;
+- strict runtime parsing and bounded payloads;
+- idempotent intake behavior;
+- durable private submission audit foundation;
+- no direct canonical or public mutation from intake.
 
-- supported legacy alias normalization without treating source values as canonical truth;
-- phone, description, opening-hours text, amenities, and review-safe social links in private review data;
-- deterministic exact-duplicate behavior for amenities and social-link review values;
-- handle-only legacy social values preserved without fabricated URLs;
-- malformed practical source values rejected fail closed;
-- unknown/private source payload values excluded from Candidate detail responses;
-- existing Candidate replay, duplicate-signal, source metadata, and effective-license boundaries preserved.
+P5-01 must preserve the existing Candidate, canonical, Evidence, Media, verification, export, and publication boundaries.
 
-## P4-18B2 completed boundary
+## Phase 4 handoff result
 
-P4-18B2 connected the B1 practical profile review data to the protected new-target Promotion workspace and explicit field-level provenance:
+P4-18E established that the Phase 5 handoff gate may close while keeping unavailable configured-environment checks explicit.
 
-- phone, description, opening-hours text, amenities, and official social-link controls are reviewer-visible;
-- supported source values are prefilled without treating source data as canonical truth;
-- handle-only and non-HTTPS social values remain visible as source-only review information rather than fabricated canonical URLs;
-- amenities and social-link form values use deterministic parsing and normalization;
-- malformed or duplicate canonical social-link values fail closed;
-- non-empty practical Location values require explicit source assignments;
-- assignments outside the exact Candidate source set are rejected;
-- omitted or empty editor provenance plans are rejected before commit;
-- Candidate version and complete source-set guards remain in force;
-- Promotion continues to create hidden records without automatic verification or publication;
-- existing-target linking remains bounded and does not become a practical-profile correction operation.
+Verified handoff evidence includes:
 
-## P4-18B3 completed boundary
+- fixed review deployment receipt matched the intended handoff `main` commit;
+- relevant staging validation succeeded;
+- Foundation validation and Migration drift succeeded;
+- representative screenshots were captured successfully;
+- representative desktop/mobile and interactive-state images were inspected directly;
+- no material visual Phase 5 handoff blocker was found.
 
-P4-18B3 closed the repository-owned new-target practical Place path through canonical persistence and validated public Place projection.
+Unavailable live checks remain explicit Launch work or configured-environment verification and are not treated as passed.
 
-Repository coverage includes:
+## Retained Launch work
 
-- atomic practical-profile persistence and rollback behavior;
-- replay and changed-content conflict behavior;
-- field-level practical-profile provenance expansion;
-- explicit allowlisted canonical Place projection;
-- strict canonical and public runtime validation;
-- private-extra-field exclusion and leakage checks;
-- optional-field absence semantics;
-- malformed structured social-link rejection;
-- public Place provenance aggregation from resolved source metadata and field-level provenance rows;
-- Promotion-preserved practical values through hidden canonical state, hidden projection rejection, explicit public state, public provenance aggregation, public Place projection, and Place artifact validation;
-- practical profile presentation on canonical Place detail;
-- practical profile consumption by desktop selected panel and mobile expanded sheet;
-- built staging Place detail coverage for description, hours, amenities, phone, official social link, and Media.
+Starting Phase 5 does not waive launch work recorded by P4-18D/E.
 
-The repository release-review path begins from an already generated private candidate bundle. The configured canonical query → complete twelve-artifact candidate generation → private upload → release-review path is an environment-specific verification item assigned precisely to P4-18E. Repository tests do not prove that live path.
+Retained work includes:
 
-## P4-18B4 completed boundary
+- live Cloudflare Access and identity verification;
+- actual allowlist and deployed environment verification;
+- live Neon migration-state verification;
+- representative protected Admin journeys with configured data;
+- canonical query → complete candidate generation → private upload → release-review handoff;
+- corrected canonical value → generation → release → activation flow;
+- concrete R2 publication conditional-write verification;
+- production restore persistence, invocation, R2 adapter wiring, durable restore Audit source, reconciliation runbook, and drills.
 
-P4-18B4 closed the repository path for reviewed practical-profile corrections on already canonical Places without widening existing-target Candidate linking.
-
-Repository coverage includes:
-
-- bounded scalar and structured correction semantics;
-- exact changed-field correction provenance;
-- deterministic replay, changed-content conflict, stale-state conflict, no-op rejection, and rollback coverage;
-- durable reviewer decisions with exact expected Location version, before/after values, source set, field assignments, reasons, and request fingerprint;
-- atomic Location update, current correction provenance maintenance, and durable decision persistence;
-- protected Candidate-source-set and canonical-Location workspace binding;
-- dedicated correction subject allowlist and UUID idempotency key;
-- Candidate-version, Location-version, exact-source-set, and eligibility revalidation immediately before write;
-- reviewer controls for scalar set/clear and Amenities/Social Link add/remove/replace/clear operations;
-- explicit navigation from selected physical existing-target review to the separate correction workspace;
-- metadata-only protected Audit history normalization of durable correction decisions;
-- operator reachability, conflict, unavailable, and retry recovery coverage;
-- built artifact checks for the correction admin page and server-only marker leakage.
-
-Live migration application, Access allowlist configuration, representative live correction, live protected Audit appearance, and configured corrected-value release flow remain P4-18E verification items. Repository tests do not prove those live conditions.
-
-## P4-18C completed boundary
-
-P4-18C closed the fixed UI residual scope through C1, C2, and direct C3 final-artifact reconciliation:
-
-- Mobile Places List cards were compacted while retaining status, category, locality, payment assets, networks, routes, freshness, map selection, and payment-detail access;
-- the Mobile Menu moved from a sparse full-height drawer to a bounded two-column navigation panel while preserving focus, Escape, overlay, body-scroll, and active-page behavior;
-- expanded mobile Place information now presents Location and Navigate followed immediately by `How to pay` and core payment metadata before long practical-profile content;
-- Mobile Filters now include an explicit sticky completion action with live result count while retaining immediate application, Clear, zero-result recovery, Widen area, Include Stale, and existing desktop behavior;
-- representative Methodology long-form mobile output was directly inspected with no material overflow, hidden interaction, or broken density/layout defect found;
-- final direct review of the same latest artifact set found no material horizontal overflow or hidden primary interaction across the fixed five-item scope.
-
-Screenshot workflow success was not used as a substitute for image inspection. The closure record is `docs/P4_18_C_UI_AUDIT.md`.
-
-## P4-18D completed boundary
-
-P4-18D closed the repository administration integration audit across:
-
-- Candidate queue and detail;
-- duplicate review and identity resolution;
-- new-target Promotion;
-- existing-target linking;
-- separate Location correction;
-- Evidence review and Claim decisions;
-- reconfirmation queue and expiration behavior;
-- Media review;
-- export candidate, release decision, activation, history, and restore boundaries;
-- protected Audit history coverage;
-- conflict, retry, replay, rollback, and operator-reachability behavior.
-
-D1 through D4 resolved or classified repository findings. D5 assigns every remaining environment-dependent check to P4-18E or explicit Launch work. Publication activation and release history are explicit non-UI protected boundaries. Restore contracts and workflow exist in the repository, but production restore persistence, invocation, R2 adapter wiring, durable restore Audit source, reconciliation runbook, and drills remain explicit Launch work and are not described as production-operational.
-
-## P4-18E handoff
-
-P4-18E is the active gate. It must use `docs/P4_18_D5_CLOSURE_AND_ENVIRONMENT_INVENTORY.md` and:
-
-- verify the fixed review deployment receipt against intended `main`;
-- verify or precisely mark unavailable the configured Access, allowlist, Functions environment, Neon migration, representative Admin path, candidate generation/upload/review, publication activation, release history, and Audit checks;
-- run staging artifact validation;
-- run representative screenshot capture and inspect the relevant images directly;
-- classify every unavailable environment check precisely;
-- keep Launch work assignments visible rather than treating them as repository-complete;
-- confirm Phase 5 prerequisites before moving to P5-01.
-
-## Phase 5 handoff
-
-Phase 5 does not begin until P4-18E completes the handoff and this status file moves to P5-01.
-
-Planned Phase 5 order:
-
-1. P5-01 — Shared submission foundation
-2. P5-02 — Suggest Place and Online Service
-3. P5-03 — Payment and problem reports
-4. P5-04 — Business and service claims
-5. P5-05 — Photo and Media submission intake
-6. P5-06 — Review workflow extensions
-7. P5-07 — Canonical application transactions and retention
-8. P5-08 — MVP-B integration audit
+Launch readiness must not be claimed until the relevant launch criteria and retained Launch work are complete.
 
 ## Next
 
-Execute P4-18E live review and Phase 5 handoff audit. Do not move to P5-01 until the D5-assigned live-review checks are verified or precisely classified and the Phase 5 handoff gate is explicitly completed.
+Execute P5-01 Shared submission foundation.
+
+Do not begin individual submission-form implementation before the common submission envelope, privacy, workflow, abuse, idempotency, and audit foundations are explicit and validated.
 
 ## Blocked
 
-No known repository blocker.
+No known repository blocker to P5-01.
 
-Phase 5 remains blocked on P4-18E completion.
-
-Production restore persistence, protected invocation, concrete R2 restore adapter wiring, durable restore Audit source, post-switch reconciliation runbook, and production restore drills remain explicit Launch work. They must not be represented as complete by repository tests.
+Production restore completion remains a Launch gate rather than a P5-01 start blocker.
 
 ## Verification rule
 
-Repository reality is determined by current `main`, merged pull requests, and actual CI results. Current work order is determined by `docs/PROJECT_STATUS.md`, `docs/IMPLEMENTATION_PLAN.md`, and the active closure or phase specification.
+Repository reality is determined by current `main`, merged pull requests, and actual CI results. Current work order is determined by `docs/PROJECT_STATUS.md`, `docs/IMPLEMENTATION_PLAN.md`, and the active phase specification.
 
-Do not claim live verification from repository checks alone. Do not claim visual acceptance from screenshot generation alone; relevant images must be inspected.
+Do not claim live verification from repository checks alone. Do not claim visual acceptance from screenshot generation alone; relevant images must be inspected directly.


### PR DESCRIPTION
## Tracking handoff

Move repository execution state from completed P4-18E to active Phase 5 / P5-01.

## Changes

- mark `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md` completed through #148;
- move `docs/PROJECT_STATUS.md` to Phase 5 / P5-01;
- reconcile `docs/IMPLEMENTATION_PLAN.md` around completed Phase 4 closure and active Phase 5;
- define bounded P5-01A–P5-01E execution slices and P5-01 completion criteria;
- retain configured-environment and production restore Launch work explicitly.

## Current item after merge

`P5-01 — Shared submission foundation`

## Boundary

This tracking handoff does not implement submission intake. It establishes the authoritative work order before P5-01 implementation begins.
