### PR TITLE
P5-02I: bind Submission status-secret environment key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ PUBLIC_SITE_URL=http://localhost:4321
 # Server-only database connection. Leave unset for public static builds.
 # Set this only in local server tooling, protected workers, or migration environments.
 DATABASE_URL=
+
+# Server-only Submission status-secret HMAC key.
+# Canonical unpadded Base64URL encoding of at least 32 random bytes.
+CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL=

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # CryptoPayMap implementation plan
 
 **Status:** Active  
-**Last updated:** 2026-07-10
+**Last updated:** 2026-07-11
 
 This file tracks repository implementation work. GitHub `main`, merged pull requests, and actual CI results are authoritative when this file differs from repository reality.
 
@@ -215,7 +215,9 @@ P5-02G — guarded time-bounded in_review→on_hold operation                  C
     ↓
 P5-02H — atomic accepted-as-Candidate outcome                              Completed #163
     ↓
-public Suggest route/form wiring with real environment-backed providers  In progress
+P5-02I — Submission status-secret environment binding                     In progress
+    ↓
+remaining public Suggest route/form provider and exposure slices
     ↓
 P5-02 integration and handoff audit
 ```

--- a/docs/P5_02I_SUBMISSION_STATUS_SECRET_ENVIRONMENT_BINDING.md
+++ b/docs/P5_02I_SUBMISSION_STATUS_SECRET_ENVIRONMENT_BINDING.md
@@ -1,0 +1,51 @@
+# P5-02I Submission status-secret environment binding
+
+**Implementation item:** P5-02I  
+**Status:** In progress  
+**Last updated:** 2026-07-11
+
+## Purpose
+
+P5-02I binds server-only configured key material to the existing deterministic Submission status-secret provider. It does not add a public route or change the P5-01C derivation algorithm.
+
+## Environment contract
+
+The server environment key is:
+
+```text
+CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL
+```
+
+Its value is canonical unpadded Base64URL using only `A-Z`, `a-z`, `0-9`, `-`, and `_`. It must decode to at least 32 bytes. Missing, empty, malformed, padded, incorrectly encoded, or too-short values fail closed with a bounded configuration error that does not contain the configured value.
+
+The binding accepts an explicit environment record so a later Cloudflare Pages Function can pass `context.env`. It does not read `process.env` implicitly and the key is not a `PUBLIC_*` value.
+
+```text
+explicit server environment record
+→ strict canonical Base64URL parse
+→ decode and minimum-length validation
+→ createHmacSubmissionStatusSecretProvider
+→ SubmissionStatusSecretProvider
+```
+
+The configured value belongs only in an approved runtime secret facility. It must not be committed, logged, placed in public build metadata, or copied into generated artifacts.
+
+## Preserved behavior
+
+P5-02I reuses the P5-01C HMAC provider and therefore preserves:
+
+- the existing HMAC-SHA-256 domain and status-secret encoding;
+- same key plus same request UUID producing the same secret;
+- different request UUIDs producing different secrets;
+- stored token-hash replay-integrity verification;
+- no plaintext status-secret persistence.
+
+## Out of scope
+
+P5-02I does not implement contact encryption, email hashing, opaque rate-limit keys, distributed rate limiting, remote-IP extraction, Turnstile changes, CSP, a public API route, or a public form/page. Public Suggest intake remains unavailable. P5-03 remains blocked.
+
+## Completion criteria
+
+P5-02I is complete when the explicit environment binding strictly validates and decodes the server-only key, returns the existing provider interface, preserves deterministic request behavior, fails closed without exposing configured values, and passes focused and full repository validation.
+
+Repository tests do not claim live configured-environment verification.

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -176,3 +176,174 @@ A suggestion can move from public intake to protected review and resolve without
 P5-02 is not complete when P5-02H finishes. Public Suggest route/form wiring with real environment-backed providers and a bounded integration/handoff audit still remain.
 
 ---
+
+## P5-03 — Payment and problem reports
+
+### Goal
+
+Accept target-aware reports about payment success, failure, and incorrect or problematic public information.
+
+### Scope
+
+- preselected Place or Online Service targets;
+- positive and negative payment outcomes;
+- asset, network, route, method, and observed payment steps;
+- optional public evidence links;
+- restricted transaction or receipt evidence boundary;
+- factual correction proposals;
+- practical profile correction proposals for address, phone, website, hours, amenities, social links, and description where relevant;
+- privacy, rights, duplicate, closure, and other problem categories;
+- priority recheck signal generation;
+- negative Evidence review entry;
+- no automatic Claim status change.
+
+### Completion gate
+
+Reports become review material, may add Evidence or recheck priority after explicit review, and cannot directly confirm, stale, end, hide, or publish a canonical Claim.
+
+---
+
+## P5-04 — Business and service claims
+
+### Goal
+
+Accept representative claims and verify ownership or authority separately from payment verification.
+
+### Scope
+
+- claimant role and target scope;
+- official contact method boundary;
+- proposed practical profile and payment corrections;
+- ownership-verification method state;
+- official-domain, website, DNS, official-social, and approved assisted verification adapter boundaries where implemented;
+- protected ownership proof handling;
+- ownership relationship status and scope;
+- expiration and revocation boundaries;
+- handoff of proposed changes to normal field and Claim review.
+
+### Completion gate
+
+A verified representative relationship can be recorded without granting uncontrolled editing rights or bypassing Evidence, canonical application, and publication review.
+
+---
+
+## P5-05 — Photo and Media submission intake
+
+### Goal
+
+Accept public-gallery Media proposals safely and connect them to the existing protected Media review system.
+
+### Scope
+
+- target binding;
+- image role;
+- capture date and description;
+- rights and authorization basis;
+- public-display permission;
+- privacy and rights acknowledgements;
+- bounded upload authorization;
+- quarantine object path;
+- MIME, size, dimension, and file-integrity validation;
+- duplicate file hash behavior;
+- derivative processing boundary;
+- Media asset creation in non-public state;
+- handoff to the existing Media review queue;
+- cleanup and retention of rejected or abandoned private uploads.
+
+### Completion gate
+
+A submitted image remains non-public until the existing Media decision and controlled publication boundaries approve it.
+
+---
+
+## P5-06 — Review workflow extensions
+
+### Goal
+
+Support the review states and partial decisions required by real public submissions.
+
+### Scope
+
+- Submission review queue and detail workspace;
+- field-level proposed-versus-current diff;
+- information request;
+- submitter follow-up response;
+- time-bounded hold with reason and next review date;
+- partial approval;
+- duplicate and no-change outcomes;
+- accepted-as-Candidate outcome;
+- withdrawal behavior;
+- status history;
+- private reviewer notes separated from public status text;
+- bounded public-facing resolution summaries.
+
+### Completion gate
+
+A multi-field Submission can resolve fields independently, request more information, pause safely, and report a bounded public status without exposing private review content.
+
+---
+
+## P5-07 — Canonical application transactions and retention
+
+### Goal
+
+Apply approved Submission decisions safely to canonical data and enforce private-data lifecycle rules.
+
+### Scope
+
+- explicit application plan derived from approved field decisions;
+- exact canonical version or state expectations;
+- field-level diff and correction provenance;
+- atomic canonical create or update transaction;
+- Claim, Claim Asset, identity, and practical profile boundaries kept distinct;
+- Media decisions remain delegated to Media review operations;
+- request replay and stale-state conflict handling;
+- application receipt and Audit history;
+- public export and release remain separate;
+- contact, private payload, evidence, ownership proof, and upload retention jobs;
+- deletion or anonymization where required;
+- preservation of minimum Audit records where lawful and necessary.
+
+### Completion gate
+
+Approved changes can be applied once, replay safely, conflict on stale state, retain provenance and review identity, and reach public output only through the normal export and release workflow.
+
+---
+
+## P5-08 — MVP-B integration audit
+
+### Goal
+
+Verify the complete Submission system across all public and protected boundaries before launch preparation.
+
+### Required journeys
+
+1. Suggestion → review → Candidate or approved canonical change → export → publication.
+2. Positive payment report → Evidence review → optional reconfirmation → publication.
+3. Negative payment report → Evidence/recheck → explicit Claim decision if justified.
+4. Problem report → correction, no change, duplicate, privacy, or rights outcome.
+5. Business claim → ownership verification → normal proposed-change review.
+6. Photo submission → quarantine → Media review → controlled public Media publication.
+7. Information request → private follow-up → resumed review.
+8. Partial approval → approved-field application with rejected or held fields preserved correctly.
+
+### Audit categories
+
+- privacy and data minimization;
+- authorization;
+- abuse controls;
+- replay and duplicate handling;
+- status secret handling;
+- field-level review and provenance;
+- stale-state conflict behavior;
+- canonical/public separation;
+- Media isolation;
+- export leakage validation;
+- public status privacy;
+- retention and cleanup;
+- mobile and accessibility behavior;
+- failure, retry, and rollback boundaries.
+
+### Completion gate
+
+Phase 5 is complete only when the full Submission-to-publication path is auditable and the system can demonstrate that unreviewed Submission data never becomes public canonical data automatically.

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -2,7 +2,7 @@
 
 **Phase:** Phase 5 — Public submissions / MVP-B  
 **Status:** Active — P5-02 Suggest work in progress  
-**Last updated:** 2026-07-10
+**Last updated:** 2026-07-11
 
 ## Purpose
 
@@ -64,7 +64,8 @@ P5-02E  Completed through #160
 P5-02F  Completed through #161
 P5-02G  Completed through #162
 P5-02H  Completed through #163
-Public Suggest route/form wiring with real environment-backed providers  In progress
+P5-02I  Submission status-secret environment binding                    In progress
+Remaining public Suggest route/form provider and exposure slices        Planned
 P5-02 integration and handoff audit                                    Planned
 ```
 
@@ -146,7 +147,9 @@ P5-02G — guarded time-bounded in_review→on_hold operation              Compl
     ↓
 P5-02H — atomic accepted-as-Candidate outcome                          Completed #163
     ↓
-public Suggest route/form wiring with real environment-backed providers  In progress
+P5-02I — Submission status-secret environment binding                  In progress
+    ↓
+remaining public Suggest route/form provider and exposure slices       Planned
     ↓
 P5-02 integration and handoff audit                                    Planned
 ```
@@ -173,174 +176,3 @@ A suggestion can move from public intake to protected review and resolve without
 P5-02 is not complete when P5-02H finishes. Public Suggest route/form wiring with real environment-backed providers and a bounded integration/handoff audit still remain.
 
 ---
-
-## P5-03 — Payment and problem reports
-
-### Goal
-
-Accept target-aware reports about payment success, failure, and incorrect or problematic public information.
-
-### Scope
-
-- preselected Place or Online Service targets;
-- positive and negative payment outcomes;
-- asset, network, route, method, and observed payment steps;
-- optional public evidence links;
-- restricted transaction or receipt evidence boundary;
-- factual correction proposals;
-- practical profile correction proposals for address, phone, website, hours, amenities, social links, and description where relevant;
-- privacy, rights, duplicate, closure, and other problem categories;
-- priority recheck signal generation;
-- negative Evidence review entry;
-- no automatic Claim status change.
-
-### Completion gate
-
-Reports become review material, may add Evidence or recheck priority after explicit review, and cannot directly confirm, stale, end, hide, or publish a canonical Claim.
-
----
-
-## P5-04 — Business and service claims
-
-### Goal
-
-Accept representative claims and verify ownership or authority separately from payment verification.
-
-### Scope
-
-- claimant role and target scope;
-- official contact method boundary;
-- proposed practical profile and payment corrections;
-- ownership-verification method state;
-- official-domain, website, DNS, official-social, and approved assisted verification adapter boundaries where implemented;
-- protected ownership proof handling;
-- ownership relationship status and scope;
-- expiration and revocation boundaries;
-- handoff of proposed changes to normal field and Claim review.
-
-### Completion gate
-
-A verified representative relationship can be recorded without granting uncontrolled editing rights or bypassing Evidence, canonical application, and publication review.
-
----
-
-## P5-05 — Photo and Media submission intake
-
-### Goal
-
-Accept public-gallery Media proposals safely and connect them to the existing protected Media review system.
-
-### Scope
-
-- target binding;
-- image role;
-- capture date and description;
-- rights and authorization basis;
-- public-display permission;
-- privacy and rights acknowledgements;
-- bounded upload authorization;
-- quarantine object path;
-- MIME, size, dimension, and file-integrity validation;
-- duplicate file hash behavior;
-- derivative processing boundary;
-- Media asset creation in non-public state;
-- handoff to the existing Media review queue;
-- cleanup and retention of rejected or abandoned private uploads.
-
-### Completion gate
-
-A submitted image remains non-public until the existing Media decision and controlled publication boundaries approve it.
-
----
-
-## P5-06 — Review workflow extensions
-
-### Goal
-
-Support the review states and partial decisions required by real public submissions.
-
-### Scope
-
-- Submission review queue and detail workspace;
-- field-level proposed-versus-current diff;
-- information request;
-- submitter follow-up response;
-- time-bounded hold with reason and next review date;
-- partial approval;
-- duplicate and no-change outcomes;
-- accepted-as-Candidate outcome;
-- withdrawal behavior;
-- status history;
-- private reviewer notes separated from public status text;
-- bounded public-facing resolution summaries.
-
-### Completion gate
-
-A multi-field Submission can resolve fields independently, request more information, pause safely, and report a bounded public status without exposing private review content.
-
----
-
-## P5-07 — Canonical application transactions and retention
-
-### Goal
-
-Apply approved Submission decisions safely to canonical data and enforce private-data lifecycle rules.
-
-### Scope
-
-- explicit application plan derived from approved field decisions;
-- exact canonical version or state expectations;
-- field-level diff and correction provenance;
-- atomic canonical create or update transaction;
-- Claim, Claim Asset, identity, and practical profile boundaries kept distinct;
-- Media decisions remain delegated to Media review operations;
-- request replay and stale-state conflict handling;
-- application receipt and Audit history;
-- public export and release remain separate;
-- contact, private payload, evidence, ownership proof, and upload retention jobs;
-- deletion or anonymization where required;
-- preservation of minimum Audit records where lawful and necessary.
-
-### Completion gate
-
-Approved changes can be applied once, replay safely, conflict on stale state, retain provenance and review identity, and reach public output only through the normal export and release workflow.
-
----
-
-## P5-08 — MVP-B integration audit
-
-### Goal
-
-Verify the complete Submission system across all public and protected boundaries before launch preparation.
-
-### Required journeys
-
-1. Suggestion → review → Candidate or approved canonical change → export → publication.
-2. Positive payment report → Evidence review → optional reconfirmation → publication.
-3. Negative payment report → Evidence/recheck → explicit Claim decision if justified.
-4. Problem report → correction, no change, duplicate, privacy, or rights outcome.
-5. Business claim → ownership verification → normal proposed-change review.
-6. Photo submission → quarantine → Media review → controlled public Media publication.
-7. Information request → private follow-up → resumed review.
-8. Partial approval → approved-field application with rejected or held fields preserved correctly.
-
-### Audit categories
-
-- privacy and data minimization;
-- authorization;
-- abuse controls;
-- replay and duplicate handling;
-- status secret handling;
-- field-level review and provenance;
-- stale-state conflict behavior;
-- canonical/public separation;
-- Media isolation;
-- export leakage validation;
-- public status privacy;
-- retention and cleanup;
-- mobile and accessibility behavior;
-- failure, retry, and rollback boundaries.
-
-### Completion gate
-
-Phase 5 is complete only when the full Submission-to-publication path is auditable and the system can demonstrate that unreviewed Submission data never becomes public canonical data automatically.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # CryptoPayMap project status
 
-**Last verified:** 2026-07-10
+**Last verified:** 2026-07-11
 
 ## Current phase
 
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-02 — Public Suggest route/form wiring
+P5-02I — Submission status-secret environment binding
 
 ## Current repository state
 
@@ -26,7 +26,7 @@ P5-02 — Public Suggest route/form wiring
 - P5-02F bounded in_review→needs_information request boundary is complete through #161.
 - P5-02G bounded in_review→on_hold operation with 30/60/90 day next-review timing is complete through #162.
 - P5-02H atomic accepted-as-Candidate transaction boundary is complete through #163.
-- Public Suggest route/form wiring with real environment-backed providers is the next active P5-02 work.
+- P5-02I Submission status-secret environment binding is in progress without public route exposure.
 
 ## Fixed review environment
 
@@ -93,7 +93,9 @@ P5-02G  Guarded time-bounded in_review→on_hold operation                  Comp
     ↓
 P5-02H  Atomic accepted-as-Candidate outcome                              Completed #163
     ↓
-public Suggest route/form wiring with real environment-backed providers  In progress
+P5-02I  Submission status-secret environment binding                     In progress
+    ↓
+remaining public Suggest route/form provider and exposure slices
     ↓
 P5-02 integration and handoff audit
 ```

--- a/scripts/check-runtime-schemas.ts
+++ b/scripts/check-runtime-schemas.ts
@@ -8,6 +8,7 @@ import './check-online-service-importer';
 import './check-phase-2-integration';
 import './check-physical-place-importer';
 import './check-source-provenance';
+import './check-submission-status-secret-environment';
 import './check-verification-events';
 import { assetRegistry, findAssetCandidates } from '../src/registries/assets';
 import { findNetworkCandidates, networkRegistry } from '../src/registries/networks';

--- a/scripts/check-submission-status-secret-environment.ts
+++ b/scripts/check-submission-status-secret-environment.ts
@@ -1,0 +1,20 @@
+import { createSubmissionStatusSecretProviderFromEnvironment } from '../src/submissions/status-secret-environment';
+
+const requestId = '20000000-0000-4000-8000-000000000001';
+const testKeyBytes = new Uint8Array(32).fill(7);
+let testKeyBinary = '';
+for (const byte of testKeyBytes) testKeyBinary += String.fromCharCode(byte);
+const provider = createSubmissionStatusSecretProviderFromEnvironment({
+  CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: btoa(testKeyBinary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, ''),
+});
+const first = await provider.issueForRequest(requestId);
+const replay = await provider.issueForRequest(requestId);
+
+if (first.secret !== replay.secret || first.tokenHash !== replay.tokenHash) {
+  throw new Error('Submission status-secret environment binding is not deterministic.');
+}
+
+console.log('Submission status-secret environment binding checks passed.');

--- a/src/submissions/status-secret-environment.ts
+++ b/src/submissions/status-secret-environment.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+import {
+  createHmacSubmissionStatusSecretProvider,
+  type SubmissionStatusSecretProvider,
+} from './status-secret-provider';
+
+export const submissionStatusHmacEnvironmentKey =
+  'CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL' as const;
+
+const minimumKeyByteLength = 32;
+const canonicalBase64UrlSchema = z
+  .string()
+  .min(1)
+  .regex(/^[A-Za-z0-9_-]+$/)
+  .refine((value) => value.length % 4 !== 1);
+
+export const submissionStatusSecretEnvironmentSchema = z
+  .object({ CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: canonicalBase64UrlSchema })
+  .strict();
+
+export type SubmissionStatusSecretEnvironment = Readonly<
+  Record<string, unknown> & { CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL?: unknown }
+>;
+
+export class SubmissionStatusSecretConfigurationError extends Error {
+  constructor() {
+    super('Submission status-secret configuration is unavailable.');
+    this.name = 'SubmissionStatusSecretConfigurationError';
+  }
+}
+
+function decodeCanonicalBase64Url(value: string): Uint8Array {
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const paddingLength = (4 - (normalized.length % 4)) % 4;
+    const decoded = globalThis.atob(normalized.padEnd(normalized.length + paddingLength, '='));
+    const bytes = Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+    let canonical = '';
+    for (const byte of bytes) canonical += String.fromCharCode(byte);
+    const encodedAgain = globalThis
+      .btoa(canonical)
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '');
+    if (encodedAgain !== value || bytes.byteLength < minimumKeyByteLength) {
+      throw new SubmissionStatusSecretConfigurationError();
+    }
+    return bytes;
+  } catch (error) {
+    if (error instanceof SubmissionStatusSecretConfigurationError) throw error;
+    throw new SubmissionStatusSecretConfigurationError();
+  }
+}
+
+/**
+ * Reads an unpadded canonical Base64URL key from an explicit server environment record and
+ * composes the existing request-bound HMAC status-secret provider.
+ */
+export function createSubmissionStatusSecretProviderFromEnvironment(
+  environment: SubmissionStatusSecretEnvironment,
+): SubmissionStatusSecretProvider {
+  const parsed = submissionStatusSecretEnvironmentSchema.safeParse({
+    CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: environment.CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL,
+  });
+  if (!parsed.success) throw new SubmissionStatusSecretConfigurationError();
+
+  return createHmacSubmissionStatusSecretProvider(
+    decodeCanonicalBase64Url(parsed.data.CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL),
+  );
+}

--- a/tests/submission-status-secret-environment.test.ts
+++ b/tests/submission-status-secret-environment.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSubmissionStatusSecretProviderFromEnvironment,
+  SubmissionStatusSecretConfigurationError,
+} from '../src/submissions/status-secret-environment';
+
+const requestId = '20000000-0000-4000-8000-000000000001';
+const differentRequestId = '20000000-0000-4000-8000-000000000002';
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function environment(keyBytes = new Uint8Array(32).fill(7)): Record<string, unknown> {
+  return { CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: encodeBase64Url(keyBytes) };
+}
+
+describe('P5-02I Submission status-secret environment binding', () => {
+  it('creates the existing provider from an explicit environment record', async () => {
+    const explicitEnvironment = environment();
+    const provider = createSubmissionStatusSecretProviderFromEnvironment(explicitEnvironment);
+    await expect(provider.issueForRequest(requestId)).resolves.toMatchObject({
+      secret: expect.stringMatching(/^cpmss_[A-Za-z0-9_-]{43}$/),
+      tokenHash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+    });
+  });
+
+  it.each([
+    ['missing', {}],
+    ['empty', { CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: '' }],
+    ['malformed alphabet', { CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: 'not+base64url' }],
+    ['invalid encoded length', { CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: 'A' }],
+    ['padded', { CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: `${'A'.repeat(43)}=` }],
+    ['too short', environment(new Uint8Array(31).fill(7))],
+  ])('fails closed for %s configuration', (_name, configuredEnvironment) => {
+    expect(() =>
+      createSubmissionStatusSecretProviderFromEnvironment(configuredEnvironment),
+    ).toThrow(SubmissionStatusSecretConfigurationError);
+  });
+
+  it('accepts exactly 32 decoded key bytes', async () => {
+    const provider = createSubmissionStatusSecretProviderFromEnvironment(
+      environment(new Uint8Array(32).fill(1)),
+    );
+    await expect(provider.issueForRequest(requestId)).resolves.toBeDefined();
+  });
+
+  it('reproduces the same secret for the same key and request UUID', async () => {
+    const firstProvider = createSubmissionStatusSecretProviderFromEnvironment(environment());
+    const secondProvider = createSubmissionStatusSecretProviderFromEnvironment(environment());
+    expect(await firstProvider.issueForRequest(requestId)).toEqual(
+      await secondProvider.issueForRequest(requestId),
+    );
+  });
+
+  it('separates different request UUIDs under the same key', async () => {
+    const provider = createSubmissionStatusSecretProviderFromEnvironment(environment());
+    const first = await provider.issueForRequest(requestId);
+    const second = await provider.issueForRequest(differentRequestId);
+    expect(second.secret).not.toBe(first.secret);
+    expect(second.tokenHash).not.toBe(first.tokenHash);
+  });
+
+  it('does not include configured secret material in errors', () => {
+    const configuredSecret = 'sensitive+invalid/value=';
+    let caught: unknown;
+    try {
+      createSubmissionStatusSecretProviderFromEnvironment({
+        CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL: configuredSecret,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SubmissionStatusSecretConfigurationError);
+    expect(String(caught)).not.toContain(configuredSecret);
+  });
+});


### PR DESCRIPTION
## Implementation item

P5-02I — Submission status-secret environment binding

## Purpose

Bind explicit server-only environment key material to the existing deterministic Submission status-secret HMAC provider without exposing a public Suggest route.

## Scope

- add `CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL` as a server-only environment contract;
- strictly parse canonical unpadded Base64URL and require at least 32 decoded bytes;
- compose the existing `createHmacSubmissionStatusSecretProvider` from an explicit environment record;
- fail closed with a bounded configuration error that does not expose configured material;
- add focused tests and runtime schema coverage;
- record P5-02I as the active bounded slice.

## Explicit exclusions

- no contact encryption or email hashing;
- no opaque rate-limit bucket derivation;
- no distributed rate limiter;
- no remote-IP extraction;
- no Turnstile behavior or browser wiring changes;
- no CSP changes;
- no public API route;
- no public Suggest form/page;
- no canonical, export, or publication mutation;
- no P5-03 work.

## Validation before PR

Codex local validation on the same implementation reported:

- focused P5-02I plus existing replay-integrity tests: 19/19 passed;
- runtime contract script passed;
- `git diff --check` passed;
- formatting passed;
- format, lint, Astro/type checks, schema checks, and database drift passed during the host-level quality run;
- the full suite reached 747/749 tests, with two unrelated Candidate-promotion component timeouts;
- those timed-out tests immediately passed 3/3 on isolated rerun;
- because the sequential quality command stopped at those timeouts, build, accessibility, and staging checks were then run separately and passed.

The literal local `npm run quality` invocation did not finish green, so this PR relies on GitHub CI for the authoritative full repository result.

## Security and privacy invariants

- the existing HMAC derivation algorithm and domain are reused unchanged;
- same key plus same request UUID remains deterministic;
- different request UUIDs remain separated;
- configured secret values are never logged or included in configuration errors;
- the key is server-only and is not a `PUBLIC_*` value;
- public Suggest intake remains unavailable.

## Remaining work

Later bounded slices still need contact protection, opaque rate-limit bucket derivation, distributed rate limiting, trusted edge identity extraction, Turnstile environment/browser wiring, public HTTP composition, Suggest UI/CSP, configured-environment verification, and the final P5-02 integration/handoff audit.