### PR TITLE
P5-02J: add Submission contact protection provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,13 @@ DATABASE_URL=
 # Server-only Submission status-secret HMAC key.
 # Canonical unpadded Base64URL encoding of at least 32 random bytes.
 CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL=
+
+# Server-only Submission contact protection configuration.
+# The AES-GCM encryption key is exactly 32 random bytes encoded as canonical unpadded Base64URL.
+CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL=
+# Stable non-secret identifier for the active contact encryption key version.
+CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID=
+# Separate HMAC key for normalized email hashes; at least 32 random bytes, canonical unpadded Base64URL.
+CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL=
+# Configured contact retention period in whole days, from 1 through 3650.
+CPM_SUBMISSION_CONTACT_RETENTION_DAYS=

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -215,7 +215,9 @@ P5-02G — guarded time-bounded in_review→on_hold operation                  C
     ↓
 P5-02H — atomic accepted-as-Candidate outcome                              Completed #163
     ↓
-P5-02I — Submission status-secret environment binding                     In progress
+P5-02I — Submission status-secret environment binding                     Completed #167
+    ↓
+P5-02J — Submission contact protection                                    In progress
     ↓
 remaining public Suggest route/form provider and exposure slices
     ↓
@@ -300,7 +302,16 @@ P5-02H established:
 - deterministic replay and normalized-payload version guards;
 - no canonical mutation, export, or publication.
 
-The active P5-02 work must wire the public Suggest route/form with real environment-backed providers. P5-02 then closes with a bounded integration and handoff audit before P5-03 begins.
+P5-02I established:
+
+- explicit server-only environment binding for the existing deterministic status-secret HMAC provider;
+- strict canonical Base64URL decoding and minimum key-length enforcement;
+- bounded configuration failures without configured-value disclosure;
+- no public route exposure.
+
+P5-02J now establishes production-capable protected contact output for the existing private intake service while keeping public intake unavailable.
+
+The active P5-02 work must continue the remaining public Suggest provider and exposure slices. P5-02 then closes with a bounded integration and handoff audit before P5-03 begins.
 
 ### P5-03 — Payment and problem reports
 

--- a/docs/P5_02J_SUBMISSION_CONTACT_PROTECTION.md
+++ b/docs/P5_02J_SUBMISSION_CONTACT_PROTECTION.md
@@ -1,0 +1,78 @@
+# P5-02J Submission contact protection
+
+**Implementation item:** P5-02J  
+**Status:** In progress  
+**Last updated:** 2026-07-11
+
+## Purpose
+
+P5-02J implements the production-capable `SubmissionContactProtector` required by the existing private intake service. It protects optional contact email before persistence without adding a public route or changing Suggest intake semantics.
+
+## Environment contract
+
+The server-only environment inputs are:
+
+```text
+CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL
+CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID
+CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL
+CPM_SUBMISSION_CONTACT_RETENTION_DAYS
+```
+
+The encryption key is exactly 32 bytes encoded as canonical unpadded Base64URL and is imported as AES-GCM key material. The email-hash HMAC key is separate purpose-specific key material of at least 32 bytes. The provider rejects equal encryption and hash key material.
+
+The key ID is a bounded non-secret version identifier embedded in the encrypted envelope. Retention is configured as a whole number of days from 1 through 3650. The exact deployed period remains an operational/privacy choice that must be disclosed before public submission launch.
+
+All binding uses an explicit environment record so a later Cloudflare Pages Function can supply `context.env`. No provider secret is read from a `PUBLIC_*` variable.
+
+## Contact protection behavior
+
+Validated email contact is transformed as follows:
+
+```text
+validated email
+├─ original validated address
+│  → AES-256-GCM with random 96-bit IV and version/key-id AAD
+│  → v1.<key-id>.<iv-base64url>.<ciphertext-base64url>
+└─ NFC + lowercase normalized identity
+   → HMAC-SHA-256 with separate hash key and domain separation
+   → 64-character lowercase hexadecimal email_hash
+```
+
+The encrypted address is randomized between calls while the keyed normalized email hash is deterministic for duplicate/abuse comparison. Plaintext email is never returned from the provider output.
+
+`retention_until` is derived from the validated `receivedAt` timestamp plus the configured retention days.
+
+## Security and privacy invariants
+
+P5-02J preserves these boundaries:
+
+- plaintext email is accepted only at the contact-protection boundary;
+- persistence receives only `encryptedEmail`, `emailHash`, `retentionUntil`, and the existing contact permission state;
+- encryption and email-hash keys are separate by purpose;
+- ciphertext uses a fresh random IV for every protection operation;
+- configuration and operation errors are bounded and do not contain email or secret material;
+- no contact or provider secret is logged;
+- public receipts and public status projections remain unchanged;
+- repository checks do not claim live configured-environment verification.
+
+## Out of scope
+
+P5-02J does not implement contact decryption workflows, email delivery, status-secret changes, opaque rate-limit keys, distributed rate limiting, remote-IP extraction, Turnstile changes, CSP, a public API route, a public Suggest form/page, canonical mutation, export, or publication.
+
+Public Suggest intake remains unavailable. P5-03 remains blocked.
+
+## Completion criteria
+
+P5-02J is complete when:
+
+1. explicit server environment input creates the existing `SubmissionContactProtector` interface;
+2. AES-GCM encryption uses exactly 32-byte configured key material and a fresh 96-bit IV;
+3. ciphertext carries a bounded version and key identifier;
+4. normalized email hash uses a separately keyed, domain-separated HMAC-SHA-256;
+5. same normalized identity produces the same email hash while repeated encryption remains non-deterministic;
+6. retention date is derived from configured whole-day policy;
+7. missing, malformed, non-canonical, incorrectly sized, same-purpose key material, invalid key IDs, and invalid retention fail closed;
+8. operation errors expose neither plaintext email nor configured secret values;
+9. focused tests, runtime checks, and full GitHub CI pass;
+10. no public route or form is introduced.

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -64,12 +64,13 @@ P5-02E  Completed through #160
 P5-02F  Completed through #161
 P5-02G  Completed through #162
 P5-02H  Completed through #163
-P5-02I  Submission status-secret environment binding                    In progress
+P5-02I  Submission status-secret environment binding                    Completed #167
+P5-02J  Submission contact protection                                   In progress
 Remaining public Suggest route/form provider and exposure slices        Planned
 P5-02 integration and handoff audit                                    Planned
 ```
 
-P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, and the accepted-as-Candidate transaction boundary. Public route/form wiring with real environment-backed providers is active; a bounded P5-02 integration and handoff audit remains after it.
+P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, and status-secret environment binding. Contact protection is the current bounded provider-wiring slice; public route/form exposure and a bounded P5-02 integration and handoff audit remain afterward.
 
 ---
 
@@ -147,7 +148,9 @@ P5-02G — guarded time-bounded in_review→on_hold operation              Compl
     ↓
 P5-02H — atomic accepted-as-Candidate outcome                          Completed #163
     ↓
-P5-02I — Submission status-secret environment binding                  In progress
+P5-02I — Submission status-secret environment binding                  Completed #167
+    ↓
+P5-02J — Submission contact protection                                 In progress
     ↓
 remaining public Suggest route/form provider and exposure slices       Planned
     ↓

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-02I — Submission status-secret environment binding
+P5-02J — Submission contact protection
 
 ## Current repository state
 
@@ -26,7 +26,8 @@ P5-02I — Submission status-secret environment binding
 - P5-02F bounded in_review→needs_information request boundary is complete through #161.
 - P5-02G bounded in_review→on_hold operation with 30/60/90 day next-review timing is complete through #162.
 - P5-02H atomic accepted-as-Candidate transaction boundary is complete through #163.
-- P5-02I Submission status-secret environment binding is in progress without public route exposure.
+- P5-02I Submission status-secret environment binding is complete through #167.
+- P5-02J Submission contact protection is in progress without public route exposure.
 
 ## Fixed review environment
 
@@ -59,7 +60,9 @@ Before P5-02 implementation or review, read:
 17. `docs/P5_02F_SUGGEST_INFORMATION_REQUEST.md`;
 18. `docs/P5_02G_TIME_BOUNDED_HOLD.md`;
 19. `docs/P5_02H_ACCEPTED_AS_CANDIDATE.md`;
-20. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
+20. `docs/P5_02I_SUBMISSION_STATUS_SECRET_ENVIRONMENT_BINDING.md`;
+21. `docs/P5_02J_SUBMISSION_CONTACT_PROTECTION.md`;
+22. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
 
 Media work must also read `docs/MEDIA_POLICY.md`.
 
@@ -93,7 +96,9 @@ P5-02G  Guarded time-bounded in_review→on_hold operation                  Comp
     ↓
 P5-02H  Atomic accepted-as-Candidate outcome                              Completed #163
     ↓
-P5-02I  Submission status-secret environment binding                     In progress
+P5-02I  Submission status-secret environment binding                     Completed #167
+    ↓
+P5-02J  Submission contact protection                                    In progress
     ↓
 remaining public Suggest route/form provider and exposure slices
     ↓
@@ -152,13 +157,13 @@ Launch readiness must not be claimed until the relevant launch criteria and reta
 
 ## Next
 
-Wire the public Suggest route/form with real environment-backed providers. Then close P5-02 with a bounded integration and handoff audit before P5-03 begins.
+Complete P5-02J Submission contact protection, then continue the remaining public Suggest provider and exposure slices. Close P5-02 with a bounded integration and handoff audit before P5-03 begins.
 
 ## Blocked
 
-No known repository blocker to beginning the public Suggest route/form wiring.
+No known repository blocker to continuing the public Suggest route/form wiring.
 
-Configured environment-backed contact protection, HMAC key binding, distributed rate limiting, opaque bucket-key derivation, and Turnstile bindings are required before the public Suggest route is exposed.
+Configured environment-backed contact protection, distributed rate limiting, opaque bucket-key derivation, and Turnstile bindings are still required before the public Suggest route is exposed. Status-secret HMAC key binding is repository-complete through #167 but still requires configured-environment verification when composed into the route.
 
 `CPM_USER_SUBMISSION_SOURCE_ID` and the Candidate-create allowlist remain required in configured environments for the accepted-as-Candidate transaction path.
 

--- a/scripts/check-runtime-schemas.ts
+++ b/scripts/check-runtime-schemas.ts
@@ -8,6 +8,7 @@ import './check-online-service-importer';
 import './check-phase-2-integration';
 import './check-physical-place-importer';
 import './check-source-provenance';
+import './check-submission-contact-protection';
 import './check-submission-status-secret-environment';
 import './check-verification-events';
 import { assetRegistry, findAssetCandidates } from '../src/registries/assets';

--- a/scripts/check-submission-contact-protection.ts
+++ b/scripts/check-submission-contact-protection.ts
@@ -7,13 +7,9 @@ function encodeBase64Url(bytes: Uint8Array): string {
 }
 
 const protector = createSubmissionContactProtectorFromEnvironment({
-  CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
-    new Uint8Array(32).fill(11),
-  ),
+  CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(new Uint8Array(32).fill(11)),
   CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID: 'contact-check-v1',
-  CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
-    new Uint8Array(32).fill(29),
-  ),
+  CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(new Uint8Array(32).fill(29)),
   CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '30',
 });
 

--- a/scripts/check-submission-contact-protection.ts
+++ b/scripts/check-submission-contact-protection.ts
@@ -1,0 +1,34 @@
+import { createSubmissionContactProtectorFromEnvironment } from '../src/submissions/contact-protection-environment';
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+const protector = createSubmissionContactProtectorFromEnvironment({
+  CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
+    new Uint8Array(32).fill(11),
+  ),
+  CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID: 'contact-check-v1',
+  CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
+    new Uint8Array(32).fill(29),
+  ),
+  CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '30',
+});
+
+const receivedAt = new Date('2026-07-11T00:00:00.000Z');
+const first = await protector.protectEmail('User@Example.com', receivedAt);
+const second = await protector.protectEmail('user@example.com', receivedAt);
+
+if (first.emailHash !== second.emailHash) {
+  throw new Error('Submission contact email hash normalization is not deterministic.');
+}
+if (first.encryptedEmail === second.encryptedEmail) {
+  throw new Error('Submission contact encryption must use randomized ciphertext.');
+}
+if (first.retentionUntil?.toISOString() !== '2026-08-10T00:00:00.000Z') {
+  throw new Error('Submission contact retention calculation is incorrect.');
+}
+
+console.log('Submission contact protection checks passed.');

--- a/src/submissions/contact-protection-environment.ts
+++ b/src/submissions/contact-protection-environment.ts
@@ -1,0 +1,208 @@
+import { z } from 'zod';
+import {
+  protectedSubmissionContactSchema,
+  type SubmissionContactProtector,
+} from './contact-protection';
+
+export const submissionContactEncryptionKeyEnvironmentKey =
+  'CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL' as const;
+export const submissionContactEncryptionKeyIdEnvironmentKey =
+  'CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID' as const;
+export const submissionEmailHashHmacKeyEnvironmentKey =
+  'CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL' as const;
+export const submissionContactRetentionDaysEnvironmentKey =
+  'CPM_SUBMISSION_CONTACT_RETENTION_DAYS' as const;
+
+const encryptionKeyByteLength = 32;
+const minimumHashKeyByteLength = 32;
+const ivByteLength = 12;
+const millisecondsPerDay = 86_400_000;
+const maximumRetentionDays = 3_650;
+const encryptionDomain = 'cryptopaymap:submission-contact-email:v1:';
+const hashDomain = 'cryptopaymap:submission-email-hash:v1:';
+const emailSchema = z.email().max(320);
+const keyIdSchema = z.string().min(1).max(32).regex(/^[A-Za-z0-9_-]+$/);
+const canonicalBase64UrlSchema = z
+  .string()
+  .min(1)
+  .regex(/^[A-Za-z0-9_-]+$/)
+  .refine((value) => value.length % 4 !== 1);
+const retentionDaysSchema = z
+  .string()
+  .regex(/^[1-9][0-9]{0,3}$/)
+  .refine((value) => Number(value) <= maximumRetentionDays);
+
+export const submissionContactProtectionEnvironmentSchema = z
+  .object({
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: canonicalBase64UrlSchema,
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID: keyIdSchema,
+    CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: canonicalBase64UrlSchema,
+    CPM_SUBMISSION_CONTACT_RETENTION_DAYS: retentionDaysSchema,
+  })
+  .strict();
+
+export type SubmissionContactProtectionEnvironment = Readonly<
+  Record<string, unknown> & {
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL?: unknown;
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID?: unknown;
+    CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL?: unknown;
+    CPM_SUBMISSION_CONTACT_RETENTION_DAYS?: unknown;
+  }
+>;
+
+export class SubmissionContactProtectionConfigurationError extends Error {
+  constructor() {
+    super('Submission contact-protection configuration is unavailable.');
+    this.name = 'SubmissionContactProtectionConfigurationError';
+  }
+}
+
+export class SubmissionContactProtectionError extends Error {
+  constructor() {
+    super('Submission contact protection is unavailable.');
+    this.name = 'SubmissionContactProtectionError';
+  }
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return globalThis
+    .btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function decodeCanonicalBase64Url(value: string): Uint8Array {
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const paddingLength = (4 - (normalized.length % 4)) % 4;
+    const decoded = globalThis.atob(normalized.padEnd(normalized.length + paddingLength, '='));
+    const bytes = Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+    if (base64UrlEncode(bytes) !== value) {
+      throw new SubmissionContactProtectionConfigurationError();
+    }
+    return bytes;
+  } catch (error) {
+    if (error instanceof SubmissionContactProtectionConfigurationError) throw error;
+    throw new SubmissionContactProtectionConfigurationError();
+  }
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    difference |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+  return difference === 0;
+}
+
+function hexEncode(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function normalizeEmailForHash(email: string): string {
+  return email.normalize('NFC').toLowerCase();
+}
+
+export function createSubmissionContactProtectorFromEnvironment(
+  environment: SubmissionContactProtectionEnvironment,
+): SubmissionContactProtector {
+  const parsed = submissionContactProtectionEnvironmentSchema.safeParse({
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL:
+      environment.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL,
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID:
+      environment.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID,
+    CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL:
+      environment.CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL,
+    CPM_SUBMISSION_CONTACT_RETENTION_DAYS:
+      environment.CPM_SUBMISSION_CONTACT_RETENTION_DAYS,
+  });
+  if (!parsed.success) throw new SubmissionContactProtectionConfigurationError();
+
+  const encryptionKeyBytes = decodeCanonicalBase64Url(
+    parsed.data.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL,
+  );
+  const hashKeyBytes = decodeCanonicalBase64Url(
+    parsed.data.CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL,
+  );
+  if (
+    encryptionKeyBytes.byteLength !== encryptionKeyByteLength ||
+    hashKeyBytes.byteLength < minimumHashKeyByteLength ||
+    equalBytes(encryptionKeyBytes, hashKeyBytes)
+  ) {
+    throw new SubmissionContactProtectionConfigurationError();
+  }
+
+  const keyId = parsed.data.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID;
+  const retentionDays = Number(parsed.data.CPM_SUBMISSION_CONTACT_RETENTION_DAYS);
+  const encoder = new TextEncoder();
+  const additionalData = encoder.encode(`${encryptionDomain}${keyId}`);
+  const encryptionKeyPromise = crypto.subtle.importKey(
+    'raw',
+    copyArrayBuffer(encryptionKeyBytes),
+    { name: 'AES-GCM' },
+    false,
+    ['encrypt'],
+  );
+  const hashKeyPromise = crypto.subtle.importKey(
+    'raw',
+    copyArrayBuffer(hashKeyBytes),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  return {
+    async protectEmail(email, receivedAt) {
+      const parsedEmail = emailSchema.safeParse(email);
+      if (
+        !parsedEmail.success ||
+        !(receivedAt instanceof Date) ||
+        Number.isNaN(receivedAt.getTime())
+      ) {
+        throw new SubmissionContactProtectionError();
+      }
+
+      try {
+        const retentionUntilMs = receivedAt.getTime() + retentionDays * millisecondsPerDay;
+        if (!Number.isFinite(retentionUntilMs)) throw new SubmissionContactProtectionError();
+
+        const iv = crypto.getRandomValues(new Uint8Array(ivByteLength));
+        const [encryptionKey, hashKey] = await Promise.all([
+          encryptionKeyPromise,
+          hashKeyPromise,
+        ]);
+        const ciphertext = await crypto.subtle.encrypt(
+          { name: 'AES-GCM', iv, additionalData },
+          encryptionKey,
+          encoder.encode(parsedEmail.data),
+        );
+        const signature = await crypto.subtle.sign(
+          'HMAC',
+          hashKey,
+          encoder.encode(`${hashDomain}${normalizeEmailForHash(parsedEmail.data)}`),
+        );
+
+        return protectedSubmissionContactSchema.parse({
+          encryptedEmail: `v1.${keyId}.${base64UrlEncode(iv)}.${base64UrlEncode(
+            new Uint8Array(ciphertext),
+          )}`,
+          emailHash: hexEncode(new Uint8Array(signature)),
+          retentionUntil: new Date(retentionUntilMs),
+        });
+      } catch (error) {
+        if (error instanceof SubmissionContactProtectionError) throw error;
+        throw new SubmissionContactProtectionError();
+      }
+    },
+  };
+}

--- a/src/submissions/contact-protection-environment.ts
+++ b/src/submissions/contact-protection-environment.ts
@@ -21,7 +21,11 @@ const maximumRetentionDays = 3_650;
 const encryptionDomain = 'cryptopaymap:submission-contact-email:v1:';
 const hashDomain = 'cryptopaymap:submission-email-hash:v1:';
 const emailSchema = z.email().max(320);
-const keyIdSchema = z.string().min(1).max(32).regex(/^[A-Za-z0-9_-]+$/);
+const keyIdSchema = z
+  .string()
+  .min(1)
+  .max(32)
+  .regex(/^[A-Za-z0-9_-]+$/);
 const canonicalBase64UrlSchema = z
   .string()
   .min(1)
@@ -67,11 +71,7 @@ export class SubmissionContactProtectionError extends Error {
 function base64UrlEncode(bytes: Uint8Array): string {
   let binary = '';
   for (const byte of bytes) binary += String.fromCharCode(byte);
-  return globalThis
-    .btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/g, '');
+  return globalThis.btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
 function decodeCanonicalBase64Url(value: string): Uint8Array {
@@ -119,12 +119,10 @@ export function createSubmissionContactProtectorFromEnvironment(
   const parsed = submissionContactProtectionEnvironmentSchema.safeParse({
     CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL:
       environment.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL,
-    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID:
-      environment.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID,
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID: environment.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID,
     CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL:
       environment.CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL,
-    CPM_SUBMISSION_CONTACT_RETENTION_DAYS:
-      environment.CPM_SUBMISSION_CONTACT_RETENTION_DAYS,
+    CPM_SUBMISSION_CONTACT_RETENTION_DAYS: environment.CPM_SUBMISSION_CONTACT_RETENTION_DAYS,
   });
   if (!parsed.success) throw new SubmissionContactProtectionConfigurationError();
 
@@ -177,10 +175,7 @@ export function createSubmissionContactProtectorFromEnvironment(
         if (!Number.isFinite(retentionUntilMs)) throw new SubmissionContactProtectionError();
 
         const iv = crypto.getRandomValues(new Uint8Array(ivByteLength));
-        const [encryptionKey, hashKey] = await Promise.all([
-          encryptionKeyPromise,
-          hashKeyPromise,
-        ]);
+        const [encryptionKey, hashKey] = await Promise.all([encryptionKeyPromise, hashKeyPromise]);
         const ciphertext = await crypto.subtle.encrypt(
           { name: 'AES-GCM', iv, additionalData },
           encryptionKey,

--- a/tests/submission-contact-protection-environment.test.ts
+++ b/tests/submission-contact-protection-environment.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSubmissionContactProtectorFromEnvironment,
+  SubmissionContactProtectionConfigurationError,
+  SubmissionContactProtectionError,
+} from '../src/submissions/contact-protection-environment';
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingLength = (4 - (normalized.length % 4)) % 4;
+  return Uint8Array.from(
+    atob(normalized.padEnd(normalized.length + paddingLength, '=')),
+    (character) => character.charCodeAt(0),
+  );
+}
+
+function environment(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
+      new Uint8Array(32).fill(11),
+    ),
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID: 'contact-2026-01',
+    CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
+      new Uint8Array(32).fill(29),
+    ),
+    CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '30',
+    ...overrides,
+  };
+}
+
+async function decryptEnvelope(encryptedEmail: string, keyBytes: Uint8Array): Promise<string> {
+  const [version, keyId, ivEncoded, ciphertextEncoded] = encryptedEmail.split('.');
+  expect(version).toBe('v1');
+  expect(keyId).toBe('contact-2026-01');
+  const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM' }, false, [
+    'decrypt',
+  ]);
+  const plaintext = await crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: decodeBase64Url(ivEncoded ?? ''),
+      additionalData: new TextEncoder().encode(
+        'cryptopaymap:submission-contact-email:v1:contact-2026-01',
+      ),
+    },
+    key,
+    decodeBase64Url(ciphertextEncoded ?? ''),
+  );
+  return new TextDecoder().decode(plaintext);
+}
+
+describe('P5-02J Submission contact protection', () => {
+  it('encrypts the validated email and assigns configured retention', async () => {
+    const receivedAt = new Date('2026-07-11T00:00:00.000Z');
+    const protector = createSubmissionContactProtectorFromEnvironment(environment());
+    const protectedContact = await protector.protectEmail('User@Example.com', receivedAt);
+
+    expect(protectedContact.encryptedEmail).toMatch(
+      /^v1\.contact-2026-01\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/,
+    );
+    expect(protectedContact.emailHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(protectedContact.retentionUntil).toEqual(new Date('2026-08-10T00:00:00.000Z'));
+    await expect(
+      decryptEnvelope(protectedContact.encryptedEmail, new Uint8Array(32).fill(11)),
+    ).resolves.toBe('User@Example.com');
+  });
+
+  it('uses randomized ciphertext for the same email', async () => {
+    const protector = createSubmissionContactProtectorFromEnvironment(environment());
+    const receivedAt = new Date('2026-07-11T00:00:00.000Z');
+    const first = await protector.protectEmail('user@example.com', receivedAt);
+    const second = await protector.protectEmail('user@example.com', receivedAt);
+
+    expect(second.encryptedEmail).not.toBe(first.encryptedEmail);
+    expect(second.emailHash).toBe(first.emailHash);
+  });
+
+  it('hashes normalized email identity deterministically', async () => {
+    const protector = createSubmissionContactProtectorFromEnvironment(environment());
+    const receivedAt = new Date('2026-07-11T00:00:00.000Z');
+    const first = await protector.protectEmail('User@Example.COM', receivedAt);
+    const second = await protector.protectEmail('user@example.com', receivedAt);
+
+    expect(second.emailHash).toBe(first.emailHash);
+  });
+
+  it('changes email hashes when the HMAC key changes', async () => {
+    const receivedAt = new Date('2026-07-11T00:00:00.000Z');
+    const first = createSubmissionContactProtectorFromEnvironment(environment());
+    const second = createSubmissionContactProtectorFromEnvironment(
+      environment({
+        CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
+          new Uint8Array(32).fill(31),
+        ),
+      }),
+    );
+
+    expect((await first.protectEmail('user@example.com', receivedAt)).emailHash).not.toBe(
+      (await second.protectEmail('user@example.com', receivedAt)).emailHash,
+    );
+  });
+
+  it.each([
+    ['missing encryption key', { CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: undefined }],
+    ['empty encryption key', { CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: '' }],
+    ['short encryption key', {
+      CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
+        new Uint8Array(31).fill(11),
+      ),
+    }],
+    ['long encryption key', {
+      CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
+        new Uint8Array(33).fill(11),
+      ),
+    }],
+    ['short hash key', {
+      CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
+        new Uint8Array(31).fill(29),
+      ),
+    }],
+    ['same encryption and hash key material', {
+      CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
+        new Uint8Array(32).fill(11),
+      ),
+    }],
+    ['invalid key id', { CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID: 'contact key' }],
+    ['zero retention', { CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '0' }],
+    ['excessive retention', { CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '3651' }],
+    ['non-integer retention', { CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '30.5' }],
+  ])('fails closed for %s', (_name, overrides) => {
+    expect(() => createSubmissionContactProtectorFromEnvironment(environment(overrides))).toThrow(
+      SubmissionContactProtectionConfigurationError,
+    );
+  });
+
+  it('rejects padded or malformed key encoding', () => {
+    const valid = String(environment().CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL);
+    expect(() =>
+      createSubmissionContactProtectorFromEnvironment(
+        environment({ CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: `${valid}=` }),
+      ),
+    ).toThrow(SubmissionContactProtectionConfigurationError);
+    expect(() =>
+      createSubmissionContactProtectorFromEnvironment(
+        environment({ CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: 'not+base64url' }),
+      ),
+    ).toThrow(SubmissionContactProtectionConfigurationError);
+  });
+
+  it('does not include secret material in configuration errors', () => {
+    const secret = 'sensitive+invalid/value=';
+    let caught: unknown;
+    try {
+      createSubmissionContactProtectorFromEnvironment(
+        environment({ CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: secret }),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SubmissionContactProtectionConfigurationError);
+    expect(String(caught)).not.toContain(secret);
+  });
+
+  it('fails with a bounded operation error for invalid email or timestamp', async () => {
+    const protector = createSubmissionContactProtectorFromEnvironment(environment());
+    await expect(
+      protector.protectEmail('not-an-email', new Date('2026-07-11T00:00:00.000Z')),
+    ).rejects.toBeInstanceOf(SubmissionContactProtectionError);
+    await expect(
+      protector.protectEmail('user@example.com', new Date(Number.NaN)),
+    ).rejects.toBeInstanceOf(SubmissionContactProtectionError);
+  });
+
+  it('accepts explicit environment records that contain unrelated server bindings', async () => {
+    const protector = createSubmissionContactProtectorFromEnvironment(
+      environment({ DATABASE_URL: 'postgresql://example.invalid/db' }),
+    );
+    await expect(
+      protector.protectEmail('user@example.com', new Date('2026-07-11T00:00:00.000Z')),
+    ).resolves.toMatchObject({ emailHash: expect.stringMatching(/^[a-f0-9]{64}$/) });
+  });
+});

--- a/tests/submission-contact-protection-environment.test.ts
+++ b/tests/submission-contact-protection-environment.test.ts
@@ -20,15 +20,17 @@ function decodeBase64Url(value: string): Uint8Array {
   );
 }
 
+function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
 function environment(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
-    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
-      new Uint8Array(32).fill(11),
-    ),
+    CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(new Uint8Array(32).fill(11)),
     CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID: 'contact-2026-01',
-    CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
-      new Uint8Array(32).fill(29),
-    ),
+    CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(new Uint8Array(32).fill(29)),
     CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '30',
     ...overrides,
   };
@@ -38,19 +40,23 @@ async function decryptEnvelope(encryptedEmail: string, keyBytes: Uint8Array): Pr
   const [version, keyId, ivEncoded, ciphertextEncoded] = encryptedEmail.split('.');
   expect(version).toBe('v1');
   expect(keyId).toBe('contact-2026-01');
-  const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM' }, false, [
-    'decrypt',
-  ]);
+  const key = await crypto.subtle.importKey(
+    'raw',
+    copyArrayBuffer(keyBytes),
+    { name: 'AES-GCM' },
+    false,
+    ['decrypt'],
+  );
   const plaintext = await crypto.subtle.decrypt(
     {
       name: 'AES-GCM',
-      iv: decodeBase64Url(ivEncoded ?? ''),
+      iv: copyArrayBuffer(decodeBase64Url(ivEncoded ?? '')),
       additionalData: new TextEncoder().encode(
         'cryptopaymap:submission-contact-email:v1:contact-2026-01',
       ),
     },
     key,
-    decodeBase64Url(ciphertextEncoded ?? ''),
+    copyArrayBuffer(decodeBase64Url(ciphertextEncoded ?? '')),
   );
   return new TextDecoder().decode(plaintext);
 }
@@ -95,9 +101,7 @@ describe('P5-02J Submission contact protection', () => {
     const first = createSubmissionContactProtectorFromEnvironment(environment());
     const second = createSubmissionContactProtectorFromEnvironment(
       environment({
-        CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
-          new Uint8Array(32).fill(31),
-        ),
+        CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(new Uint8Array(32).fill(31)),
       }),
     );
 
@@ -109,26 +113,34 @@ describe('P5-02J Submission contact protection', () => {
   it.each([
     ['missing encryption key', { CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: undefined }],
     ['empty encryption key', { CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: '' }],
-    ['short encryption key', {
-      CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
-        new Uint8Array(31).fill(11),
-      ),
-    }],
-    ['long encryption key', {
-      CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
-        new Uint8Array(33).fill(11),
-      ),
-    }],
-    ['short hash key', {
-      CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
-        new Uint8Array(31).fill(29),
-      ),
-    }],
-    ['same encryption and hash key material', {
-      CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(
-        new Uint8Array(32).fill(11),
-      ),
-    }],
+    [
+      'short encryption key',
+      {
+        CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
+          new Uint8Array(31).fill(11),
+        ),
+      },
+    ],
+    [
+      'long encryption key',
+      {
+        CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL: encodeBase64Url(
+          new Uint8Array(33).fill(11),
+        ),
+      },
+    ],
+    [
+      'short hash key',
+      {
+        CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(new Uint8Array(31).fill(29)),
+      },
+    ],
+    [
+      'same encryption and hash key material',
+      {
+        CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL: encodeBase64Url(new Uint8Array(32).fill(11)),
+      },
+    ],
     ['invalid key id', { CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID: 'contact key' }],
     ['zero retention', { CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '0' }],
     ['excessive retention', { CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '3651' }],


### PR DESCRIPTION
## Implementation item

P5-02J — Submission contact protection

## Purpose

Implement the production-capable `SubmissionContactProtector` required by the existing private intake service, without exposing public Suggest intake.

## Scope

- add explicit server-only environment binding for contact protection;
- encrypt validated contact email with AES-256-GCM and a fresh 96-bit IV;
- persist a versioned/key-identified ciphertext envelope;
- derive a deterministic normalized-email hash with separately keyed, domain-separated HMAC-SHA-256;
- reject identical encryption and hashing key material;
- derive `retentionUntil` from a configured whole-day retention policy;
- add focused tests, runtime schema coverage, environment examples, and bounded tracking/specification updates.

## Environment contract

- `CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL`: exactly 32 random bytes, canonical unpadded Base64URL;
- `CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID`: bounded non-secret key identifier;
- `CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL`: separate HMAC key, at least 32 random bytes, canonical unpadded Base64URL;
- `CPM_SUBMISSION_CONTACT_RETENTION_DAYS`: configured whole days from 1 through 3650.

The exact deployed retention period remains an operational/privacy decision that must be disclosed before public submission launch.

## Security and privacy invariants

- plaintext email enters only the contact-protection boundary;
- output matches the existing `SubmissionContactProtector` interface and protected contact schema;
- encryption and email hashing use separate purpose-specific keys;
- repeated encryption is randomized while normalized email hash is deterministic;
- configuration and operation errors are bounded and contain neither plaintext email nor configured secret values;
- no provider secret uses a `PUBLIC_*` environment name;
- public receipts and public status projections are unchanged;
- public Suggest intake remains unavailable.

## Explicit exclusions

- no contact decryption workflow;
- no email delivery;
- no status-secret changes;
- no opaque rate-limit bucket derivation;
- no distributed rate limiter;
- no trusted remote-IP extraction;
- no Turnstile changes;
- no CSP changes;
- no public API route;
- no public Suggest form/page;
- no canonical, export, or publication mutation;
- no P5-03 work.

## Validation

This branch adds focused Vitest coverage and a runtime contract check. GitHub CI is the authoritative validation gate for format, lint, TypeScript/Astro, runtime schemas, migration drift, full unit/component tests, build, accessibility, and staging artifacts.

## Remaining work

Later bounded slices still need opaque rate-limit bucket derivation, trusted edge identity extraction, distributed rate limiting, Turnstile environment/browser wiring, public HTTP composition, Suggest UI/CSP, configured-environment verification, and the final P5-02 integration/handoff audit.