### PR TITLE
P5-02K: add opaque Submission rate-limit bucket derivation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_ID=
 CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL=
 # Configured contact retention period in whole days, from 1 through 3650.
 CPM_SUBMISSION_CONTACT_RETENTION_DAYS=
+
+# Server-only keyed derivation secret for opaque Submission rate-limit buckets.
+# Canonical unpadded Base64URL encoding of at least 32 random bytes.
+CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL=

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -217,7 +217,9 @@ P5-02H — atomic accepted-as-Candidate outcome                              Com
     ↓
 P5-02I — Submission status-secret environment binding                     Completed #167
     ↓
-P5-02J — Submission contact protection                                    In progress
+P5-02J — Submission contact protection                                    Completed #168
+    ↓
+P5-02K — Opaque Submission rate-limit bucket derivation                    In progress
     ↓
 remaining public Suggest route/form provider and exposure slices
     ↓
@@ -309,7 +311,15 @@ P5-02I established:
 - bounded configuration failures without configured-value disclosure;
 - no public route exposure.
 
-P5-02J now establishes production-capable protected contact output for the existing private intake service while keeping public intake unavailable.
+P5-02J established:
+
+- production-capable AES-GCM contact encryption with randomized ciphertext;
+- separate keyed normalized-email HMAC hashing;
+- explicit key identity and configured retention date derivation;
+- bounded configuration and operation failures without secret or plaintext email disclosure;
+- no public route exposure.
+
+P5-02K now establishes privacy-preserving opaque rate-limit bucket derivation for a later trusted edge identity input while leaving trusted-header extraction and the distributed provider out of scope.
 
 The active P5-02 work must continue the remaining public Suggest provider and exposure slices. P5-02 then closes with a bounded integration and handoff audit before P5-03 begins.
 

--- a/docs/P5_02K_OPAQUE_RATE_LIMIT_BUCKET_DERIVATION.md
+++ b/docs/P5_02K_OPAQUE_RATE_LIMIT_BUCKET_DERIVATION.md
@@ -1,0 +1,70 @@
+# P5-02K opaque Submission rate-limit bucket derivation
+
+**Implementation item:** P5-02K  
+**Status:** In progress  
+**Last updated:** 2026-07-11
+
+## Purpose
+
+P5-02K derives privacy-preserving opaque rate-limit bucket keys from a bounded trusted edge identity input. It supplies the existing abuse-control contract with `rl_<opaque>` values without storing or exposing the raw identity.
+
+This slice does not extract remote IP addresses and does not choose or implement the distributed rate-limit provider.
+
+## Environment contract
+
+The server-only key is:
+
+```text
+CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL
+```
+
+The value is canonical unpadded Base64URL and must decode to at least 32 bytes. Missing, empty, malformed, padded, non-canonical, or too-short values fail closed with a bounded configuration error that does not contain configured material.
+
+The binding accepts an explicit environment record so later Cloudflare Pages composition can supply `context.env`. The key is not a `PUBLIC_*` value.
+
+## Derivation contract
+
+```text
+bounded trusted edge identity
+→ HMAC-SHA-256 with server-only purpose-specific key
+→ domain-separated signature
+→ canonical Base64URL
+→ rl_<opaque>
+```
+
+The HMAC domain is versioned and specific to Submission rate-limit bucket derivation. The output is deterministic for the same key and edge identity, differs for different identities or keys, and matches the existing abuse-control request contract.
+
+The raw edge identity is not returned by the derivation boundary and is not embedded in the bucket output.
+
+## Security and privacy invariants
+
+P5-02K preserves these boundaries:
+
+- raw edge identity is accepted only as ephemeral derivation input;
+- derived bucket values are opaque keyed outputs;
+- the derivation key remains server-only and is never logged;
+- configuration and derivation errors contain neither raw identity nor configured secret values;
+- output matches the existing `rl_[A-Za-z0-9_-]` abuse-control shape;
+- no in-memory or distributed rate limiter is selected or composed;
+- repository checks do not claim trusted-header extraction or live configured-environment verification.
+
+## Out of scope
+
+P5-02K does not implement trusted Cloudflare remote-IP extraction, forwarded-header trust policy, distributed rate limiting, rate-limit persistence, Turnstile changes, HTTP error mapping, Retry-After headers, a public API route, a public form/page, CSP, canonical mutation, export, or publication.
+
+Public Suggest intake remains unavailable. P5-03 remains blocked.
+
+## Completion criteria
+
+P5-02K is complete when:
+
+1. explicit server environment input creates a bounded rate-limit bucket deriver;
+2. key parsing is strict, canonical, and fail-closed;
+3. key material decodes to at least 32 bytes;
+4. identical key and identity input produce identical bucket keys;
+5. different identities and different configured keys produce different bucket keys;
+6. output matches the existing `rl_<opaque>` contract;
+7. output does not contain the raw input identity;
+8. invalid identity input fails with a bounded derivation error;
+9. focused tests, runtime checks, and full GitHub CI pass;
+10. no public route or rate-limit provider is introduced.

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -65,12 +65,13 @@ P5-02F  Completed through #161
 P5-02G  Completed through #162
 P5-02H  Completed through #163
 P5-02I  Submission status-secret environment binding                    Completed #167
-P5-02J  Submission contact protection                                   In progress
+P5-02J  Submission contact protection                                   Completed #168
+P5-02K  Opaque Submission rate-limit bucket derivation                   In progress
 Remaining public Suggest route/form provider and exposure slices        Planned
 P5-02 integration and handoff audit                                    Planned
 ```
 
-P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, and status-secret environment binding. Contact protection is the current bounded provider-wiring slice; public route/form exposure and a bounded P5-02 integration and handoff audit remain afterward.
+P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, status-secret environment binding, and contact protection. Opaque bucket derivation is the current bounded provider-wiring slice; public route/form exposure and a bounded P5-02 integration and handoff audit remain afterward.
 
 ---
 
@@ -150,7 +151,9 @@ P5-02H — atomic accepted-as-Candidate outcome                          Complet
     ↓
 P5-02I — Submission status-secret environment binding                  Completed #167
     ↓
-P5-02J — Submission contact protection                                 In progress
+P5-02J — Submission contact protection                                 Completed #168
+    ↓
+P5-02K — Opaque Submission rate-limit bucket derivation                In progress
     ↓
 remaining public Suggest route/form provider and exposure slices       Planned
     ↓

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-02J — Submission contact protection
+P5-02K — Opaque Submission rate-limit bucket derivation
 
 ## Current repository state
 
@@ -27,7 +27,8 @@ P5-02J — Submission contact protection
 - P5-02G bounded in_review→on_hold operation with 30/60/90 day next-review timing is complete through #162.
 - P5-02H atomic accepted-as-Candidate transaction boundary is complete through #163.
 - P5-02I Submission status-secret environment binding is complete through #167.
-- P5-02J Submission contact protection is in progress without public route exposure.
+- P5-02J Submission contact protection is complete through #168.
+- P5-02K opaque Submission rate-limit bucket derivation is in progress without public route exposure.
 
 ## Fixed review environment
 
@@ -62,7 +63,8 @@ Before P5-02 implementation or review, read:
 19. `docs/P5_02H_ACCEPTED_AS_CANDIDATE.md`;
 20. `docs/P5_02I_SUBMISSION_STATUS_SECRET_ENVIRONMENT_BINDING.md`;
 21. `docs/P5_02J_SUBMISSION_CONTACT_PROTECTION.md`;
-22. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
+22. `docs/P5_02K_OPAQUE_RATE_LIMIT_BUCKET_DERIVATION.md`;
+23. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
 
 Media work must also read `docs/MEDIA_POLICY.md`.
 
@@ -98,7 +100,9 @@ P5-02H  Atomic accepted-as-Candidate outcome                              Comple
     ↓
 P5-02I  Submission status-secret environment binding                     Completed #167
     ↓
-P5-02J  Submission contact protection                                    In progress
+P5-02J  Submission contact protection                                    Completed #168
+    ↓
+P5-02K  Opaque Submission rate-limit bucket derivation                    In progress
     ↓
 remaining public Suggest route/form provider and exposure slices
     ↓
@@ -157,13 +161,13 @@ Launch readiness must not be claimed until the relevant launch criteria and reta
 
 ## Next
 
-Complete P5-02J Submission contact protection, then continue the remaining public Suggest provider and exposure slices. Close P5-02 with a bounded integration and handoff audit before P5-03 begins.
+Complete P5-02K opaque rate-limit bucket derivation, then continue trusted edge identity extraction and the remaining public Suggest provider/exposure slices. Close P5-02 with a bounded integration and handoff audit before P5-03 begins.
 
 ## Blocked
 
 No known repository blocker to continuing the public Suggest route/form wiring.
 
-Configured environment-backed contact protection, distributed rate limiting, opaque bucket-key derivation, and Turnstile bindings are still required before the public Suggest route is exposed. Status-secret HMAC key binding is repository-complete through #167 but still requires configured-environment verification when composed into the route.
+Configured-environment trusted edge identity extraction, distributed rate limiting, Turnstile bindings, and complete route composition remain required before the public Suggest route is exposed. Status-secret HMAC binding is repository-complete through #167 and contact protection through #168, but both still require configured-environment verification when composed into the route.
 
 `CPM_USER_SUBMISSION_SOURCE_ID` and the Candidate-create allowlist remain required in configured environments for the accepted-as-Candidate transaction path.
 

--- a/scripts/check-runtime-schemas.ts
+++ b/scripts/check-runtime-schemas.ts
@@ -9,6 +9,7 @@ import './check-phase-2-integration';
 import './check-physical-place-importer';
 import './check-source-provenance';
 import './check-submission-contact-protection';
+import './check-submission-rate-limit-bucket';
 import './check-submission-status-secret-environment';
 import './check-verification-events';
 import { assetRegistry, findAssetCandidates } from '../src/registries/assets';

--- a/scripts/check-submission-rate-limit-bucket.ts
+++ b/scripts/check-submission-rate-limit-bucket.ts
@@ -1,0 +1,26 @@
+import { createSubmissionRateLimitBucketDeriverFromEnvironment } from '../src/submissions/rate-limit-bucket-environment';
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+const deriver = createSubmissionRateLimitBucketDeriverFromEnvironment({
+  CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: encodeBase64Url(
+    new Uint8Array(32).fill(17),
+  ),
+});
+
+const rawIdentity = '203.0.113.42';
+const first = await deriver.deriveBucketKey(rawIdentity);
+const second = await deriver.deriveBucketKey(rawIdentity);
+
+if (first !== second || !/^rl_[A-Za-z0-9_-]{16,128}$/.test(first)) {
+  throw new Error('Submission rate-limit bucket derivation contract failed.');
+}
+if (first.includes(rawIdentity)) {
+  throw new Error('Submission rate-limit bucket key exposed raw edge identity.');
+}
+
+console.log('Submission rate-limit bucket derivation checks passed.');

--- a/scripts/check-submission-rate-limit-bucket.ts
+++ b/scripts/check-submission-rate-limit-bucket.ts
@@ -7,9 +7,7 @@ function encodeBase64Url(bytes: Uint8Array): string {
 }
 
 const deriver = createSubmissionRateLimitBucketDeriverFromEnvironment({
-  CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: encodeBase64Url(
-    new Uint8Array(32).fill(17),
-  ),
+  CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: encodeBase64Url(new Uint8Array(32).fill(17)),
 });
 
 const rawIdentity = '203.0.113.42';

--- a/src/submissions/rate-limit-bucket-environment.ts
+++ b/src/submissions/rate-limit-bucket-environment.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod';
+
+export const submissionRateLimitBucketHmacEnvironmentKey =
+  'CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL' as const;
+
+const minimumKeyByteLength = 32;
+const domain = 'cryptopaymap:submission-rate-limit-bucket:v1:';
+const edgeIdentitySchema = z.string().min(1).max(64);
+const bucketKeySchema = z.string().regex(/^rl_[A-Za-z0-9_-]{16,128}$/);
+const canonicalBase64UrlSchema = z
+  .string()
+  .min(1)
+  .regex(/^[A-Za-z0-9_-]+$/)
+  .refine((value) => value.length % 4 !== 1);
+
+export const submissionRateLimitBucketEnvironmentSchema = z
+  .object({ CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: canonicalBase64UrlSchema })
+  .strict();
+
+export type SubmissionRateLimitBucketEnvironment = Readonly<
+  Record<string, unknown> & { CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL?: unknown }
+>;
+
+export interface SubmissionRateLimitBucketDeriver {
+  deriveBucketKey(edgeIdentity: string): Promise<string>;
+}
+
+export class SubmissionRateLimitBucketConfigurationError extends Error {
+  constructor() {
+    super('Submission rate-limit bucket configuration is unavailable.');
+    this.name = 'SubmissionRateLimitBucketConfigurationError';
+  }
+}
+
+export class SubmissionRateLimitBucketDerivationError extends Error {
+  constructor() {
+    super('Submission rate-limit bucket derivation is unavailable.');
+    this.name = 'SubmissionRateLimitBucketDerivationError';
+  }
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return globalThis.btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function decodeCanonicalBase64Url(value: string): Uint8Array {
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const paddingLength = (4 - (normalized.length % 4)) % 4;
+    const decoded = globalThis.atob(normalized.padEnd(normalized.length + paddingLength, '='));
+    const bytes = Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+    if (base64UrlEncode(bytes) !== value || bytes.byteLength < minimumKeyByteLength) {
+      throw new SubmissionRateLimitBucketConfigurationError();
+    }
+    return bytes;
+  } catch (error) {
+    if (error instanceof SubmissionRateLimitBucketConfigurationError) throw error;
+    throw new SubmissionRateLimitBucketConfigurationError();
+  }
+}
+
+function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+export function createSubmissionRateLimitBucketDeriverFromEnvironment(
+  environment: SubmissionRateLimitBucketEnvironment,
+): SubmissionRateLimitBucketDeriver {
+  const parsed = submissionRateLimitBucketEnvironmentSchema.safeParse({
+    CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL:
+      environment.CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL,
+  });
+  if (!parsed.success) throw new SubmissionRateLimitBucketConfigurationError();
+
+  const keyBytes = decodeCanonicalBase64Url(
+    parsed.data.CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL,
+  );
+  const keyPromise = crypto.subtle.importKey(
+    'raw',
+    copyArrayBuffer(keyBytes),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const encoder = new TextEncoder();
+
+  return {
+    async deriveBucketKey(edgeIdentity) {
+      const parsedIdentity = edgeIdentitySchema.safeParse(edgeIdentity);
+      if (!parsedIdentity.success) throw new SubmissionRateLimitBucketDerivationError();
+
+      try {
+        const key = await keyPromise;
+        const signature = await crypto.subtle.sign(
+          'HMAC',
+          key,
+          encoder.encode(`${domain}${parsedIdentity.data}`),
+        );
+        return bucketKeySchema.parse(`rl_${base64UrlEncode(new Uint8Array(signature))}`);
+      } catch (error) {
+        if (error instanceof SubmissionRateLimitBucketDerivationError) throw error;
+        throw new SubmissionRateLimitBucketDerivationError();
+      }
+    },
+  };
+}

--- a/tests/submission-rate-limit-bucket-environment.test.ts
+++ b/tests/submission-rate-limit-bucket-environment.test.ts
@@ -60,9 +60,9 @@ describe('P5-02K opaque Submission rate-limit bucket derivation', () => {
     ['padded', { CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: `${'A'.repeat(43)}=` }],
     ['too short', environment(new Uint8Array(31).fill(17))],
   ])('fails closed for %s configuration', (_name, configuredEnvironment) => {
-    expect(() => createSubmissionRateLimitBucketDeriverFromEnvironment(configuredEnvironment)).toThrow(
-      SubmissionRateLimitBucketConfigurationError,
-    );
+    expect(() =>
+      createSubmissionRateLimitBucketDeriverFromEnvironment(configuredEnvironment),
+    ).toThrow(SubmissionRateLimitBucketConfigurationError);
   });
 
   it('accepts exactly 32 decoded key bytes', async () => {

--- a/tests/submission-rate-limit-bucket-environment.test.ts
+++ b/tests/submission-rate-limit-bucket-environment.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSubmissionRateLimitBucketDeriverFromEnvironment,
+  SubmissionRateLimitBucketConfigurationError,
+  SubmissionRateLimitBucketDerivationError,
+} from '../src/submissions/rate-limit-bucket-environment';
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function environment(keyBytes = new Uint8Array(32).fill(17)): Record<string, unknown> {
+  return {
+    CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: encodeBase64Url(keyBytes),
+  };
+}
+
+describe('P5-02K opaque Submission rate-limit bucket derivation', () => {
+  it('derives an opaque bucket key accepted by the abuse-control contract', async () => {
+    const rawIdentity = '203.0.113.42';
+    const deriver = createSubmissionRateLimitBucketDeriverFromEnvironment(environment());
+    const bucketKey = await deriver.deriveBucketKey(rawIdentity);
+
+    expect(bucketKey).toMatch(/^rl_[A-Za-z0-9_-]{16,128}$/);
+    expect(bucketKey).not.toContain(rawIdentity);
+  });
+
+  it('is deterministic for the same configured key and edge identity', async () => {
+    const first = createSubmissionRateLimitBucketDeriverFromEnvironment(environment());
+    const second = createSubmissionRateLimitBucketDeriverFromEnvironment(environment());
+
+    await expect(first.deriveBucketKey('2001:db8::1')).resolves.toBe(
+      await second.deriveBucketKey('2001:db8::1'),
+    );
+  });
+
+  it('separates different edge identities', async () => {
+    const deriver = createSubmissionRateLimitBucketDeriverFromEnvironment(environment());
+    expect(await deriver.deriveBucketKey('203.0.113.1')).not.toBe(
+      await deriver.deriveBucketKey('203.0.113.2'),
+    );
+  });
+
+  it('separates configured HMAC keys', async () => {
+    const first = createSubmissionRateLimitBucketDeriverFromEnvironment(environment());
+    const second = createSubmissionRateLimitBucketDeriverFromEnvironment(
+      environment(new Uint8Array(32).fill(19)),
+    );
+    expect(await first.deriveBucketKey('203.0.113.42')).not.toBe(
+      await second.deriveBucketKey('203.0.113.42'),
+    );
+  });
+
+  it.each([
+    ['missing', {}],
+    ['empty', { CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: '' }],
+    ['malformed', { CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: 'not+base64url' }],
+    ['padded', { CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: `${'A'.repeat(43)}=` }],
+    ['too short', environment(new Uint8Array(31).fill(17))],
+  ])('fails closed for %s configuration', (_name, configuredEnvironment) => {
+    expect(() => createSubmissionRateLimitBucketDeriverFromEnvironment(configuredEnvironment)).toThrow(
+      SubmissionRateLimitBucketConfigurationError,
+    );
+  });
+
+  it('accepts exactly 32 decoded key bytes', async () => {
+    const deriver = createSubmissionRateLimitBucketDeriverFromEnvironment(
+      environment(new Uint8Array(32).fill(1)),
+    );
+    await expect(deriver.deriveBucketKey('203.0.113.42')).resolves.toMatch(/^rl_/);
+  });
+
+  it('does not include configured secret material in errors', () => {
+    const secret = 'sensitive+invalid/value=';
+    let caught: unknown;
+    try {
+      createSubmissionRateLimitBucketDeriverFromEnvironment({
+        CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL: secret,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SubmissionRateLimitBucketConfigurationError);
+    expect(String(caught)).not.toContain(secret);
+  });
+
+  it.each(['', 'x'.repeat(65)])('rejects invalid edge identity input', async (edgeIdentity) => {
+    const deriver = createSubmissionRateLimitBucketDeriverFromEnvironment(environment());
+    await expect(deriver.deriveBucketKey(edgeIdentity)).rejects.toBeInstanceOf(
+      SubmissionRateLimitBucketDerivationError,
+    );
+  });
+
+  it('accepts explicit environment records with unrelated server bindings', async () => {
+    const deriver = createSubmissionRateLimitBucketDeriverFromEnvironment({
+      ...environment(),
+      DATABASE_URL: 'postgresql://example.invalid/db',
+    });
+    await expect(deriver.deriveBucketKey('203.0.113.42')).resolves.toMatch(/^rl_/);
+  });
+});


### PR DESCRIPTION
## Implementation item

P5-02K — Opaque Submission rate-limit bucket derivation

## Purpose

Derive privacy-preserving opaque rate-limit bucket keys from a bounded trusted edge identity input for the existing abuse-control contract, without exposing a public route or selecting the distributed rate-limit provider.

## Scope

- add explicit server-only HMAC environment binding;
- strictly decode canonical unpadded Base64URL key material of at least 32 bytes;
- derive domain-separated HMAC-SHA-256 output;
- encode the output as `rl_<opaque>` matching the existing abuse-control request shape;
- keep derivation deterministic for the same key/input and separated across identities or configured keys;
- add focused tests, runtime schema coverage, environment example, and bounded tracking/specification updates.

## Environment contract

- `CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL`: server-only, canonical unpadded Base64URL, at least 32 decoded bytes.

## Security and privacy invariants

- raw edge identity is accepted only as ephemeral derivation input;
- derived bucket values do not contain the raw input identity;
- the HMAC key remains server-only and is never logged;
- configuration and derivation failures are bounded and contain neither raw identity nor configured secret values;
- output matches the existing `rl_[A-Za-z0-9_-]` abuse-control contract;
- no in-memory or distributed rate limiter is composed;
- public Suggest intake remains unavailable.

## Explicit exclusions

- no trusted Cloudflare remote-IP extraction;
- no forwarded-header trust policy;
- no distributed rate-limit provider or persistence;
- no Turnstile changes;
- no Retry-After HTTP behavior;
- no public API route;
- no public Suggest form/page;
- no CSP changes;
- no canonical, export, or publication mutation;
- no P5-03 work.

## Validation

This branch adds focused Vitest coverage and a runtime contract check. GitHub CI is the authoritative validation gate for format, lint, TypeScript/Astro, runtime schemas, migration drift, full unit/component tests, build, accessibility, and staging artifacts.

## Remaining work

Later bounded slices still need trusted edge identity extraction, a production distributed rate-limit adapter, Turnstile environment/browser wiring, public HTTP composition and safe error mapping, Suggest UI/CSP, configured-environment verification, and the final P5-02 integration/handoff audit.