### PR TITLE
P5-02L: add trusted Cloudflare edge identity extraction

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -219,7 +219,9 @@ P5-02I — Submission status-secret environment binding                     Comp
     ↓
 P5-02J — Submission contact protection                                    Completed #168
     ↓
-P5-02K — Opaque Submission rate-limit bucket derivation                    In progress
+P5-02K — Opaque Submission rate-limit bucket derivation                    Completed #169
+    ↓
+P5-02L — Trusted Cloudflare edge identity extraction                       In progress
     ↓
 remaining public Suggest route/form provider and exposure slices
     ↓
@@ -319,7 +321,14 @@ P5-02J established:
 - bounded configuration and operation failures without secret or plaintext email disclosure;
 - no public route exposure.
 
-P5-02K now establishes privacy-preserving opaque rate-limit bucket derivation for a later trusted edge identity input while leaving trusted-header extraction and the distributed provider out of scope.
+P5-02K established:
+
+- explicit server-only HMAC binding for opaque rate-limit bucket derivation;
+- versioned domain-separated HMAC-SHA-256 derivation;
+- deterministic `rl_<opaque>` output accepted by the existing abuse-control contract;
+- no raw edge identity in output and no public route exposure.
+
+P5-02L now establishes a direct incoming Pages Function request boundary for strict `CF-Connecting-IP` extraction and IP normalization while leaving distributed rate limiting and public route composition out of scope.
 
 The active P5-02 work must continue the remaining public Suggest provider and exposure slices. P5-02 then closes with a bounded integration and handoff audit before P5-03 begins.
 

--- a/docs/P5_02L_CLOUDFLARE_EDGE_IDENTITY.md
+++ b/docs/P5_02L_CLOUDFLARE_EDGE_IDENTITY.md
@@ -1,0 +1,78 @@
+# P5-02L trusted Cloudflare edge identity extraction
+
+**Implementation item:** P5-02L  
+**Status:** In progress  
+**Last updated:** 2026-07-11
+
+## Purpose
+
+P5-02L establishes the narrow Cloudflare Pages request boundary that reads a single trusted edge identity for later privacy-preserving rate-limit bucket derivation.
+
+This slice reads only `CF-Connecting-IP` from the incoming Pages Function `Request`. It does not use `X-Forwarded-For`, `X-Real-IP`, or another client-controlled fallback.
+
+## Platform contract
+
+Cloudflare documents `CF-Connecting-IP` as the client IP address connecting to Cloudflare and recommends it over `X-Forwarded-For` when an application requires the original visitor IP in a consistent single-value format.
+
+Pages Functions provide the incoming `Request` as `context.request`. A later public route may therefore compose:
+
+```text
+context.request
+→ read CF-Connecting-IP
+→ strict IPv4 / IPv6 validation and normalization
+→ ephemeral trusted edge identity
+→ P5-02K opaque bucket derivation
+```
+
+## Validation and normalization
+
+P5-02L accepts:
+
+- canonical dotted-decimal IPv4;
+- valid unbracketed IPv6, normalized to the URL parser canonical lowercase form.
+
+It rejects:
+
+- missing or empty header values;
+- comma-separated lists;
+- invalid IPv4 ranges;
+- non-canonical dotted IPv4 with leading-zero octets;
+- bracketed IPv6;
+- IPv6 zone identifiers;
+- arbitrary non-IP text;
+- values longer than the bounded edge-identity input contract.
+
+## Security and privacy invariants
+
+P5-02L preserves these boundaries:
+
+- only `CF-Connecting-IP` is accepted as the trusted edge identity source;
+- no fallback to `X-Forwarded-For` or `X-Real-IP` exists;
+- the raw edge identity is returned only for immediate P5-02K derivation and is not persisted by this boundary;
+- errors are bounded and do not echo header content;
+- no logging is introduced;
+- no public route is exposed;
+- repository checks do not claim live Cloudflare header verification.
+
+## Platform caveat
+
+Cloudflare documents different `CF-Connecting-IP` behavior for Worker subrequests. P5-02L is scoped to the direct incoming Pages Function request boundary. Any later architecture that inserts Worker subrequests or stacked CDN behavior before the public route must re-audit this trust boundary rather than assuming identical semantics.
+
+## Out of scope
+
+P5-02L does not implement opaque bucket HMAC derivation, distributed rate limiting, rate-limit persistence, Turnstile changes, HTTP error mapping, Retry-After behavior, a public API route, a public form/page, CSP, canonical mutation, export, or publication.
+
+Public Suggest intake remains unavailable. P5-03 remains blocked.
+
+## Completion criteria
+
+P5-02L is complete when:
+
+1. the extraction boundary accepts a Pages-compatible incoming `Request`;
+2. only `CF-Connecting-IP` is read as the identity source;
+3. valid IPv4 and IPv6 inputs are accepted and normalized;
+4. missing, multi-value, malformed, or unsupported identity forms fail closed;
+5. alternate forwarded headers are ignored as identity sources;
+6. errors do not echo raw header content;
+7. focused tests, runtime checks, and full GitHub CI pass;
+8. no public route, distributed provider, or persistence behavior is introduced.

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -66,12 +66,13 @@ P5-02G  Completed through #162
 P5-02H  Completed through #163
 P5-02I  Submission status-secret environment binding                    Completed #167
 P5-02J  Submission contact protection                                   Completed #168
-P5-02K  Opaque Submission rate-limit bucket derivation                   In progress
+P5-02K  Opaque Submission rate-limit bucket derivation                   Completed #169
+P5-02L  Trusted Cloudflare edge identity extraction                      In progress
 Remaining public Suggest route/form provider and exposure slices        Planned
 P5-02 integration and handoff audit                                    Planned
 ```
 
-P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, status-secret environment binding, and contact protection. Opaque bucket derivation is the current bounded provider-wiring slice; public route/form exposure and a bounded P5-02 integration and handoff audit remain afterward.
+P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, status-secret environment binding, contact protection, and opaque bucket derivation. Trusted edge identity extraction is the current bounded provider-wiring slice; public route/form exposure and a bounded P5-02 integration and handoff audit remain afterward.
 
 ---
 
@@ -153,7 +154,9 @@ P5-02I — Submission status-secret environment binding                  Complet
     ↓
 P5-02J — Submission contact protection                                 Completed #168
     ↓
-P5-02K — Opaque Submission rate-limit bucket derivation                In progress
+P5-02K — Opaque Submission rate-limit bucket derivation                Completed #169
+    ↓
+P5-02L — Trusted Cloudflare edge identity extraction                   In progress
     ↓
 remaining public Suggest route/form provider and exposure slices       Planned
     ↓

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-02K — Opaque Submission rate-limit bucket derivation
+P5-02L — Trusted Cloudflare edge identity extraction
 
 ## Current repository state
 
@@ -28,7 +28,8 @@ P5-02K — Opaque Submission rate-limit bucket derivation
 - P5-02H atomic accepted-as-Candidate transaction boundary is complete through #163.
 - P5-02I Submission status-secret environment binding is complete through #167.
 - P5-02J Submission contact protection is complete through #168.
-- P5-02K opaque Submission rate-limit bucket derivation is in progress without public route exposure.
+- P5-02K opaque Submission rate-limit bucket derivation is complete through #169.
+- P5-02L trusted Cloudflare edge identity extraction is in progress without public route exposure.
 
 ## Fixed review environment
 
@@ -64,7 +65,8 @@ Before P5-02 implementation or review, read:
 20. `docs/P5_02I_SUBMISSION_STATUS_SECRET_ENVIRONMENT_BINDING.md`;
 21. `docs/P5_02J_SUBMISSION_CONTACT_PROTECTION.md`;
 22. `docs/P5_02K_OPAQUE_RATE_LIMIT_BUCKET_DERIVATION.md`;
-23. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
+23. `docs/P5_02L_CLOUDFLARE_EDGE_IDENTITY.md`;
+24. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
 
 Media work must also read `docs/MEDIA_POLICY.md`.
 
@@ -102,7 +104,9 @@ P5-02I  Submission status-secret environment binding                     Complet
     ↓
 P5-02J  Submission contact protection                                    Completed #168
     ↓
-P5-02K  Opaque Submission rate-limit bucket derivation                    In progress
+P5-02K  Opaque Submission rate-limit bucket derivation                    Completed #169
+    ↓
+P5-02L  Trusted Cloudflare edge identity extraction                       In progress
     ↓
 remaining public Suggest route/form provider and exposure slices
     ↓
@@ -161,13 +165,13 @@ Launch readiness must not be claimed until the relevant launch criteria and reta
 
 ## Next
 
-Complete P5-02K opaque rate-limit bucket derivation, then continue trusted edge identity extraction and the remaining public Suggest provider/exposure slices. Close P5-02 with a bounded integration and handoff audit before P5-03 begins.
+Complete P5-02L trusted Cloudflare edge identity extraction, then continue the distributed rate-limit provider and remaining public Suggest provider/exposure slices. Close P5-02 with a bounded integration and handoff audit before P5-03 begins.
 
 ## Blocked
 
 No known repository blocker to continuing the public Suggest route/form wiring.
 
-Configured-environment trusted edge identity extraction, distributed rate limiting, Turnstile bindings, and complete route composition remain required before the public Suggest route is exposed. Status-secret HMAC binding is repository-complete through #167 and contact protection through #168, but both still require configured-environment verification when composed into the route.
+A production distributed rate limiter, Turnstile environment/browser wiring, and complete route composition remain required before public Suggest intake is exposed. Status-secret HMAC binding is repository-complete through #167, contact protection through #168, and opaque bucket derivation through #169, but configured-environment route verification still remains.
 
 `CPM_USER_SUBMISSION_SOURCE_ID` and the Candidate-create allowlist remain required in configured environments for the accepted-as-Candidate transaction path.
 

--- a/scripts/check-runtime-schemas.ts
+++ b/scripts/check-runtime-schemas.ts
@@ -8,6 +8,7 @@ import './check-online-service-importer';
 import './check-phase-2-integration';
 import './check-physical-place-importer';
 import './check-source-provenance';
+import './check-submission-cloudflare-edge-identity';
 import './check-submission-contact-protection';
 import './check-submission-rate-limit-bucket';
 import './check-submission-status-secret-environment';

--- a/scripts/check-submission-cloudflare-edge-identity.ts
+++ b/scripts/check-submission-cloudflare-edge-identity.ts
@@ -1,0 +1,18 @@
+import { readTrustedCloudflareEdgeIdentity } from '../src/submissions/cloudflare-edge-identity';
+
+const ipv4 = readTrustedCloudflareEdgeIdentity(
+  new Request('https://example.test/api/suggest', {
+    headers: { 'CF-Connecting-IP': '203.0.113.42' },
+  }),
+);
+const ipv6 = readTrustedCloudflareEdgeIdentity(
+  new Request('https://example.test/api/suggest', {
+    headers: { 'CF-Connecting-IP': '2001:0db8:0:0:0:0:0:1' },
+  }),
+);
+
+if (ipv4 !== '203.0.113.42' || ipv6 !== '2001:db8::1') {
+  throw new Error('Submission Cloudflare edge identity extraction contract failed.');
+}
+
+console.log('Submission Cloudflare edge identity checks passed.');

--- a/src/submissions/cloudflare-edge-identity.ts
+++ b/src/submissions/cloudflare-edge-identity.ts
@@ -1,0 +1,52 @@
+export const cloudflareConnectingIpHeaderName = 'CF-Connecting-IP' as const;
+
+export class SubmissionEdgeIdentityError extends Error {
+  constructor() {
+    super('Submission edge identity is unavailable.');
+    this.name = 'SubmissionEdgeIdentityError';
+  }
+}
+
+function parseCanonicalIpv4(value: string): string | null {
+  const segments = value.split('.');
+  if (segments.length !== 4) return null;
+
+  const canonical: string[] = [];
+  for (const segment of segments) {
+    if (!/^(0|[1-9][0-9]{0,2})$/.test(segment)) return null;
+    const octet = Number(segment);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) return null;
+    canonical.push(String(octet));
+  }
+  return canonical.join('.');
+}
+
+function parseCanonicalIpv6(value: string): string | null {
+  if (!value.includes(':') || value.includes('[') || value.includes(']') || value.includes('%')) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(`http://[${value}]/`);
+    const hostname = parsed.hostname;
+    if (!hostname.startsWith('[') || !hostname.endsWith(']')) return null;
+    return hostname.slice(1, -1).toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function readTrustedCloudflareEdgeIdentity(request: Request): string {
+  const raw = request.headers.get(cloudflareConnectingIpHeaderName);
+  if (raw === null || raw.length === 0 || raw.length > 64) {
+    throw new SubmissionEdgeIdentityError();
+  }
+
+  const ipv4 = parseCanonicalIpv4(raw);
+  if (ipv4 !== null) return ipv4;
+
+  const ipv6 = parseCanonicalIpv6(raw);
+  if (ipv6 !== null) return ipv6;
+
+  throw new SubmissionEdgeIdentityError();
+}

--- a/tests/submission-cloudflare-edge-identity.test.ts
+++ b/tests/submission-cloudflare-edge-identity.test.ts
@@ -11,9 +11,7 @@ function requestWithHeaders(headers: HeadersInit): Request {
 describe('P5-02L trusted Cloudflare edge identity extraction', () => {
   it('reads a canonical IPv4 identity from CF-Connecting-IP', () => {
     expect(
-      readTrustedCloudflareEdgeIdentity(
-        requestWithHeaders({ 'CF-Connecting-IP': '203.0.113.42' }),
-      ),
+      readTrustedCloudflareEdgeIdentity(requestWithHeaders({ 'CF-Connecting-IP': '203.0.113.42' })),
     ).toBe('203.0.113.42');
   });
 
@@ -27,17 +25,13 @@ describe('P5-02L trusted Cloudflare edge identity extraction', () => {
 
   it('accepts compressed IPv6', () => {
     expect(
-      readTrustedCloudflareEdgeIdentity(
-        requestWithHeaders({ 'CF-Connecting-IP': '2001:db8::2' }),
-      ),
+      readTrustedCloudflareEdgeIdentity(requestWithHeaders({ 'CF-Connecting-IP': '2001:db8::2' })),
     ).toBe('2001:db8::2');
   });
 
   it('does not fall back to X-Forwarded-For', () => {
     expect(() =>
-      readTrustedCloudflareEdgeIdentity(
-        requestWithHeaders({ 'X-Forwarded-For': '203.0.113.42' }),
-      ),
+      readTrustedCloudflareEdgeIdentity(requestWithHeaders({ 'X-Forwarded-For': '203.0.113.42' })),
     ).toThrow(SubmissionEdgeIdentityError);
   });
 

--- a/tests/submission-cloudflare-edge-identity.test.ts
+++ b/tests/submission-cloudflare-edge-identity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  readTrustedCloudflareEdgeIdentity,
+  SubmissionEdgeIdentityError,
+} from '../src/submissions/cloudflare-edge-identity';
+
+function requestWithHeaders(headers: HeadersInit): Request {
+  return new Request('https://example.test/api/suggest', { headers });
+}
+
+describe('P5-02L trusted Cloudflare edge identity extraction', () => {
+  it('reads a canonical IPv4 identity from CF-Connecting-IP', () => {
+    expect(
+      readTrustedCloudflareEdgeIdentity(
+        requestWithHeaders({ 'CF-Connecting-IP': '203.0.113.42' }),
+      ),
+    ).toBe('203.0.113.42');
+  });
+
+  it('normalizes a valid IPv6 identity', () => {
+    expect(
+      readTrustedCloudflareEdgeIdentity(
+        requestWithHeaders({ 'CF-Connecting-IP': '2001:0db8:0:0:0:0:0:1' }),
+      ),
+    ).toBe('2001:db8::1');
+  });
+
+  it('accepts compressed IPv6', () => {
+    expect(
+      readTrustedCloudflareEdgeIdentity(
+        requestWithHeaders({ 'CF-Connecting-IP': '2001:db8::2' }),
+      ),
+    ).toBe('2001:db8::2');
+  });
+
+  it('does not fall back to X-Forwarded-For', () => {
+    expect(() =>
+      readTrustedCloudflareEdgeIdentity(
+        requestWithHeaders({ 'X-Forwarded-For': '203.0.113.42' }),
+      ),
+    ).toThrow(SubmissionEdgeIdentityError);
+  });
+
+  it.each([
+    ['missing header', {}],
+    ['empty header', { 'CF-Connecting-IP': '' }],
+    ['comma-separated list', { 'CF-Connecting-IP': '203.0.113.1, 203.0.113.2' }],
+    ['invalid IPv4 range', { 'CF-Connecting-IP': '203.0.113.999' }],
+    ['non-canonical IPv4', { 'CF-Connecting-IP': '203.0.113.042' }],
+    ['bracketed IPv6', { 'CF-Connecting-IP': '[2001:db8::1]' }],
+    ['IPv6 zone identifier', { 'CF-Connecting-IP': 'fe80::1%eth0' }],
+    ['arbitrary text', { 'CF-Connecting-IP': 'not-an-ip' }],
+  ])('fails closed for %s', (_name, headers) => {
+    expect(() => readTrustedCloudflareEdgeIdentity(requestWithHeaders(headers))).toThrow(
+      SubmissionEdgeIdentityError,
+    );
+  });
+
+  it('returns only the edge identity and does not inspect unrelated headers', () => {
+    const request = requestWithHeaders({
+      'CF-Connecting-IP': '198.51.100.7',
+      'X-Forwarded-For': '192.0.2.1, 192.0.2.2',
+      'X-Real-IP': '192.0.2.9',
+    });
+    expect(readTrustedCloudflareEdgeIdentity(request)).toBe('198.51.100.7');
+  });
+});


### PR DESCRIPTION
## Implementation item

P5-02L — Trusted Cloudflare edge identity extraction

## Purpose

Establish the narrow Cloudflare Pages request boundary that reads a single edge-provided client identity for later P5-02K opaque rate-limit bucket derivation, without exposing public Suggest intake.

## Scope

- read only `CF-Connecting-IP` from an incoming `Request`;
- validate canonical dotted-decimal IPv4;
- validate and normalize unbracketed IPv6;
- reject missing, empty, multi-value, malformed, bracketed, zone-qualified, or oversized values;
- do not fall back to `X-Forwarded-For` or `X-Real-IP`;
- add focused tests, runtime schema coverage, platform-contract documentation, and bounded tracking updates.

## Platform basis

Cloudflare documents `CF-Connecting-IP` as the client IP connecting to Cloudflare and recommends it over `X-Forwarded-For` when an application needs the original visitor IP in a consistent single-value format. Pages Functions provide the incoming `Request` as `context.request`.

The boundary is intentionally scoped to a direct incoming Pages Function request. Any later architecture that inserts Worker subrequests or stacked CDN behavior before the route must re-audit the trust boundary.

## Security and privacy invariants

- only `CF-Connecting-IP` is accepted as the edge identity source;
- no alternate forwarded-header fallback exists;
- raw identity is returned only for immediate opaque-bucket derivation and is not persisted by this slice;
- errors are bounded and do not echo header content;
- no logging is introduced;
- no public route is exposed.

## Explicit exclusions

- no opaque bucket HMAC changes;
- no distributed rate limiter;
- no rate-limit persistence;
- no Turnstile changes;
- no Retry-After HTTP behavior;
- no public API route;
- no public Suggest form/page;
- no CSP changes;
- no canonical, export, or publication mutation;
- no P5-03 work.

## Validation

This branch adds focused Vitest coverage and a runtime contract check. GitHub CI is the authoritative validation gate for format, lint, TypeScript/Astro, runtime schemas, migration drift, full unit/component tests, build, accessibility, and staging artifacts.

## Remaining work

Later bounded slices still need a production distributed rate-limit adapter, Turnstile environment/browser wiring, public HTTP composition and safe error mapping, Suggest UI/CSP, configured-environment verification, and the final P5-02 integration/handoff audit.