### PR TITLE
P5-02N: add Turnstile environment binding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,12 @@ CPM_SUBMISSION_CONTACT_RETENTION_DAYS=
 # Server-only keyed derivation secret for opaque Submission rate-limit buckets.
 # Canonical unpadded Base64URL encoding of at least 32 random bytes.
 CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL=
+
+# Cloudflare Turnstile configuration for public Submission intake.
+# Secret key stays server-only. Site key is intentionally public for browser rendering.
+CPM_TURNSTILE_SECRET_KEY=
+PUBLIC_TURNSTILE_SITE_KEY=
+# Exact lowercase hostname returned by Siteverify, without scheme, port, path, or trailing dot.
+CPM_TURNSTILE_EXPECTED_HOSTNAME=
+# 1-32 characters; ASCII letters, digits, underscore, and hyphen only.
+CPM_TURNSTILE_EXPECTED_ACTION=submission_intake

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -223,9 +223,11 @@ P5-02K — Opaque Submission rate-limit bucket derivation                    Com
     ↓
 P5-02L — Trusted Cloudflare edge identity extraction                       Completed #170
     ↓
-P5-02M — Durable Object distributed Submission rate limiting               In progress
+P5-02M — Durable Object distributed Submission rate limiting               Completed #171
     ↓
-remaining public Suggest route/form provider and exposure slices
+P5-02N — Turnstile environment binding                                    In progress
+    ↓
+remaining public Suggest route/form composition and exposure slices
     ↓
 P5-02 integration and handoff audit
 ```
@@ -337,9 +339,17 @@ P5-02L established:
 - fail-closed handling with no forwarded-header fallback;
 - no raw identity persistence or public route exposure.
 
-P5-02M now establishes a SQLite-backed Durable Object distributed fixed-window provider behind the existing `SubmissionRateLimiter` interface. It keeps raw edge identity out of the provider and leaves live Pages binding, route policy values, Turnstile wiring, and public route activation for later slices.
+P5-02M established:
 
-The active P5-02 work must continue the remaining public Suggest provider and exposure slices. P5-02 then closes with a bounded integration and handoff audit before P5-03 begins.
+- a SQLite-backed Durable Object distributed fixed-window provider behind the existing `SubmissionRateLimiter` interface;
+- deterministic mapping from opaque rate-limit bucket keys to Durable Object identities;
+- fail-closed provider, malformed-response, invalid persisted-state, and clock-rollback handling;
+- Wrangler dry-run bundle validation through the repository schema-check CI path;
+- no raw identity in the provider contract and no public route exposure.
+
+P5-02N now establishes explicit Turnstile server/browser environment binding, one shared action value for widget and server verification, exact configured hostname/action enforcement through the existing Siteverify adapter, client-safe configuration separation, and bounded configuration failure behavior without public route exposure.
+
+The active P5-02 work must continue public HTTP composition, safe error and Retry-After mapping, Suggest browser/form wiring, and configured-environment verification. P5-02 then closes with a bounded integration and handoff audit before P5-03 begins.
 
 ### P5-03 — Payment and problem reports
 

--- a/docs/P5_02N_TURNSTILE_ENVIRONMENT_BINDING.md
+++ b/docs/P5_02N_TURNSTILE_ENVIRONMENT_BINDING.md
@@ -1,0 +1,148 @@
+# P5-02N Turnstile environment binding
+
+**Implementation item:** P5-02N  
+**Status:** In progress  
+**Last updated:** 2026-07-11
+
+## Purpose
+
+P5-02N binds the existing P5-01D Cloudflare Turnstile Siteverify adapter to explicit server and browser configuration while preserving exact hostname and action verification.
+
+This slice does not expose the public Suggest route. It establishes the configuration boundary required by the later public route and form composition slices.
+
+## Environment contract
+
+The required bindings are:
+
+```text
+CPM_TURNSTILE_SECRET_KEY
+PUBLIC_TURNSTILE_SITE_KEY
+CPM_TURNSTILE_EXPECTED_HOSTNAME
+CPM_TURNSTILE_EXPECTED_ACTION
+```
+
+Responsibilities are separated:
+
+```text
+CPM_TURNSTILE_SECRET_KEY
+server-only Siteverify credential
+
+PUBLIC_TURNSTILE_SITE_KEY
+client-safe site key used to render the widget
+
+CPM_TURNSTILE_EXPECTED_HOSTNAME
+exact lowercase hostname expected in successful Siteverify responses
+
+CPM_TURNSTILE_EXPECTED_ACTION
+one action identifier shared by widget rendering and server-side response validation
+```
+
+The configuration constructor returns only:
+
+- the server-side `SubmissionChallengeVerifier`;
+- client-safe site key and action values;
+- the expected hostname needed by later configured-environment verification.
+
+The Turnstile secret is never included in the client configuration object.
+
+## Hostname contract
+
+`CPM_TURNSTILE_EXPECTED_HOSTNAME` must be a lowercase hostname only.
+
+It must not include:
+
+- a URL scheme;
+- a port;
+- a path;
+- a query;
+- a fragment;
+- uppercase labels;
+- a trailing dot.
+
+The existing Siteverify adapter compares the returned `hostname` to this configured value exactly. A mismatch is a deny decision.
+
+## Action contract
+
+`CPM_TURNSTILE_EXPECTED_ACTION` must contain 1 through 32 ASCII characters from:
+
+```text
+A-Z
+a-z
+0-9
+_
+-
+```
+
+The same configured action is returned in the client-safe widget configuration and passed to the existing server-side verifier as the expected action.
+
+This prevents browser and server configuration drift inside the application boundary. A successful provider response with a different action is denied by the existing Siteverify adapter.
+
+## Failure behavior
+
+Configuration failures use one bounded error type:
+
+```text
+SubmissionTurnstileConfigurationError
+```
+
+The public message is generic:
+
+```text
+Submission Turnstile configuration is unavailable.
+```
+
+Validation detail, secret values, site keys, hostnames, and action values are not copied into configuration error messages.
+
+Challenge verification behavior remains owned by the P5-01D Siteverify adapter:
+
+- valid response with exact hostname and action → allow;
+- failed challenge → deny;
+- hostname mismatch → deny;
+- action mismatch → deny;
+- provider internal error, timeout, network failure, invalid JSON, or invalid response shape → unavailable.
+
+## Security and privacy invariants
+
+P5-02N preserves these boundaries:
+
+- the Turnstile secret remains server-only;
+- the site key is explicitly client-safe;
+- widget action and server expected action derive from one configured value;
+- hostname and action validation remain exact;
+- no challenge token is logged;
+- no configured value is echoed through configuration errors;
+- no public route is exposed;
+- no intake, Candidate, canonical, export, or publication mutation is added.
+
+## Out of scope
+
+P5-02N does not implement:
+
+- public Suggest API route composition;
+- rate-limit policy values;
+- HTTP safe error mapping;
+- `Retry-After` response headers;
+- browser widget component rendering;
+- Suggest form UI;
+- Content Security Policy changes;
+- live Turnstile dashboard hostname configuration;
+- live Worker or Pages binding deployment;
+- configured-environment end-to-end verification;
+- P5-03 work.
+
+Public Suggest intake remains unavailable.
+
+## Completion criteria
+
+P5-02N is complete when:
+
+1. all four Turnstile environment values are parsed through one strict boundary;
+2. the existing Siteverify verifier is composed from server configuration;
+3. only site key and action are returned as client-safe widget configuration;
+4. hostname and action mismatch behavior remains deny;
+5. action shape and length are bounded;
+6. malformed or missing environment values produce one generic configuration error;
+7. configured values are absent from error messages;
+8. focused tests and runtime checks pass;
+9. full GitHub CI passes;
+10. no public route or form is introduced.

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -68,12 +68,13 @@ P5-02I  Submission status-secret environment binding                    Complete
 P5-02J  Submission contact protection                                   Completed #168
 P5-02K  Opaque Submission rate-limit bucket derivation                   Completed #169
 P5-02L  Trusted Cloudflare edge identity extraction                      Completed #170
-P5-02M  Durable Object distributed Submission rate limiting              In progress
-Remaining public Suggest route/form provider and exposure slices        Planned
+P5-02M  Durable Object distributed Submission rate limiting              Completed #171
+P5-02N  Turnstile environment binding                                   In progress
+Remaining public Suggest route/form composition and exposure slices     Planned
 P5-02 integration and handoff audit                                    Planned
 ```
 
-P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, status-secret environment binding, contact protection, opaque bucket derivation, and trusted edge identity extraction. Distributed rate limiting is the current bounded provider-wiring slice; public route/form exposure and a bounded P5-02 integration and handoff audit remain afterward.
+P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, status-secret environment binding, contact protection, opaque bucket derivation, trusted edge identity extraction, and distributed rate limiting. Turnstile environment binding is the current bounded provider-wiring slice; public route/form composition and a bounded P5-02 integration and handoff audit remain afterward.
 
 ---
 
@@ -159,9 +160,11 @@ P5-02K — Opaque Submission rate-limit bucket derivation                Complet
     ↓
 P5-02L — Trusted Cloudflare edge identity extraction                   Completed #170
     ↓
-P5-02M — Durable Object distributed Submission rate limiting           In progress
+P5-02M — Durable Object distributed Submission rate limiting           Completed #171
     ↓
-remaining public Suggest route/form provider and exposure slices       Planned
+P5-02N — Turnstile environment binding                                In progress
+    ↓
+remaining public Suggest route/form composition and exposure slices    Planned
     ↓
 P5-02 integration and handoff audit                                    Planned
 ```

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-02M — Durable Object distributed Submission rate limiting
+P5-02N — Turnstile environment binding
 
 ## Current repository state
 
@@ -30,7 +30,8 @@ P5-02M — Durable Object distributed Submission rate limiting
 - P5-02J Submission contact protection is complete through #168.
 - P5-02K opaque Submission rate-limit bucket derivation is complete through #169.
 - P5-02L trusted Cloudflare edge identity extraction is complete through #170.
-- P5-02M Durable Object distributed Submission rate limiting is in progress without public route exposure.
+- P5-02M Durable Object distributed Submission rate limiting is complete through #171.
+- P5-02N Turnstile environment binding is in progress without public route exposure.
 
 ## Fixed review environment
 
@@ -68,7 +69,8 @@ Before P5-02 implementation or review, read:
 22. `docs/P5_02K_OPAQUE_RATE_LIMIT_BUCKET_DERIVATION.md`;
 23. `docs/P5_02L_CLOUDFLARE_EDGE_IDENTITY.md`;
 24. `docs/P5_02M_DURABLE_OBJECT_RATE_LIMIT.md`;
-25. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
+25. `docs/P5_02N_TURNSTILE_ENVIRONMENT_BINDING.md`;
+26. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
 
 Media work must also read `docs/MEDIA_POLICY.md`.
 
@@ -110,9 +112,11 @@ P5-02K  Opaque Submission rate-limit bucket derivation                    Comple
     ↓
 P5-02L  Trusted Cloudflare edge identity extraction                       Completed #170
     ↓
-P5-02M  Durable Object distributed Submission rate limiting               In progress
+P5-02M  Durable Object distributed Submission rate limiting               Completed #171
     ↓
-remaining public Suggest route/form provider and exposure slices
+P5-02N  Turnstile environment binding                                    In progress
+    ↓
+remaining public Suggest route/form composition and exposure slices
     ↓
 P5-02 integration and handoff audit
 ```
@@ -169,13 +173,13 @@ Launch readiness must not be claimed until the relevant launch criteria and reta
 
 ## Next
 
-Complete P5-02M Durable Object distributed rate limiting, then continue Turnstile environment/browser wiring and the remaining public Suggest provider/exposure slices. Close P5-02 with a bounded integration and handoff audit before P5-03 begins.
+Complete P5-02N Turnstile environment binding, then continue public HTTP composition, safe error and Retry-After mapping, Suggest form/browser wiring, and configured-environment verification. Close P5-02 with a bounded integration and handoff audit before P5-03 begins.
 
 ## Blocked
 
 No known repository blocker to continuing the public Suggest route/form wiring.
 
-Turnstile environment/browser wiring, complete route composition, and configured deployment verification remain required before public Suggest intake is exposed. Status-secret HMAC binding is repository-complete through #167, contact protection through #168, opaque bucket derivation through #169, and trusted edge identity extraction through #170.
+Public HTTP composition, safe error and Retry-After mapping, Suggest form/browser wiring, and configured deployment verification remain required before public Suggest intake is exposed. Status-secret HMAC binding is repository-complete through #167, contact protection through #168, opaque bucket derivation through #169, trusted edge identity extraction through #170, and distributed rate limiting through #171.
 
 The P5-02M Durable Object worker and Pages binding must be deployed and verified in a configured environment before route activation. Repository dry-run compilation does not prove that live binding.
 

--- a/scripts/check-runtime-schemas.ts
+++ b/scripts/check-runtime-schemas.ts
@@ -13,6 +13,7 @@ import './check-submission-contact-protection';
 import './check-submission-durable-object-rate-limit';
 import './check-submission-rate-limit-bucket';
 import './check-submission-status-secret-environment';
+import './check-submission-turnstile-environment';
 import './check-verification-events';
 import { assetRegistry, findAssetCandidates } from '../src/registries/assets';
 import { findNetworkCandidates, networkRegistry } from '../src/registries/networks';

--- a/scripts/check-submission-turnstile-environment.ts
+++ b/scripts/check-submission-turnstile-environment.ts
@@ -1,0 +1,55 @@
+import {
+  createSubmissionTurnstileConfigurationFromEnvironment,
+  SubmissionTurnstileConfigurationError,
+} from '../src/submissions/turnstile-environment';
+
+const configuration = createSubmissionTurnstileConfigurationFromEnvironment(
+  {
+    CPM_TURNSTILE_SECRET_KEY: 'runtime-server-secret',
+    PUBLIC_TURNSTILE_SITE_KEY: 'runtime-public-site-key',
+    CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.example.test',
+    CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake',
+  },
+  {
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          hostname: 'review.example.test',
+          action: 'submission_intake',
+        }),
+        { status: 200 },
+      )) as typeof fetch,
+  },
+);
+
+if (
+  configuration.client.siteKey !== 'runtime-public-site-key' ||
+  configuration.client.action !== 'submission_intake' ||
+  configuration.expectedHostname !== 'review.example.test'
+) {
+  throw new Error('Submission Turnstile environment check produced invalid client configuration.');
+}
+
+const decision = await configuration.verifier.verify({
+  requestId: '20000000-0000-4000-8000-000000000001',
+  token: 'turnstile-token',
+  remoteIp: null,
+});
+if (decision.outcome !== 'allow') {
+  throw new Error('Submission Turnstile environment check failed to compose the verifier.');
+}
+
+try {
+  createSubmissionTurnstileConfigurationFromEnvironment({
+    CPM_TURNSTILE_SECRET_KEY: 'runtime-server-secret',
+    PUBLIC_TURNSTILE_SITE_KEY: 'runtime-public-site-key',
+    CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.example.test',
+    CPM_TURNSTILE_EXPECTED_ACTION: 'invalid action',
+  });
+  throw new Error('Expected invalid Turnstile configuration to fail.');
+} catch (error) {
+  if (!(error instanceof SubmissionTurnstileConfigurationError)) throw error;
+}
+
+console.log('Submission Turnstile environment checks passed.');

--- a/src/submissions/turnstile-environment.ts
+++ b/src/submissions/turnstile-environment.ts
@@ -7,9 +7,7 @@ const hostnameSchema = z
   .string()
   .min(1)
   .max(253)
-  .regex(
-    /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/,
-  );
+  .regex(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/);
 const actionSchema = z.string().regex(/^[A-Za-z0-9_-]{1,32}$/);
 
 export const submissionTurnstileEnvironmentSchema = z

--- a/src/submissions/turnstile-environment.ts
+++ b/src/submissions/turnstile-environment.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import type { SubmissionChallengeVerifier } from './challenge-verification';
+import { createTurnstileSiteverifyVerifier } from './turnstile-siteverify';
+
+const nonWhitespaceTokenSchema = z.string().min(1).max(512).regex(/^\S+$/);
+const hostnameSchema = z
+  .string()
+  .min(1)
+  .max(253)
+  .regex(
+    /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/,
+  );
+const actionSchema = z.string().regex(/^[A-Za-z0-9_-]{1,32}$/);
+
+export const submissionTurnstileEnvironmentSchema = z
+  .object({
+    CPM_TURNSTILE_SECRET_KEY: nonWhitespaceTokenSchema,
+    PUBLIC_TURNSTILE_SITE_KEY: nonWhitespaceTokenSchema,
+    CPM_TURNSTILE_EXPECTED_HOSTNAME: hostnameSchema,
+    CPM_TURNSTILE_EXPECTED_ACTION: actionSchema,
+  })
+  .strict();
+
+export type SubmissionTurnstileEnvironment = Readonly<
+  Record<string, unknown> & {
+    CPM_TURNSTILE_SECRET_KEY?: unknown;
+    PUBLIC_TURNSTILE_SITE_KEY?: unknown;
+    CPM_TURNSTILE_EXPECTED_HOSTNAME?: unknown;
+    CPM_TURNSTILE_EXPECTED_ACTION?: unknown;
+  }
+>;
+
+export interface SubmissionTurnstileClientConfiguration {
+  siteKey: string;
+  action: string;
+}
+
+export interface SubmissionTurnstileConfiguration {
+  verifier: SubmissionChallengeVerifier;
+  client: SubmissionTurnstileClientConfiguration;
+  expectedHostname: string;
+}
+
+export interface SubmissionTurnstileEnvironmentOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export class SubmissionTurnstileConfigurationError extends Error {
+  constructor() {
+    super('Submission Turnstile configuration is unavailable.');
+    this.name = 'SubmissionTurnstileConfigurationError';
+  }
+}
+
+export function createSubmissionTurnstileConfigurationFromEnvironment(
+  environment: SubmissionTurnstileEnvironment,
+  options: SubmissionTurnstileEnvironmentOptions = {},
+): SubmissionTurnstileConfiguration {
+  const parsed = submissionTurnstileEnvironmentSchema.safeParse({
+    CPM_TURNSTILE_SECRET_KEY: environment.CPM_TURNSTILE_SECRET_KEY,
+    PUBLIC_TURNSTILE_SITE_KEY: environment.PUBLIC_TURNSTILE_SITE_KEY,
+    CPM_TURNSTILE_EXPECTED_HOSTNAME: environment.CPM_TURNSTILE_EXPECTED_HOSTNAME,
+    CPM_TURNSTILE_EXPECTED_ACTION: environment.CPM_TURNSTILE_EXPECTED_ACTION,
+  });
+  if (!parsed.success) throw new SubmissionTurnstileConfigurationError();
+
+  try {
+    const verifier = createTurnstileSiteverifyVerifier({
+      secretKey: parsed.data.CPM_TURNSTILE_SECRET_KEY,
+      expectedHostname: parsed.data.CPM_TURNSTILE_EXPECTED_HOSTNAME,
+      expectedAction: parsed.data.CPM_TURNSTILE_EXPECTED_ACTION,
+      ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+      ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+    });
+
+    return {
+      verifier,
+      client: {
+        siteKey: parsed.data.PUBLIC_TURNSTILE_SITE_KEY,
+        action: parsed.data.CPM_TURNSTILE_EXPECTED_ACTION,
+      },
+      expectedHostname: parsed.data.CPM_TURNSTILE_EXPECTED_HOSTNAME,
+    };
+  } catch {
+    throw new SubmissionTurnstileConfigurationError();
+  }
+}

--- a/tests/submission-turnstile-environment.test.ts
+++ b/tests/submission-turnstile-environment.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createSubmissionTurnstileConfigurationFromEnvironment,
+  SubmissionTurnstileConfigurationError,
+} from '../src/submissions/turnstile-environment';
+
+const requestId = '20000000-0000-4000-8000-000000000001';
+const validEnvironment = {
+  CPM_TURNSTILE_SECRET_KEY: 'server-secret',
+  PUBLIC_TURNSTILE_SITE_KEY: 'public-site-key',
+  CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.example.test',
+  CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake',
+};
+
+describe('P5-02N Turnstile environment binding', () => {
+  it('binds server verification and returns only client-safe widget configuration', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body))).toEqual({
+        secret: 'server-secret',
+        response: 'turnstile-token',
+        idempotency_key: requestId,
+        remoteip: '203.0.113.10',
+      });
+      return new Response(
+        JSON.stringify({
+          success: true,
+          hostname: 'review.example.test',
+          action: 'submission_intake',
+        }),
+        { status: 200 },
+      );
+    });
+    const configuration = createSubmissionTurnstileConfigurationFromEnvironment(validEnvironment, {
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(configuration.client).toEqual({
+      siteKey: 'public-site-key',
+      action: 'submission_intake',
+    });
+    expect(configuration.expectedHostname).toBe('review.example.test');
+    expect(configuration).not.toHaveProperty('secretKey');
+    await expect(
+      configuration.verifier.verify({
+        requestId,
+        token: 'turnstile-token',
+        remoteIp: '203.0.113.10',
+      }),
+    ).resolves.toEqual({ outcome: 'allow', reasonCode: 'challenge_verified' });
+  });
+
+  it('preserves exact hostname and action mismatch denial through the existing verifier', async () => {
+    const configuration = createSubmissionTurnstileConfigurationFromEnvironment(validEnvironment, {
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            success: true,
+            hostname: 'wrong.example.test',
+            action: 'submission_intake',
+          }),
+          { status: 200 },
+        )) as typeof fetch,
+    });
+
+    await expect(
+      configuration.verifier.verify({ requestId, token: 'turnstile-token', remoteIp: null }),
+    ).resolves.toEqual({ outcome: 'deny', reasonCode: 'challenge_hostname_mismatch' });
+  });
+
+  it.each([
+    ['missing secret', { ...validEnvironment, CPM_TURNSTILE_SECRET_KEY: undefined }],
+    ['site key with whitespace', { ...validEnvironment, PUBLIC_TURNSTILE_SITE_KEY: 'not valid' }],
+    [
+      'hostname with scheme',
+      { ...validEnvironment, CPM_TURNSTILE_EXPECTED_HOSTNAME: 'https://review.example.test' },
+    ],
+    [
+      'hostname with uppercase',
+      { ...validEnvironment, CPM_TURNSTILE_EXPECTED_HOSTNAME: 'Review.example.test' },
+    ],
+    [
+      'action longer than 32 characters',
+      { ...validEnvironment, CPM_TURNSTILE_EXPECTED_ACTION: 'x'.repeat(33) },
+    ],
+    [
+      'action with unsupported characters',
+      { ...validEnvironment, CPM_TURNSTILE_EXPECTED_ACTION: 'submission intake' },
+    ],
+  ])('rejects %s with one generic configuration error', (_name, environment) => {
+    expect(() => createSubmissionTurnstileConfigurationFromEnvironment(environment)).toThrow(
+      SubmissionTurnstileConfigurationError,
+    );
+    expect(() => createSubmissionTurnstileConfigurationFromEnvironment(environment)).toThrow(
+      'Submission Turnstile configuration is unavailable.',
+    );
+  });
+
+  it('does not disclose configured values through configuration errors', () => {
+    const secret = 'do-not-disclose-this-secret';
+    try {
+      createSubmissionTurnstileConfigurationFromEnvironment({
+        ...validEnvironment,
+        CPM_TURNSTILE_SECRET_KEY: secret,
+        CPM_TURNSTILE_EXPECTED_ACTION: 'invalid action',
+      });
+      throw new Error('Expected Turnstile configuration failure.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SubmissionTurnstileConfigurationError);
+      expect(String(error)).not.toContain(secret);
+      expect(String(error)).not.toContain('invalid action');
+    }
+  });
+});

--- a/tests/submission-turnstile-environment.test.ts
+++ b/tests/submission-turnstile-environment.test.ts
@@ -49,7 +49,7 @@ describe('P5-02N Turnstile environment binding', () => {
     ).resolves.toEqual({ outcome: 'allow', reasonCode: 'challenge_verified' });
   });
 
-  it('preserves exact hostname and action mismatch denial through the existing verifier', async () => {
+  it('preserves exact hostname mismatch denial through the existing verifier', async () => {
     const configuration = createSubmissionTurnstileConfigurationFromEnvironment(validEnvironment, {
       fetchImpl: (async () =>
         new Response(
@@ -65,6 +65,24 @@ describe('P5-02N Turnstile environment binding', () => {
     await expect(
       configuration.verifier.verify({ requestId, token: 'turnstile-token', remoteIp: null }),
     ).resolves.toEqual({ outcome: 'deny', reasonCode: 'challenge_hostname_mismatch' });
+  });
+
+  it('preserves exact action mismatch denial through the existing verifier', async () => {
+    const configuration = createSubmissionTurnstileConfigurationFromEnvironment(validEnvironment, {
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            success: true,
+            hostname: 'review.example.test',
+            action: 'different_action',
+          }),
+          { status: 200 },
+        )) as typeof fetch,
+    });
+
+    await expect(
+      configuration.verifier.verify({ requestId, token: 'turnstile-token', remoteIp: null }),
+    ).resolves.toEqual({ outcome: 'deny', reasonCode: 'challenge_action_mismatch' });
   });
 
   it.each([


### PR DESCRIPTION
## Implementation item

P5-02N — Turnstile environment binding

## Purpose

Bind the existing P5-01D Cloudflare Turnstile Siteverify adapter to explicit server and browser configuration with exact hostname and action verification, without exposing public Suggest intake.

## Scope

- add strict environment parsing for server secret, public site key, expected hostname, and expected action;
- compose the existing `SubmissionChallengeVerifier` from the server-only configuration;
- return only client-safe site key and action configuration for later widget rendering;
- derive browser action and server expected action from the same configured value;
- preserve exact hostname and action mismatch denial through the existing Siteverify adapter;
- bound action shape and length;
- use one generic configuration error without configured-value disclosure;
- add focused tests, runtime checks, `.env.example` documentation, specification, and tracking updates.

## Security and privacy invariants

- Turnstile secret remains server-only;
- client configuration contains only site key and action;
- hostname and action validation are exact;
- challenge token logging is not introduced;
- configuration errors do not echo secret, site key, hostname, or action values;
- no public route or form is exposed;
- no intake, Candidate, canonical, export, or publication mutation is added.

## Explicit exclusions

- no public Suggest API route composition;
- no rate-limit policy values;
- no HTTP safe error mapping;
- no `Retry-After` header emission;
- no browser widget component rendering;
- no Suggest form UI;
- no CSP changes;
- no live Turnstile dashboard hostname configuration;
- no live Worker or Pages binding deployment;
- no configured-environment end-to-end verification;
- no P5-03 work.

## Validation

The branch adds focused Vitest coverage and runtime schema-path checks. GitHub CI is the authoritative validation gate for format, lint, TypeScript/Astro, runtime schemas including P5-02M Worker dry-run validation, migration drift, full unit/component tests, build, accessibility, and staging artifacts.

## Remaining work

Later bounded slices still need public HTTP composition and safe error/Retry-After mapping, Suggest form and browser widget/CSP wiring, configured Worker/Pages/Turnstile verification, complete configured-environment route verification, and the final P5-02 integration/handoff audit.