### PR TITLE
P5-02Q: preserve Worker deploy diagnostics and receipt state

### DIFF
--- a/.github/workflows/staging-review-deploy.yml
+++ b/.github/workflows/staging-review-deploy.yml
@@ -77,7 +77,19 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler deploy --config workers/submission-rate-limit/wrangler.jsonc
+        run: |
+          set -o pipefail
+          npx wrangler deploy --config workers/submission-rate-limit/wrangler.jsonc \
+            2>&1 | tee worker-deployment-output.log
+
+      - name: Upload Worker deployment diagnostics
+        if: always() && steps.worker_deploy.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-review-worker-deployment-log
+          path: worker-deployment-output.log
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Synchronize configured Suggest Pages secrets
         id: pages_secrets
@@ -223,6 +235,9 @@ jobs:
               contactRetentionDays: 180,
               rateLimit: { maximumRequests: 5, windowSeconds: 600 },
             },
+            ...(checks.durableObjectWorker === 'failure'
+              ? { diagnosticsArtifact: 'staging-review-worker-deployment-log' }
+              : {}),
             ...(missingConfiguredInputs.length > 0 ? { missingConfiguredInputs } : {}),
           };
           mkdirSync('staging-review-receipt', { recursive: true });
@@ -241,17 +256,27 @@ jobs:
       - name: Publish deployment receipt to status branch
         if: always()
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
+          STATUS_WORKTREE: ${{ runner.temp }}/cryptopaymap-staging-review-status
         run: |
           set -euo pipefail
-          CONTENT="$(base64 -w 0 staging-review-receipt/deployment-receipt.json)"
-          CURRENT_SHA="$(gh api "repos/$REPOSITORY/contents/config/staging-review/deployment-receipt.json?ref=staging-review" --jq '.sha')"
-          gh api --method PUT "repos/$REPOSITORY/contents/config/staging-review/deployment-receipt.json" \
-            -f message='P5-02Q: record configured review deployment result' \
-            -f content="$CONTENT" \
-            -f sha="$CURRENT_SHA" \
-            -f branch='staging-review'
+          rm -rf "$STATUS_WORKTREE"
+          git fetch origin staging-review:refs/remotes/origin/staging-review
+          git worktree add --detach "$STATUS_WORKTREE" refs/remotes/origin/staging-review
+          trap 'git worktree remove --force "$STATUS_WORKTREE" >/dev/null 2>&1 || true' EXIT
+
+          mkdir -p "$STATUS_WORKTREE/config/staging-review"
+          cp staging-review-receipt/deployment-receipt.json \
+            "$STATUS_WORKTREE/config/staging-review/deployment-receipt.json"
+
+          git -C "$STATUS_WORKTREE" config user.name 'github-actions[bot]'
+          git -C "$STATUS_WORKTREE" config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git -C "$STATUS_WORKTREE" add config/staging-review/deployment-receipt.json
+          if git -C "$STATUS_WORKTREE" diff --cached --quiet; then
+            echo 'Deployment receipt is unchanged.'
+            exit 0
+          fi
+          git -C "$STATUS_WORKTREE" commit -m 'P5-02Q: record configured review deployment result'
+          git -C "$STATUS_WORKTREE" push origin HEAD:staging-review
 
       - name: Enforce successful configured deployment
         if: always()

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -48,6 +48,9 @@ for (const marker of [
 const workflowMarkers = [
   'Deploy Submission rate-limit Durable Object Worker',
   'wrangler deploy --config workers/submission-rate-limit/wrangler.jsonc',
+  'tee worker-deployment-output.log',
+  'Upload Worker deployment diagnostics',
+  'staging-review-worker-deployment-log',
   'CPM_REVIEW_SECRET_SEED_BASE64URL',
   'node scripts/derive-suggest-review-secrets.mjs review-derived-secrets.json',
   'wrangler pages secret bulk pages-secrets.json',
@@ -67,11 +70,28 @@ const workflowMarkers = [
   '/api/suggest/readiness',
   'Authorization: Bearer $CPM_SUGGEST_READINESS_TOKEN',
   'configuredVerification',
+  'git worktree add --detach',
+  'git -C "$STATUS_WORKTREE" push origin HEAD:staging-review',
 ];
 
 for (const marker of workflowMarkers) {
   if (!workflow.includes(marker)) {
     throw new Error(`Configured Suggest workflow marker missing: ${marker}`);
+  }
+}
+
+for (const obsoleteMarker of [
+  'gh api --method PUT',
+  'secrets.CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL',
+  'secrets.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL',
+  'secrets.CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL',
+  'secrets.CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL',
+  'secrets.CPM_TURNSTILE_SECRET_KEY',
+  'secrets.PUBLIC_TURNSTILE_SITE_KEY',
+  'secrets.CPM_SUGGEST_READINESS_TOKEN',
+]) {
+  if (workflow.includes(obsoleteMarker)) {
+    throw new Error(`Obsolete configured deployment marker remains: ${obsoleteMarker}`);
   }
 }
 
@@ -86,20 +106,6 @@ for (const marker of [
 ]) {
   if (!reviewSecretDerivation.includes(marker)) {
     throw new Error(`Review secret derivation marker missing: ${marker}`);
-  }
-}
-
-for (const obsoleteSecret of [
-  'secrets.CPM_SUBMISSION_STATUS_HMAC_KEY_BASE64URL',
-  'secrets.CPM_SUBMISSION_CONTACT_ENCRYPTION_KEY_BASE64URL',
-  'secrets.CPM_SUBMISSION_EMAIL_HASH_HMAC_KEY_BASE64URL',
-  'secrets.CPM_SUBMISSION_RATE_LIMIT_BUCKET_HMAC_KEY_BASE64URL',
-  'secrets.CPM_TURNSTILE_SECRET_KEY',
-  'secrets.PUBLIC_TURNSTILE_SITE_KEY',
-  'secrets.CPM_SUGGEST_READINESS_TOKEN',
-]) {
-  if (workflow.includes(obsoleteSecret)) {
-    throw new Error(`Obsolete per-value review secret remains in workflow: ${obsoleteSecret}`);
   }
 }
 


### PR DESCRIPTION
## Implementation item

P5-02Q follow-up — fixed-review deployment diagnostics

## Purpose

Make the current `worker_deploy_failed` state actionable without requiring manual inspection of collapsed GitHub Actions logs, and make deployment receipt publication independent of GitHub CLI response parsing.

## Scope

- capture the full standard Wrangler output for the separate Submission rate-limit Durable Object Worker deploy;
- upload that output as the bounded `staging-review-worker-deployment-log` artifact only when the Worker deploy fails;
- record the diagnostics artifact name in the deployment receipt on Worker failure;
- replace the failing GitHub Contents API/`gh api` receipt publication step with a fast-forward git worktree update of the existing `staging-review` status branch;
- preserve the existing fail-closed downstream ordering and final deployment enforcement;
- strengthen the configured deployment contract checker to require the diagnostic artifact and git receipt publication path and reject the obsolete `gh api` path.

## Current failure established

Run #77 completed credential and configured-input checks, but the actual `worker_deploy` outcome was failure. The step appeared green only because it is intentionally `continue-on-error`; Pages secret synchronization and all later deployment steps were therefore correctly skipped. The uploaded receipt records `worker_deploy_failed`.

## Security boundary

- only the standard Worker deploy command output is uploaded;
- no derived application secrets, database URL, or readiness token are passed to the Worker deploy step;
- the Cloudflare token remains masked by GitHub Actions;
- receipt contents remain non-secret;
- no runtime, Candidate, canonical, export, or publication behavior changes.

## Validation

GitHub CI remains authoritative for format, lint, TypeScript/Astro, runtime checks, Worker dry-run compilation, migration drift, full tests, build, accessibility, staging artifacts, and the updated deployment contract gate.