### PR TITLE
P5-02Q: publish bounded Worker deployment error summary

### DIFF
--- a/.github/workflows/staging-review-deploy.yml
+++ b/.github/workflows/staging-review-deploy.yml
@@ -82,12 +82,21 @@ jobs:
           npx wrangler deploy --config workers/submission-rate-limit/wrangler.jsonc \
             2>&1 | tee worker-deployment-output.log
 
+      - name: Prepare Worker deployment diagnostic summary
+        if: always() && steps.worker_deploy.outcome == 'failure'
+        run: |
+          node scripts/summarize-worker-deployment-log.mjs \
+            worker-deployment-output.log \
+            worker-deployment-diagnostic.json
+
       - name: Upload Worker deployment diagnostics
         if: always() && steps.worker_deploy.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: staging-review-worker-deployment-log
-          path: worker-deployment-output.log
+          path: |
+            worker-deployment-output.log
+            worker-deployment-diagnostic.json
           if-no-files-found: error
           retention-days: 30
 
@@ -220,6 +229,9 @@ jobs:
           const missingConfiguredInputs = existsSync('missing-configured-inputs.txt')
             ? readFileSync('missing-configured-inputs.txt', 'utf8').split(/\r?\n/).filter(Boolean)
             : [];
+          const workerDeploymentDiagnostic = existsSync('worker-deployment-diagnostic.json')
+            ? JSON.parse(readFileSync('worker-deployment-diagnostic.json', 'utf8'))
+            : null;
           const output = existsSync('deployment-output.log') ? readFileSync('deployment-output.log', 'utf8') : '';
           const urls = output.match(/https:\/\/[^\s]+\.pages\.dev/g) ?? [];
           const receipt = {
@@ -238,6 +250,7 @@ jobs:
             ...(checks.durableObjectWorker === 'failure'
               ? { diagnosticsArtifact: 'staging-review-worker-deployment-log' }
               : {}),
+            ...(workerDeploymentDiagnostic ? { workerDeploymentDiagnostic } : {}),
             ...(missingConfiguredInputs.length > 0 ? { missingConfiguredInputs } : {}),
           };
           mkdirSync('staging-review-receipt', { recursive: true });

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -172,8 +172,14 @@ See https://user:password@example.test/private
 const diagnosticJson = JSON.stringify(diagnostic);
 assert(diagnostic.lines.length > 0, 'Worker diagnostic summary is empty.');
 assert(diagnosticJson.includes('10000'), 'Worker diagnostic summary removed the error code.');
-assert(!diagnosticJson.includes('Bearer A'), 'Worker diagnostic summary leaked authorization data.');
-assert(!diagnosticJson.includes('b'.repeat(32)), 'Worker diagnostic summary leaked a long account identifier.');
+assert(
+  !diagnosticJson.includes('Bearer A'),
+  'Worker diagnostic summary leaked authorization data.',
+);
+assert(
+  !diagnosticJson.includes('b'.repeat(32)),
+  'Worker diagnostic summary leaked a long account identifier.',
+);
 assert(!diagnosticJson.includes('password'), 'Worker diagnostic summary leaked URL credentials.');
 
 if (!suggestPage.includes('ConfiguredSuggestForm')) {

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { deriveSuggestReviewSecrets } from './derive-suggest-review-secrets.mjs';
+import { summarizeWorkerDeploymentLog } from './summarize-worker-deployment-log.mjs';
 
 const pagesConfig = JSON.parse(readFileSync('wrangler.jsonc', 'utf8'));
 const workflow = readFileSync('.github/workflows/staging-review-deploy.yml', 'utf8');
@@ -49,6 +50,9 @@ const workflowMarkers = [
   'Deploy Submission rate-limit Durable Object Worker',
   'wrangler deploy --config workers/submission-rate-limit/wrangler.jsonc',
   'tee worker-deployment-output.log',
+  'Prepare Worker deployment diagnostic summary',
+  'scripts/summarize-worker-deployment-log.mjs',
+  'worker-deployment-diagnostic.json',
   'Upload Worker deployment diagnostics',
   'staging-review-worker-deployment-log',
   'CPM_REVIEW_SECRET_SEED_BASE64URL',
@@ -70,6 +74,7 @@ const workflowMarkers = [
   '/api/suggest/readiness',
   'Authorization: Bearer $CPM_SUGGEST_READINESS_TOKEN',
   'configuredVerification',
+  'workerDeploymentDiagnostic',
   'git worktree add --detach',
   'git -C "$STATUS_WORKTREE" push origin HEAD:staging-review',
 ];
@@ -157,6 +162,19 @@ for (const invalidSeed of [
   }
   assert(rejected, 'Invalid review seed was accepted.');
 }
+
+const diagnostic = summarizeWorkerDeploymentLog(`
+Authorization: Bearer ${'A'.repeat(48)}
+Account ${'b'.repeat(32)}
+ERROR code: 10000 — authentication error while deploying Durable Object Worker
+See https://user:password@example.test/private
+`);
+const diagnosticJson = JSON.stringify(diagnostic);
+assert(diagnostic.lines.length > 0, 'Worker diagnostic summary is empty.');
+assert(diagnosticJson.includes('10000'), 'Worker diagnostic summary removed the error code.');
+assert(!diagnosticJson.includes('Bearer A'), 'Worker diagnostic summary leaked authorization data.');
+assert(!diagnosticJson.includes('b'.repeat(32)), 'Worker diagnostic summary leaked a long account identifier.');
+assert(!diagnosticJson.includes('password'), 'Worker diagnostic summary leaked URL credentials.');
 
 if (!suggestPage.includes('ConfiguredSuggestForm')) {
   throw new Error('Suggest page must use runtime-configured form wrapper.');

--- a/scripts/summarize-worker-deployment-log.mjs
+++ b/scripts/summarize-worker-deployment-log.mjs
@@ -2,10 +2,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const ansiPattern = new RegExp(
-  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`,
-  'g',
-);
+const ansiPattern = new RegExp(`${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`, 'g');
 const longTokenPattern = /\b[A-Za-z0-9_-]{32,}\b/g;
 const urlCredentialPattern = /(https?:\/\/)([^\s/@:]+):([^\s/@]+)@/gi;
 const authorizationPattern = /(authorization\s*:\s*)(.+)$/i;

--- a/scripts/summarize-worker-deployment-log.mjs
+++ b/scripts/summarize-worker-deployment-log.mjs
@@ -2,7 +2,10 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const ansiPattern = /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const ansiPattern = new RegExp(
+  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`,
+  'g',
+);
 const longTokenPattern = /\b[A-Za-z0-9_-]{32,}\b/g;
 const urlCredentialPattern = /(https?:\/\/)([^\s/@:]+):([^\s/@]+)@/gi;
 const authorizationPattern = /(authorization\s*:\s*)(.+)$/i;
@@ -20,10 +23,7 @@ function sanitizeLine(line) {
 }
 
 export function summarizeWorkerDeploymentLog(rawLog) {
-  const sanitizedLines = rawLog
-    .split(/\r?\n/)
-    .map(sanitizeLine)
-    .filter(Boolean);
+  const sanitizedLines = rawLog.split(/\r?\n/).map(sanitizeLine).filter(Boolean);
   const preferred = sanitizedLines.filter((line) => diagnosticPattern.test(line));
   const source = preferred.length > 0 ? preferred : sanitizedLines.slice(-12);
   return Object.freeze({

--- a/scripts/summarize-worker-deployment-log.mjs
+++ b/scripts/summarize-worker-deployment-log.mjs
@@ -1,0 +1,48 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ansiPattern = /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const longTokenPattern = /\b[A-Za-z0-9_-]{32,}\b/g;
+const urlCredentialPattern = /(https?:\/\/)([^\s/@:]+):([^\s/@]+)@/gi;
+const authorizationPattern = /(authorization\s*:\s*)(.+)$/i;
+const diagnosticPattern =
+  /(error|code|permission|authoriz|forbidden|authentication|durable object|workers? api|workers\.api|not allowed|requires|failed)/i;
+
+function sanitizeLine(line) {
+  return line
+    .replace(ansiPattern, '')
+    .replace(urlCredentialPattern, '$1<redacted>@')
+    .replace(authorizationPattern, '$1<redacted>')
+    .replace(longTokenPattern, '<redacted-token>')
+    .trim()
+    .slice(0, 320);
+}
+
+export function summarizeWorkerDeploymentLog(rawLog) {
+  const sanitizedLines = rawLog
+    .split(/\r?\n/)
+    .map(sanitizeLine)
+    .filter(Boolean);
+  const preferred = sanitizedLines.filter((line) => diagnosticPattern.test(line));
+  const source = preferred.length > 0 ? preferred : sanitizedLines.slice(-12);
+  return Object.freeze({
+    lines: source.slice(-12),
+  });
+}
+
+function main() {
+  const inputPath = process.argv[2];
+  const outputPath = process.argv[3];
+  if (!inputPath || !outputPath) {
+    throw new Error('Input and output paths are required.');
+  }
+  const summary = summarizeWorkerDeploymentLog(readFileSync(inputPath, 'utf8'));
+  writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 });
+  console.log('Worker deployment diagnostic summary prepared.');
+}
+
+const entrypoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (entrypoint === import.meta.url) {
+  main();
+}


### PR DESCRIPTION
## Implementation item

P5-02Q follow-up — Worker deployment error summary

## Purpose

Expose the remaining Cloudflare Worker deployment failure through the durable status receipt without relying on a workflow run ID or manual expansion of GitHub Actions logs.

## Scope

- add a bounded Worker deployment log summarizer;
- strip ANSI sequences, authorization values, URL credentials, and long token-like identifiers;
- retain only diagnostic lines and cap the result to twelve bounded lines;
- generate the summary only when the Worker deploy fails;
- upload the raw log and bounded summary together in the existing authenticated Actions artifact;
- include only the bounded summary in the non-secret deployment receipt;
- extend the deployment contract gate with synthetic redaction and error-code preservation checks.

## Security boundary

- application secrets and `DATABASE_URL` are not passed to the Worker deployment step;
- authorization data, URL credentials, and long token-like values are redacted before receipt publication;
- the raw Wrangler log remains in the authenticated Actions artifact only;
- no runtime, Candidate, canonical, export, or publication behavior changes.

## Validation

GitHub CI remains authoritative for format, lint, TypeScript/Astro, runtime checks, Worker dry-run compilation, migration drift, full tests, build, accessibility, staging artifacts, and the executable diagnostic-redaction deployment contract gate.