### PR TITLE
P5-02Q: preserve Pages deployment diagnostics

### DIFF
--- a/.github/workflows/staging-review-deploy.yml
+++ b/.github/workflows/staging-review-deploy.yml
@@ -158,6 +158,24 @@ jobs:
             --branch review \
             --config wrangler.jsonc 2>&1 | tee deployment-output.log
 
+      - name: Prepare Pages deployment diagnostic summary
+        if: always() && steps.deploy.outcome == 'failure'
+        run: |
+          node scripts/summarize-worker-deployment-log.mjs \
+            deployment-output.log \
+            pages-deployment-diagnostic.json
+
+      - name: Upload Pages deployment diagnostics
+        if: always() && steps.deploy.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-review-pages-deployment-log
+          path: |
+            deployment-output.log
+            pages-deployment-diagnostic.json
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Verify configured Suggest review path
         id: configured_verify
         if: steps.deploy.outcome == 'success'
@@ -232,6 +250,9 @@ jobs:
           const workerDeploymentDiagnostic = existsSync('worker-deployment-diagnostic.json')
             ? JSON.parse(readFileSync('worker-deployment-diagnostic.json', 'utf8'))
             : null;
+          const pagesDeploymentDiagnostic = existsSync('pages-deployment-diagnostic.json')
+            ? JSON.parse(readFileSync('pages-deployment-diagnostic.json', 'utf8'))
+            : null;
           const output = existsSync('deployment-output.log') ? readFileSync('deployment-output.log', 'utf8') : '';
           const urls = output.match(/https:\/\/[^\s]+\.pages\.dev/g) ?? [];
           const receipt = {
@@ -250,7 +271,11 @@ jobs:
             ...(checks.durableObjectWorker === 'failure'
               ? { diagnosticsArtifact: 'staging-review-worker-deployment-log' }
               : {}),
+            ...(checks.pagesDeployment === 'failure'
+              ? { pagesDiagnosticsArtifact: 'staging-review-pages-deployment-log' }
+              : {}),
             ...(workerDeploymentDiagnostic ? { workerDeploymentDiagnostic } : {}),
+            ...(pagesDeploymentDiagnostic ? { pagesDeploymentDiagnostic } : {}),
             ...(missingConfiguredInputs.length > 0 ? { missingConfiguredInputs } : {}),
           };
           mkdirSync('staging-review-receipt', { recursive: true });

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -51,7 +51,6 @@ const workflowMarkers = [
   'wrangler deploy --config workers/submission-rate-limit/wrangler.jsonc',
   'tee worker-deployment-output.log',
   'Prepare Worker deployment diagnostic summary',
-  'scripts/summarize-worker-deployment-log.mjs',
   'worker-deployment-diagnostic.json',
   'Upload Worker deployment diagnostics',
   'staging-review-worker-deployment-log',
@@ -68,6 +67,11 @@ const workflowMarkers = [
   "CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.cryptopaymap-staging.pages.dev'",
   "CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake'",
   'Deploy staging review to Cloudflare Pages',
+  'tee deployment-output.log',
+  'Prepare Pages deployment diagnostic summary',
+  'pages-deployment-diagnostic.json',
+  'Upload Pages deployment diagnostics',
+  'staging-review-pages-deployment-log',
   '--config wrangler.jsonc',
   'Verify configured Suggest review path',
   '/api/suggest/config',
@@ -75,6 +79,8 @@ const workflowMarkers = [
   'Authorization: Bearer $CPM_SUGGEST_READINESS_TOKEN',
   'configuredVerification',
   'workerDeploymentDiagnostic',
+  'pagesDeploymentDiagnostic',
+  'pagesDiagnosticsArtifact',
   'git worktree add --detach',
   'git -C "$STATUS_WORKTREE" push origin HEAD:staging-review',
 ];
@@ -170,17 +176,17 @@ ERROR code: 10000 — authentication error while deploying Durable Object Worker
 See https://user:password@example.test/private
 `);
 const diagnosticJson = JSON.stringify(diagnostic);
-assert(diagnostic.lines.length > 0, 'Worker diagnostic summary is empty.');
-assert(diagnosticJson.includes('10000'), 'Worker diagnostic summary removed the error code.');
+assert(diagnostic.lines.length > 0, 'Deployment diagnostic summary is empty.');
+assert(diagnosticJson.includes('10000'), 'Deployment diagnostic summary removed the error code.');
 assert(
   !diagnosticJson.includes('Bearer A'),
-  'Worker diagnostic summary leaked authorization data.',
+  'Deployment diagnostic summary leaked authorization data.',
 );
 assert(
   !diagnosticJson.includes('b'.repeat(32)),
-  'Worker diagnostic summary leaked a long account identifier.',
+  'Deployment diagnostic summary leaked a long account identifier.',
 );
-assert(!diagnosticJson.includes('password'), 'Worker diagnostic summary leaked URL credentials.');
+assert(!diagnosticJson.includes('password'), 'Deployment diagnostic summary leaked URL credentials.');
 
 if (!suggestPage.includes('ConfiguredSuggestForm')) {
   throw new Error('Suggest page must use runtime-configured form wrapper.');

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -186,7 +186,10 @@ assert(
   !diagnosticJson.includes('b'.repeat(32)),
   'Deployment diagnostic summary leaked a long account identifier.',
 );
-assert(!diagnosticJson.includes('password'), 'Deployment diagnostic summary leaked URL credentials.');
+assert(
+  !diagnosticJson.includes('password'),
+  'Deployment diagnostic summary leaked URL credentials.',
+);
 
 if (!suggestPage.includes('ConfiguredSuggestForm')) {
   throw new Error('Suggest page must use runtime-configured form wrapper.');


### PR DESCRIPTION
## Implementation item

P5-02Q follow-up — Pages deployment diagnostics

## Purpose

Make the remaining Cloudflare Pages deployment failure actionable without requiring manual expansion of GitHub Actions logs.

## Scope

- preserve the existing `wrangler pages deploy` output;
- generate a bounded redacted diagnostic summary only when the Pages deploy fails;
- upload the raw Pages deployment log and bounded summary as the authenticated `staging-review-pages-deployment-log` artifact;
- include the bounded summary and artifact name in the deployment receipt;
- preserve the existing Worker, secret synchronization, deployment ordering, readiness, receipt publication, and final enforcement behavior;
- extend the deployment contract checker to require the Pages diagnostic path.

## Current failure established

The updated Cloudflare token now allows the separate Durable Object Worker deployment and Pages preview secret synchronization to succeed. The remaining failure is the Pages deployment step; configured review verification is therefore correctly skipped.

## Security boundary

- the Pages deploy step receives only the Cloudflare deployment credentials;
- authorization values, URL credentials, and long token-like identifiers are redacted before receipt publication;
- the raw Wrangler log remains in the authenticated Actions artifact only;
- no runtime, Candidate, canonical, export, or publication behavior changes.

## Validation

GitHub CI remains authoritative for format, lint, TypeScript/Astro, runtime checks, Worker dry-run compilation, migration drift, full tests, build, accessibility, staging artifacts, and the updated deployment contract gate.