### PR TITLE
P5-02Q: use the default Wrangler config for Pages deploy

### DIFF
--- a/.github/workflows/staging-review-deploy.yml
+++ b/.github/workflows/staging-review-deploy.yml
@@ -155,8 +155,7 @@ jobs:
           set -o pipefail
           npx wrangler pages deploy dist \
             --project-name cryptopaymap-staging \
-            --branch review \
-            --config wrangler.jsonc 2>&1 | tee deployment-output.log
+            --branch review 2>&1 | tee deployment-output.log
 
       - name: Prepare Pages deployment diagnostic summary
         if: always() && steps.deploy.outcome == 'failure'

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -72,7 +72,6 @@ const workflowMarkers = [
   'pages-deployment-diagnostic.json',
   'Upload Pages deployment diagnostics',
   'staging-review-pages-deployment-log',
-  '--config wrangler.jsonc',
   'Verify configured Suggest review path',
   '/api/suggest/config',
   '/api/suggest/readiness',
@@ -89,6 +88,16 @@ for (const marker of workflowMarkers) {
   if (!workflow.includes(marker)) {
     throw new Error(`Configured Suggest workflow marker missing: ${marker}`);
   }
+}
+
+const pagesDeployCommand = workflow.match(
+  /npx wrangler pages deploy dist[\s\S]*?tee deployment-output\.log/,
+)?.[0];
+if (!pagesDeployCommand) {
+  throw new Error('Pages deployment command contract is missing.');
+}
+if (pagesDeployCommand.includes('--config')) {
+  throw new Error('Pages deployment must use the default root Wrangler configuration.');
 }
 
 for (const obsoleteMarker of [


### PR DESCRIPTION
## Implementation item

P5-02Q follow-up — Pages deploy configuration

## Purpose

Resolve the fixed-review Pages deployment failure reported by Wrangler:

```text
Pages does not support custom paths for the Wrangler configuration file
```

## Scope

- remove the explicit `--config wrangler.jsonc` flag from `wrangler pages deploy`;
- continue to run the Pages deploy from the repository root so Wrangler discovers the root `wrangler.jsonc` normally;
- preserve the separate Durable Object Worker deploy, which still requires its own explicit Worker config path;
- add a deployment-contract check that rejects any future `--config` flag inside the Pages deploy command;
- preserve existing Pages/Worker diagnostic artifacts, receipt state, secret synchronization, readiness verification, and final enforcement.

## Current evidence

The Cloudflare Worker deploy and Pages preview secret synchronization now succeed. The Pages deploy fails only because the command passes a custom Wrangler configuration path.

## Validation

GitHub CI remains authoritative for formatting, lint, Astro/TypeScript, runtime schemas, Worker dry-run compilation, migration drift, all tests, build, accessibility, staging artifacts, and the updated deployment contract gate.