### PR TITLE
P5-02Q: diagnose configured review verification failures

### DIFF
--- a/.github/workflows/staging-review-deploy.yml
+++ b/.github/workflows/staging-review-deploy.yml
@@ -179,40 +179,22 @@ jobs:
         id: configured_verify
         if: steps.deploy.outcome == 'success'
         continue-on-error: true
+        env:
+          CPM_REVIEW_BASE_URL: https://review.cryptopaymap-staging.pages.dev
+          CPM_EXPECTED_TURNSTILE_SITE_KEY: 1x00000000000000000000AA
+          CPM_EXPECTED_TURNSTILE_ACTION: submission_intake
         run: |
-          set -euo pipefail
-          base_url='https://review.cryptopaymap-staging.pages.dev'
-          verified='false'
+          node scripts/verify-configured-suggest-review.mjs \
+            configured-verification-diagnostic.json
 
-          for attempt in $(seq 1 18); do
-            config_status="$(curl -sS -o suggest-config-response.json -w '%{http_code}' "$base_url/api/suggest/config" || true)"
-            readiness_status="$(curl -sS -o suggest-readiness-response.json -w '%{http_code}' \
-              -H "Authorization: Bearer $CPM_SUGGEST_READINESS_TOKEN" \
-              "$base_url/api/suggest/readiness" || true)"
-            if [ "$config_status" = '200' ] && [ "$readiness_status" = '200' ]; then
-              verified='true'
-              break
-            fi
-            echo "Configured Suggest verification attempt $attempt not ready: config=$config_status readiness=$readiness_status"
-            sleep 5
-          done
-
-          test "$verified" = 'true'
-
-          node <<'NODE'
-          const { readFileSync } = require('node:fs');
-          const config = JSON.parse(readFileSync('suggest-config-response.json', 'utf8'));
-          if (config.siteKey !== '1x00000000000000000000AA') process.exit(1);
-          if (config.action !== 'submission_intake') process.exit(1);
-          const readiness = JSON.parse(readFileSync('suggest-readiness-response.json', 'utf8'));
-          if (readiness.ready !== true) process.exit(1);
-          NODE
-
-          headers="$(curl -sSI "$base_url/suggest")"
-          printf '%s\n' "$headers" | grep -Eqi '^content-security-policy:.*https://challenges\.cloudflare\.com'
-          printf '%s\n' "$headers" | grep -Eqi '^content-security-policy:.*frame-src https://challenges\.cloudflare\.com'
-
-          rm -f suggest-config-response.json suggest-readiness-response.json
+      - name: Upload configured verification diagnostics
+        if: always() && steps.configured_verify.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-review-configured-verification-diagnostic
+          path: configured-verification-diagnostic.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Write deployment receipt
         if: always()
@@ -252,6 +234,9 @@ jobs:
           const pagesDeploymentDiagnostic = existsSync('pages-deployment-diagnostic.json')
             ? JSON.parse(readFileSync('pages-deployment-diagnostic.json', 'utf8'))
             : null;
+          const configuredVerificationDiagnostic = existsSync('configured-verification-diagnostic.json')
+            ? JSON.parse(readFileSync('configured-verification-diagnostic.json', 'utf8'))
+            : null;
           const output = existsSync('deployment-output.log') ? readFileSync('deployment-output.log', 'utf8') : '';
           const urls = output.match(/https:\/\/[^\s]+\.pages\.dev/g) ?? [];
           const receipt = {
@@ -273,8 +258,17 @@ jobs:
             ...(checks.pagesDeployment === 'failure'
               ? { pagesDiagnosticsArtifact: 'staging-review-pages-deployment-log' }
               : {}),
+            ...(checks.configuredVerification === 'failure'
+              ? {
+                  configuredVerificationDiagnosticsArtifact:
+                    'staging-review-configured-verification-diagnostic',
+                }
+              : {}),
             ...(workerDeploymentDiagnostic ? { workerDeploymentDiagnostic } : {}),
             ...(pagesDeploymentDiagnostic ? { pagesDeploymentDiagnostic } : {}),
+            ...(configuredVerificationDiagnostic
+              ? { configuredVerificationDiagnostic }
+              : {}),
             ...(missingConfiguredInputs.length > 0 ? { missingConfiguredInputs } : {}),
           };
           mkdirSync('staging-review-receipt', { recursive: true });

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -233,10 +233,10 @@ const expectedAction = 'submission_intake';
 const successfulVerifierFetch = async (input, init = {}) => {
   const url = new URL(String(input));
   if (url.pathname === '/api/suggest/config') {
-    return new Response(
-      JSON.stringify({ siteKey: expectedSiteKey, action: expectedAction }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
-    );
+    return new Response(JSON.stringify({ siteKey: expectedSiteKey, action: expectedAction }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
   if (url.pathname === '/api/suggest/readiness') {
     assert(
@@ -284,10 +284,10 @@ try {
     fetchImpl: async (input) => {
       const url = new URL(String(input));
       if (url.pathname === '/api/suggest/config') {
-        return new Response(
-          JSON.stringify({ siteKey: expectedSiteKey, action: expectedAction }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
+        return new Response(JSON.stringify({ siteKey: expectedSiteKey, action: expectedAction }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
       if (url.pathname === '/api/suggest/readiness') {
         return new Response(JSON.stringify({ ready: false }), {

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -1,6 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { deriveSuggestReviewSecrets } from './derive-suggest-review-secrets.mjs';
 import { summarizeWorkerDeploymentLog } from './summarize-worker-deployment-log.mjs';
+import {
+  ConfiguredSuggestReviewVerificationError,
+  verifyConfiguredSuggestReview,
+} from './verify-configured-suggest-review.mjs';
 
 const pagesConfig = JSON.parse(readFileSync('wrangler.jsonc', 'utf8'));
 const workflow = readFileSync('.github/workflows/staging-review-deploy.yml', 'utf8');
@@ -8,6 +12,7 @@ const workerConfig = readFileSync('workers/submission-rate-limit/wrangler.jsonc'
 const suggestPage = readFileSync('src/pages/suggest.astro', 'utf8');
 const configuredForm = readFileSync('src/components/submissions/ConfiguredSuggestForm.tsx', 'utf8');
 const reviewSecretDerivation = readFileSync('scripts/derive-suggest-review-secrets.mjs', 'utf8');
+const configuredVerifier = readFileSync('scripts/verify-configured-suggest-review.mjs', 'utf8');
 
 const expectedBinding = {
   name: 'SUBMISSION_RATE_LIMIT_BUCKETS',
@@ -73,10 +78,13 @@ const workflowMarkers = [
   'Upload Pages deployment diagnostics',
   'staging-review-pages-deployment-log',
   'Verify configured Suggest review path',
-  '/api/suggest/config',
-  '/api/suggest/readiness',
-  'Authorization: Bearer $CPM_SUGGEST_READINESS_TOKEN',
+  'scripts/verify-configured-suggest-review.mjs',
+  'configured-verification-diagnostic.json',
+  'Upload configured verification diagnostics',
+  'staging-review-configured-verification-diagnostic',
   'configuredVerification',
+  'configuredVerificationDiagnostic',
+  'configuredVerificationDiagnosticsArtifact',
   'workerDeploymentDiagnostic',
   'pagesDeploymentDiagnostic',
   'pagesDiagnosticsArtifact',
@@ -129,6 +137,21 @@ for (const marker of [
   }
 }
 
+for (const marker of [
+  '/api/suggest/config',
+  '/api/suggest/readiness',
+  'content-security-policy',
+  'https://challenges.cloudflare.com',
+  'ConfiguredSuggestReviewVerificationError',
+  'attemptsCompleted',
+  'siteKeyMatches',
+  'frameSrcAllowsChallenge',
+]) {
+  if (!configuredVerifier.includes(marker)) {
+    throw new Error(`Configured review verifier marker missing: ${marker}`);
+  }
+}
+
 const seedOne = Buffer.alloc(32, 7).toString('base64url');
 const seedTwo = Buffer.alloc(32, 8).toString('base64url');
 const first = deriveSuggestReviewSecrets(seedOne);
@@ -178,26 +201,117 @@ for (const invalidSeed of [
   assert(rejected, 'Invalid review seed was accepted.');
 }
 
-const diagnostic = summarizeWorkerDeploymentLog(`
+const deploymentDiagnostic = summarizeWorkerDeploymentLog(`
 Authorization: Bearer ${'A'.repeat(48)}
 Account ${'b'.repeat(32)}
 ERROR code: 10000 — authentication error while deploying Durable Object Worker
 See https://user:password@example.test/private
 `);
-const diagnosticJson = JSON.stringify(diagnostic);
-assert(diagnostic.lines.length > 0, 'Deployment diagnostic summary is empty.');
-assert(diagnosticJson.includes('10000'), 'Deployment diagnostic summary removed the error code.');
+const deploymentDiagnosticJson = JSON.stringify(deploymentDiagnostic);
+assert(deploymentDiagnostic.lines.length > 0, 'Deployment diagnostic summary is empty.');
 assert(
-  !diagnosticJson.includes('Bearer A'),
+  deploymentDiagnosticJson.includes('10000'),
+  'Deployment diagnostic summary removed the error code.',
+);
+assert(
+  !deploymentDiagnosticJson.includes('Bearer A'),
   'Deployment diagnostic summary leaked authorization data.',
 );
 assert(
-  !diagnosticJson.includes('b'.repeat(32)),
+  !deploymentDiagnosticJson.includes('b'.repeat(32)),
   'Deployment diagnostic summary leaked a long account identifier.',
 );
 assert(
-  !diagnosticJson.includes('password'),
+  !deploymentDiagnosticJson.includes('password'),
   'Deployment diagnostic summary leaked URL credentials.',
+);
+
+const verifierToken = 'T'.repeat(48);
+const verifierBaseUrl = 'https://review.example.test';
+const expectedSiteKey = '1x00000000000000000000AA';
+const expectedAction = 'submission_intake';
+const successfulVerifierFetch = async (input, init = {}) => {
+  const url = new URL(String(input));
+  if (url.pathname === '/api/suggest/config') {
+    return new Response(
+      JSON.stringify({ siteKey: expectedSiteKey, action: expectedAction }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+  if (url.pathname === '/api/suggest/readiness') {
+    assert(
+      new Headers(init.headers).get('Authorization') === `Bearer ${verifierToken}`,
+      'Configured verifier did not send the readiness bearer token.',
+    );
+    return new Response(JSON.stringify({ ready: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (url.pathname === '/suggest') {
+    return new Response('ok', {
+      status: 200,
+      headers: {
+        'Content-Security-Policy':
+          "default-src 'self'; script-src 'self' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com",
+      },
+    });
+  }
+  throw new Error(`Unexpected verifier URL: ${url.pathname}`);
+};
+
+const successfulVerification = await verifyConfiguredSuggestReview({
+  baseUrl: verifierBaseUrl,
+  readinessToken: verifierToken,
+  expectedSiteKey,
+  expectedAction,
+  attempts: 1,
+  delayMs: 0,
+  fetchImpl: successfulVerifierFetch,
+});
+assert(successfulVerification.status === 'success', 'Configured verifier success path failed.');
+assert(successfulVerification.stage === 'complete', 'Configured verifier did not complete.');
+
+let failedVerification = null;
+try {
+  await verifyConfiguredSuggestReview({
+    baseUrl: verifierBaseUrl,
+    readinessToken: verifierToken,
+    expectedSiteKey,
+    expectedAction,
+    attempts: 1,
+    delayMs: 0,
+    fetchImpl: async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/api/suggest/config') {
+        return new Response(
+          JSON.stringify({ siteKey: expectedSiteKey, action: expectedAction }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.pathname === '/api/suggest/readiness') {
+        return new Response(JSON.stringify({ ready: false }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      throw new Error(`Unexpected failed verifier URL: ${url.pathname}`);
+    },
+  });
+} catch (error) {
+  failedVerification = error;
+}
+assert(
+  failedVerification instanceof ConfiguredSuggestReviewVerificationError,
+  'Configured verifier failure did not use the bounded error type.',
+);
+assert(
+  failedVerification.diagnostic.readiness.httpStatus === 503,
+  'Configured verifier failure did not retain the readiness status.',
+);
+assert(
+  !JSON.stringify(failedVerification.diagnostic).includes(verifierToken),
+  'Configured verifier diagnostic leaked the readiness token.',
 );
 
 if (!suggestPage.includes('ConfiguredSuggestForm')) {

--- a/scripts/verify-configured-suggest-review.mjs
+++ b/scripts/verify-configured-suggest-review.mjs
@@ -34,8 +34,7 @@ function summarizeReadinessResponse(status, parsedBody) {
     httpStatus: status,
     jsonParsed: parsedBody.parsed,
     ready: objectValue?.ready === true,
-    errorCode:
-      typeof objectValue?.error === 'string' ? objectValue.error.slice(0, 64) : null,
+    errorCode: typeof objectValue?.error === 'string' ? objectValue.error.slice(0, 64) : null,
   };
 }
 
@@ -54,10 +53,8 @@ function summarizeCsp(status, headerValue) {
   return {
     httpStatus: status,
     headerPresent: headerValue.length > 0,
-    scriptSrcAllowsChallenge:
-      directives.get('script-src')?.includes(challengeOrigin) ?? false,
-    frameSrcAllowsChallenge:
-      directives.get('frame-src')?.includes(challengeOrigin) ?? false,
+    scriptSrcAllowsChallenge: directives.get('script-src')?.includes(challengeOrigin) ?? false,
+    frameSrcAllowsChallenge: directives.get('frame-src')?.includes(challengeOrigin) ?? false,
   };
 }
 
@@ -129,8 +126,7 @@ export async function verifyConfiguredSuggestReview({
       );
 
       const endpointsReady =
-        diagnostic.config.httpStatus === 200 &&
-        diagnostic.readiness.httpStatus === 200;
+        diagnostic.config.httpStatus === 200 && diagnostic.readiness.httpStatus === 200;
       const payloadsValid =
         diagnostic.config.jsonParsed &&
         diagnostic.config.siteKeyMatches &&
@@ -166,8 +162,7 @@ export async function verifyConfiguredSuggestReview({
       }
     } catch (error) {
       diagnostic.stage = 'network';
-      diagnostic.networkError =
-        error instanceof Error ? error.name.slice(0, 64) : 'UnknownError';
+      diagnostic.networkError = error instanceof Error ? error.name.slice(0, 64) : 'UnknownError';
     }
 
     if (attempt < attempts) await sleep(delayMs);

--- a/scripts/verify-configured-suggest-review.mjs
+++ b/scripts/verify-configured-suggest-review.mjs
@@ -1,0 +1,219 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const challengeOrigin = 'https://challenges.cloudflare.com';
+
+function sleep(milliseconds) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+}
+
+function parseJsonText(text) {
+  try {
+    return { parsed: true, value: JSON.parse(text) };
+  } catch {
+    return { parsed: false, value: null };
+  }
+}
+
+function summarizeConfigResponse(status, parsedBody, expectedSiteKey, expectedAction) {
+  const value = parsedBody.value;
+  const objectValue = value !== null && typeof value === 'object' ? value : null;
+  return {
+    httpStatus: status,
+    jsonParsed: parsedBody.parsed,
+    siteKeyMatches: objectValue?.siteKey === expectedSiteKey,
+    actionMatches: objectValue?.action === expectedAction,
+  };
+}
+
+function summarizeReadinessResponse(status, parsedBody) {
+  const value = parsedBody.value;
+  const objectValue = value !== null && typeof value === 'object' ? value : null;
+  return {
+    httpStatus: status,
+    jsonParsed: parsedBody.parsed,
+    ready: objectValue?.ready === true,
+    errorCode:
+      typeof objectValue?.error === 'string' ? objectValue.error.slice(0, 64) : null,
+  };
+}
+
+function parseCsp(headerValue) {
+  const directives = new Map();
+  for (const rawDirective of headerValue.split(';')) {
+    const parts = rawDirective.trim().split(/\s+/).filter(Boolean);
+    const [name, ...values] = parts;
+    if (name) directives.set(name.toLowerCase(), values);
+  }
+  return directives;
+}
+
+function summarizeCsp(status, headerValue) {
+  const directives = parseCsp(headerValue);
+  return {
+    httpStatus: status,
+    headerPresent: headerValue.length > 0,
+    scriptSrcAllowsChallenge:
+      directives.get('script-src')?.includes(challengeOrigin) ?? false,
+    frameSrcAllowsChallenge:
+      directives.get('frame-src')?.includes(challengeOrigin) ?? false,
+  };
+}
+
+export class ConfiguredSuggestReviewVerificationError extends Error {
+  constructor(diagnostic) {
+    super(`Configured Suggest review verification failed at ${diagnostic.stage}.`);
+    this.name = 'ConfiguredSuggestReviewVerificationError';
+    this.diagnostic = diagnostic;
+  }
+}
+
+export async function verifyConfiguredSuggestReview({
+  baseUrl,
+  readinessToken,
+  expectedSiteKey,
+  expectedAction,
+  attempts = 18,
+  delayMs = 5_000,
+  fetchImpl = fetch,
+}) {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+  const diagnostic = {
+    status: 'failure',
+    stage: 'endpoints',
+    baseUrl: normalizedBaseUrl,
+    attemptsCompleted: 0,
+    config: null,
+    readiness: null,
+    csp: null,
+    networkError: null,
+  };
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    diagnostic.attemptsCompleted = attempt;
+    diagnostic.networkError = null;
+
+    try {
+      const [configResponse, readinessResponse] = await Promise.all([
+        fetchImpl(`${normalizedBaseUrl}/api/suggest/config`, {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+          cache: 'no-store',
+          redirect: 'follow',
+        }),
+        fetchImpl(`${normalizedBaseUrl}/api/suggest/readiness`, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${readinessToken}`,
+          },
+          cache: 'no-store',
+          redirect: 'follow',
+        }),
+      ]);
+
+      const [configText, readinessText] = await Promise.all([
+        configResponse.text(),
+        readinessResponse.text(),
+      ]);
+      diagnostic.config = summarizeConfigResponse(
+        configResponse.status,
+        parseJsonText(configText),
+        expectedSiteKey,
+        expectedAction,
+      );
+      diagnostic.readiness = summarizeReadinessResponse(
+        readinessResponse.status,
+        parseJsonText(readinessText),
+      );
+
+      const endpointsReady =
+        diagnostic.config.httpStatus === 200 &&
+        diagnostic.readiness.httpStatus === 200;
+      const payloadsValid =
+        diagnostic.config.jsonParsed &&
+        diagnostic.config.siteKeyMatches &&
+        diagnostic.config.actionMatches &&
+        diagnostic.readiness.jsonParsed &&
+        diagnostic.readiness.ready;
+
+      if (endpointsReady && payloadsValid) {
+        diagnostic.stage = 'csp';
+        const suggestResponse = await fetchImpl(`${normalizedBaseUrl}/suggest`, {
+          method: 'GET',
+          cache: 'no-store',
+          redirect: 'follow',
+        });
+        diagnostic.csp = summarizeCsp(
+          suggestResponse.status,
+          suggestResponse.headers.get('content-security-policy') ?? '',
+        );
+
+        if (
+          diagnostic.csp.httpStatus >= 200 &&
+          diagnostic.csp.httpStatus < 400 &&
+          diagnostic.csp.headerPresent &&
+          diagnostic.csp.scriptSrcAllowsChallenge &&
+          diagnostic.csp.frameSrcAllowsChallenge
+        ) {
+          diagnostic.status = 'success';
+          diagnostic.stage = 'complete';
+          return Object.freeze(diagnostic);
+        }
+      } else {
+        diagnostic.stage = endpointsReady ? 'payloads' : 'endpoints';
+      }
+    } catch (error) {
+      diagnostic.stage = 'network';
+      diagnostic.networkError =
+        error instanceof Error ? error.name.slice(0, 64) : 'UnknownError';
+    }
+
+    if (attempt < attempts) await sleep(delayMs);
+  }
+
+  throw new ConfiguredSuggestReviewVerificationError(Object.freeze(diagnostic));
+}
+
+async function main() {
+  const outputPath = process.argv[2];
+  if (!outputPath) throw new Error('Diagnostic output path is required.');
+
+  const baseUrl = process.env.CPM_REVIEW_BASE_URL;
+  const readinessToken = process.env.CPM_SUGGEST_READINESS_TOKEN;
+  const expectedSiteKey = process.env.CPM_EXPECTED_TURNSTILE_SITE_KEY;
+  const expectedAction = process.env.CPM_EXPECTED_TURNSTILE_ACTION;
+  if (!baseUrl || !readinessToken || !expectedSiteKey || !expectedAction) {
+    throw new Error('Configured review verifier environment is incomplete.');
+  }
+
+  try {
+    const diagnostic = await verifyConfiguredSuggestReview({
+      baseUrl,
+      readinessToken,
+      expectedSiteKey,
+      expectedAction,
+    });
+    writeFileSync(outputPath, `${JSON.stringify(diagnostic, null, 2)}\n`);
+    console.log('Configured Suggest review verification passed.');
+  } catch (error) {
+    const diagnostic =
+      error instanceof ConfiguredSuggestReviewVerificationError
+        ? error.diagnostic
+        : {
+            status: 'failure',
+            stage: 'internal',
+            baseUrl,
+            attemptsCompleted: 0,
+          };
+    writeFileSync(outputPath, `${JSON.stringify(diagnostic, null, 2)}\n`);
+    console.error(`Configured Suggest review verification failed at ${diagnostic.stage}.`);
+    process.exitCode = 1;
+  }
+}
+
+const entrypoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (entrypoint === import.meta.url) {
+  await main();
+}


### PR DESCRIPTION
## Implementation item

P5-02Q follow-up — configured review verification diagnostics

## Purpose

Replace the opaque post-deployment verification failure with a bounded verifier that identifies whether the failure is in public runtime config, authenticated readiness, response payloads, network reachability, or deployed CSP.

## Scope

- add a dedicated Node verifier for `/api/suggest/config`, `/api/suggest/readiness`, and `/suggest` CSP;
- preserve the existing retry window;
- record only safe status, shape, and CSP booleans;
- never write or return the readiness bearer token;
- upload the diagnostic JSON as an authenticated Actions artifact on verification failure;
- include the bounded diagnostic and artifact name in the fixed-review deployment receipt;
- replace the prior shell/curl verifier with the dedicated verifier;
- add executable success/failure checks to the staging deployment-contract gate, including readiness-token non-disclosure.

## Current evidence

Cloudflare credentials, configured inputs, the separate Durable Object Worker deployment, Pages preview secret synchronization, and Pages deployment all succeed. Only configured verification remains failed.

## Security boundary

- the verifier stores no bearer token, database URL, secret key, raw IP, email, status secret, or provider credential;
- config diagnostics record only whether the public site key and action match;
- readiness diagnostics record HTTP status, JSON parse state, ready boolean, and bounded generic error code;
- CSP diagnostics record only directive booleans;
- no Candidate, canonical, export, or publication behavior changes.

## Validation

GitHub CI remains authoritative for formatting, lint, Astro/TypeScript, runtime checks, Worker dry-run compilation, migration drift, all tests, build, accessibility, staging artifacts, and executable verifier success/failure coverage.