### PR TITLE
P5-02Q: attach Suggest CSP through Pages Functions middleware

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,10 @@
+import { applyPagesResponseHeaders } from '../src/http/pages-response-headers';
+
+interface PagesMiddlewareContext {
+  request: Request;
+  next(): Promise<Response>;
+}
+
+export async function onRequest(context: PagesMiddlewareContext): Promise<Response> {
+  return applyPagesResponseHeaders(context.request, await context.next());
+}

--- a/scripts/check-suggest-form-artifact.mjs
+++ b/scripts/check-suggest-form-artifact.mjs
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 const suggestPage = readFileSync(join('dist', 'suggest/index.html'), 'utf8');
 const contributePage = readFileSync(join('dist', 'contribute/index.html'), 'utf8');
 const headers = readFileSync(join('dist', '_headers'), 'utf8');
+const runtimeHeaderPolicy = readFileSync('src/http/pages-response-headers.ts', 'utf8');
+const pagesMiddleware = readFileSync('functions/_middleware.ts', 'utf8');
 
 const requiredSuggestFragments = [
   'Suggest a place or online service',
@@ -53,7 +55,6 @@ for (const fragment of forbiddenSuggestFragments) {
 }
 
 const requiredCspFragments = [
-  '/suggest',
   "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
   'frame-src https://challenges.cloudflare.com',
   "connect-src 'self'",
@@ -61,10 +62,22 @@ const requiredCspFragments = [
   "frame-ancestors 'none'",
 ];
 
+if (!headers.includes('/suggest')) {
+  throw new Error('Missing static Suggest header path marker.');
+}
 for (const fragment of requiredCspFragments) {
   if (!headers.includes(fragment)) {
-    throw new Error(`Missing Suggest Turnstile CSP marker: ${fragment}`);
+    throw new Error(`Missing static Suggest Turnstile CSP marker: ${fragment}`);
+  }
+  if (!runtimeHeaderPolicy.includes(fragment)) {
+    throw new Error(`Missing Pages Function Suggest CSP marker: ${fragment}`);
   }
 }
 
-console.log('Suggest form and Turnstile CSP artifact checks passed.');
+for (const marker of ['applyPagesResponseHeaders', 'context.next()']) {
+  if (!pagesMiddleware.includes(marker)) {
+    throw new Error(`Missing Pages response-header middleware marker: ${marker}`);
+  }
+}
+
+console.log('Suggest form and static/Function Turnstile CSP checks passed.');

--- a/src/http/pages-response-headers.ts
+++ b/src/http/pages-response-headers.ts
@@ -1,0 +1,88 @@
+export const suggestContentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
+  'frame-src https://challenges.cloudflare.com',
+  "connect-src 'self'",
+  "img-src 'self' data:",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self'",
+  "base-uri 'none'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
+const reviewRobotsPolicy = 'noindex, nofollow, noarchive';
+
+function isFixedReviewHostname(hostname: string): boolean {
+  return (
+    hostname === 'cryptopaymap-staging.pages.dev' ||
+    hostname.endsWith('.cryptopaymap-staging.pages.dev')
+  );
+}
+
+function isExactPath(pathname: string, path: string): boolean {
+  return pathname === path || pathname === `${path}/`;
+}
+
+function applyCommonSecurityHeaders(headers: Headers): void {
+  headers.set('X-Content-Type-Options', 'nosniff');
+  headers.set('X-Frame-Options', 'DENY');
+  headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  headers.set(
+    'Permissions-Policy',
+    'camera=(), microphone=(), geolocation=(self), payment=()',
+  );
+}
+
+function applyPathSpecificHeaders(requestUrl: URL, headers: Headers): void {
+  const { pathname } = requestUrl;
+
+  if (isFixedReviewHostname(requestUrl.hostname)) {
+    headers.set('X-Robots-Tag', reviewRobotsPolicy);
+  }
+
+  if (isExactPath(pathname, '/suggest')) {
+    headers.set('Content-Security-Policy', suggestContentSecurityPolicy);
+    headers.set('Cache-Control', 'no-store');
+    headers.set('Referrer-Policy', 'no-referrer');
+    return;
+  }
+
+  if (isExactPath(pathname, '/admin') || pathname.startsWith('/admin/')) {
+    headers.set('Cache-Control', 'private, no-store');
+    headers.set('Referrer-Policy', 'no-referrer');
+    headers.set('X-Robots-Tag', reviewRobotsPolicy);
+    return;
+  }
+
+  if (pathname.startsWith('/_astro/')) {
+    headers.set('Cache-Control', 'public, max-age=31556952, immutable');
+    return;
+  }
+
+  if (pathname.startsWith('/data/')) {
+    headers.set('Cache-Control', 'public, max-age=300, must-revalidate');
+    return;
+  }
+
+  if (isExactPath(pathname, '/manifest.webmanifest')) {
+    headers.set('Cache-Control', 'public, max-age=300, must-revalidate');
+    return;
+  }
+
+  if (pathname.startsWith('/icons/')) {
+    headers.set('Cache-Control', 'public, max-age=86400, must-revalidate');
+  }
+}
+
+export function applyPagesResponseHeaders(request: Request, response: Response): Response {
+  const headers = new Headers(response.headers);
+  applyCommonSecurityHeaders(headers);
+  applyPathSpecificHeaders(new URL(request.url), headers);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/src/http/pages-response-headers.ts
+++ b/src/http/pages-response-headers.ts
@@ -24,11 +24,16 @@ function isExactPath(pathname: string, path: string): boolean {
   return pathname === path || pathname === `${path}/`;
 }
 
+function setIfMissing(headers: Headers, name: string, value: string): void {
+  if (!headers.has(name)) headers.set(name, value);
+}
+
 function applyCommonSecurityHeaders(headers: Headers): void {
-  headers.set('X-Content-Type-Options', 'nosniff');
-  headers.set('X-Frame-Options', 'DENY');
-  headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  headers.set(
+  setIfMissing(headers, 'X-Content-Type-Options', 'nosniff');
+  setIfMissing(headers, 'X-Frame-Options', 'DENY');
+  setIfMissing(headers, 'Referrer-Policy', 'strict-origin-when-cross-origin');
+  setIfMissing(
+    headers,
     'Permissions-Policy',
     'camera=(), microphone=(), geolocation=(self), payment=()',
   );

--- a/tests/pages-response-headers.test.ts
+++ b/tests/pages-response-headers.test.ts
@@ -15,9 +15,7 @@ describe('P5-02Q Pages Function response headers', () => {
   it('attaches the exact Suggest CSP and fail-closed cache/referrer policy', async () => {
     const response = apply('/suggest', 'review.cryptopaymap-staging.pages.dev');
 
-    expect(response.headers.get('Content-Security-Policy')).toBe(
-      suggestContentSecurityPolicy,
-    );
+    expect(response.headers.get('Content-Security-Policy')).toBe(suggestContentSecurityPolicy);
     expect(response.headers.get('Cache-Control')).toBe('no-store');
     expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
     expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');

--- a/tests/pages-response-headers.test.ts
+++ b/tests/pages-response-headers.test.ts
@@ -35,6 +35,23 @@ describe('P5-02Q Pages Function response headers', () => {
     expect(response.headers.has('X-Robots-Tag')).toBe(false);
   });
 
+  it('preserves a stricter upstream security header', () => {
+    const response = apply(
+      '/api/suggest/config',
+      'www.example.test',
+      new Response('{}', {
+        headers: {
+          'Content-Type': 'application/json',
+          'Referrer-Policy': 'no-referrer',
+          'X-Content-Type-Options': 'nosniff',
+        },
+      }),
+    );
+
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+  });
+
   it('marks every fixed-review response as non-indexable', () => {
     const response = apply('/places', 'cryptopaymap-staging.pages.dev');
 

--- a/tests/pages-response-headers.test.ts
+++ b/tests/pages-response-headers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyPagesResponseHeaders,
+  suggestContentSecurityPolicy,
+} from '../src/http/pages-response-headers';
+
+function apply(path: string, hostname = 'www.example.test', response?: Response): Response {
+  return applyPagesResponseHeaders(
+    new Request(`https://${hostname}${path}`),
+    response ?? new Response('ok', { status: 200, headers: { 'X-Upstream': 'kept' } }),
+  );
+}
+
+describe('P5-02Q Pages Function response headers', () => {
+  it('attaches the exact Suggest CSP and fail-closed cache/referrer policy', async () => {
+    const response = apply('/suggest', 'review.cryptopaymap-staging.pages.dev');
+
+    expect(response.headers.get('Content-Security-Policy')).toBe(
+      suggestContentSecurityPolicy,
+    );
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow, noarchive');
+    expect(response.headers.get('X-Upstream')).toBe('kept');
+    await expect(response.text()).resolves.toBe('ok');
+  });
+
+  it('does not attach the Suggest CSP to unrelated public paths', () => {
+    const response = apply('/places');
+
+    expect(response.headers.has('Content-Security-Policy')).toBe(false);
+    expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(response.headers.has('X-Robots-Tag')).toBe(false);
+  });
+
+  it('marks every fixed-review response as non-indexable', () => {
+    const response = apply('/places', 'cryptopaymap-staging.pages.dev');
+
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow, noarchive');
+  });
+
+  it('preserves the protected Admin cache, referrer, and robots policy', () => {
+    const response = apply('/admin/submissions/example');
+
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow, noarchive');
+  });
+
+  it.each([
+    ['/_astro/app.123.js', 'public, max-age=31556952, immutable'],
+    ['/data/places.json', 'public, max-age=300, must-revalidate'],
+    ['/manifest.webmanifest', 'public, max-age=300, must-revalidate'],
+    ['/icons/icon-192.png', 'public, max-age=86400, must-revalidate'],
+  ])('preserves the cache policy for %s', (path, expectedCacheControl) => {
+    expect(apply(path).headers.get('Cache-Control')).toBe(expectedCacheControl);
+  });
+
+  it('preserves status, status text, and existing response headers', () => {
+    const response = apply(
+      '/places',
+      'www.example.test',
+      new Response(null, {
+        status: 304,
+        statusText: 'Not Modified',
+        headers: { ETag: 'example-etag' },
+      }),
+    );
+
+    expect(response.status).toBe(304);
+    expect(response.statusText).toBe('Not Modified');
+    expect(response.headers.get('ETag')).toBe('example-etag');
+  });
+});


### PR DESCRIPTION
## Implementation item

P5-02Q follow-up — Pages Function response headers

## Purpose

Resolve the final fixed-review verification failure: runtime config, Neon readiness, Durable Object reachability, and Pages deployment all succeed, but `/suggest` has no CSP header in the deployed Pages Functions response.

Cloudflare Pages applies `_headers` only to static asset responses. Responses passing through Pages Functions require headers to be attached in Function code.

## Scope

- add root Pages Functions middleware so static pages and Function routes share one response-header boundary;
- attach the exact `/suggest` Turnstile CSP, `no-store`, and `no-referrer` policy at runtime;
- preserve the existing common security headers;
- preserve Admin no-store/noindex behavior;
- preserve `_astro`, data, manifest, and icon cache policies;
- mark fixed-review Pages hostnames as non-indexable;
- preserve stricter headers already set by API responses;
- retain `_headers` as the static fallback;
- add focused tests for Suggest CSP, review noindex, Admin and cache policies, upstream header preservation, and response status/body preservation;
- extend the Suggest artifact gate to require both static and Pages Function CSP paths.

## Current evidence

The fixed-review receipt for main commit `3c0bb09e0f9897451d707b6fec7b9f61bcf396c3` records:

- client runtime config 200 with matching site key and action;
- authenticated readiness 200 with `ready: true`;
- Pages deployment success;
- CSP stage failure because `Content-Security-Policy` is absent.

## Security boundary

- no secret or environment value is exposed;
- the middleware only transforms response headers after `context.next()`;
- existing stricter API headers are retained;
- no intake, persistence, Candidate, canonical, export, or publication behavior changes.

## Validation

GitHub CI remains authoritative for formatting, lint, Astro/TypeScript, runtime schemas, Worker dry-run compilation, migration drift, all tests, build, accessibility, staging artifacts, and the static/Function CSP artifact gate.