### PR TITLE
P5-02R: separate fixed-review browser and Siteverify actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,11 @@ CPM_TURNSTILE_SECRET_KEY=
 PUBLIC_TURNSTILE_SITE_KEY=
 # Exact lowercase hostname returned by Siteverify, without scheme, port, path, or trailing dot.
 CPM_TURNSTILE_EXPECTED_HOSTNAME=
-# 1-32 characters; ASCII letters, digits, underscore, and hyphen only.
+# Exact Siteverify action, 1-32 ASCII letters, digits, underscore, or hyphen.
 CPM_TURNSTILE_EXPECTED_ACTION=submission_intake
+# Optional browser widget action. Omit when it is identical to the Siteverify action.
+# Fixed test environments may set this to submission_intake while validating official dummy metadata.
+PUBLIC_TURNSTILE_ACTION=
 
 # Server-only bearer token for configured-environment readiness verification.
 # At least 32 non-whitespace characters. Do not reuse another application secret.

--- a/.github/workflows/staging-review-deploy.yml
+++ b/.github/workflows/staging-review-deploy.yml
@@ -130,8 +130,9 @@ jobs:
             CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: '600',
             CPM_TURNSTILE_SECRET_KEY: '1x0000000000000000000000000000000AA',
             PUBLIC_TURNSTILE_SITE_KEY: '1x00000000000000000000AA',
-            CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.cryptopaymap-staging.pages.dev',
-            CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake',
+            CPM_TURNSTILE_EXPECTED_HOSTNAME: 'localhost',
+            CPM_TURNSTILE_EXPECTED_ACTION: 'test',
+            PUBLIC_TURNSTILE_ACTION: 'submission_intake',
           };
           writeFileSync('pages-secrets.json', `${JSON.stringify(values)}\n`, { mode: 0o600 });
           appendFileSync(
@@ -249,6 +250,9 @@ jobs:
               manualSecrets: ['DATABASE_URL', 'CPM_REVIEW_SECRET_SEED_BASE64URL'],
               derivedSecretsVersion: 'cryptopaymap:review-suggest:v1',
               turnstileMode: 'cloudflare_official_always_pass_test_keys',
+              browserAction: 'submission_intake',
+              siteverifyExpectedHostname: 'localhost',
+              siteverifyExpectedAction: 'test',
               contactRetentionDays: 180,
               rateLimit: { maximumRequests: 5, windowSeconds: 600 },
             },

--- a/scripts/check-submission-turnstile-environment.ts
+++ b/scripts/check-submission-turnstile-environment.ts
@@ -7,16 +7,17 @@ const configuration = createSubmissionTurnstileConfigurationFromEnvironment(
   {
     CPM_TURNSTILE_SECRET_KEY: 'runtime-server-secret',
     PUBLIC_TURNSTILE_SITE_KEY: 'runtime-public-site-key',
-    CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.example.test',
-    CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake',
+    CPM_TURNSTILE_EXPECTED_HOSTNAME: 'localhost',
+    CPM_TURNSTILE_EXPECTED_ACTION: 'test',
+    PUBLIC_TURNSTILE_ACTION: 'submission_intake',
   },
   {
     fetchImpl: (async () =>
       new Response(
         JSON.stringify({
           success: true,
-          hostname: 'review.example.test',
-          action: 'submission_intake',
+          hostname: 'localhost',
+          action: 'test',
         }),
         { status: 200 },
       )) as typeof fetch,
@@ -26,7 +27,7 @@ const configuration = createSubmissionTurnstileConfigurationFromEnvironment(
 if (
   configuration.client.siteKey !== 'runtime-public-site-key' ||
   configuration.client.action !== 'submission_intake' ||
-  configuration.expectedHostname !== 'review.example.test'
+  configuration.expectedHostname !== 'localhost'
 ) {
   throw new Error('Submission Turnstile environment check produced invalid client configuration.');
 }
@@ -45,7 +46,8 @@ try {
     CPM_TURNSTILE_SECRET_KEY: 'runtime-server-secret',
     PUBLIC_TURNSTILE_SITE_KEY: 'runtime-public-site-key',
     CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.example.test',
-    CPM_TURNSTILE_EXPECTED_ACTION: 'invalid action',
+    CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake',
+    PUBLIC_TURNSTILE_ACTION: 'invalid action',
   });
   throw new Error('Expected invalid Turnstile configuration to fail.');
 } catch (error) {

--- a/scripts/check-suggest-configured-deployment-contract.mjs
+++ b/scripts/check-suggest-configured-deployment-contract.mjs
@@ -69,8 +69,12 @@ const workflowMarkers = [
   "CPM_SUBMISSION_CONTACT_RETENTION_DAYS: '180'",
   "CPM_SUBMISSION_RATE_LIMIT_MAX_REQUESTS: '5'",
   "CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: '600'",
-  "CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.cryptopaymap-staging.pages.dev'",
-  "CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake'",
+  "CPM_TURNSTILE_EXPECTED_HOSTNAME: 'localhost'",
+  "CPM_TURNSTILE_EXPECTED_ACTION: 'test'",
+  "PUBLIC_TURNSTILE_ACTION: 'submission_intake'",
+  "browserAction: 'submission_intake'",
+  "siteverifyExpectedHostname: 'localhost'",
+  "siteverifyExpectedAction: 'test'",
   'Deploy staging review to Cloudflare Pages',
   'tee deployment-output.log',
   'Prepare Pages deployment diagnostic summary',
@@ -95,6 +99,15 @@ const workflowMarkers = [
 for (const marker of workflowMarkers) {
   if (!workflow.includes(marker)) {
     throw new Error(`Configured Suggest workflow marker missing: ${marker}`);
+  }
+}
+
+for (const obsoleteReviewMarker of [
+  "CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.cryptopaymap-staging.pages.dev'",
+  "CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake'",
+]) {
+  if (workflow.includes(obsoleteReviewMarker)) {
+    throw new Error(`Obsolete fixed-review Turnstile marker remains: ${obsoleteReviewMarker}`);
   }
 }
 

--- a/src/submissions/turnstile-environment.ts
+++ b/src/submissions/turnstile-environment.ts
@@ -16,6 +16,7 @@ export const submissionTurnstileEnvironmentSchema = z
     PUBLIC_TURNSTILE_SITE_KEY: nonWhitespaceTokenSchema,
     CPM_TURNSTILE_EXPECTED_HOSTNAME: hostnameSchema,
     CPM_TURNSTILE_EXPECTED_ACTION: actionSchema,
+    PUBLIC_TURNSTILE_ACTION: actionSchema.optional(),
   })
   .strict();
 
@@ -25,6 +26,7 @@ export type SubmissionTurnstileEnvironment = Readonly<
     PUBLIC_TURNSTILE_SITE_KEY?: unknown;
     CPM_TURNSTILE_EXPECTED_HOSTNAME?: unknown;
     CPM_TURNSTILE_EXPECTED_ACTION?: unknown;
+    PUBLIC_TURNSTILE_ACTION?: unknown;
   }
 >;
 
@@ -60,6 +62,9 @@ export function createSubmissionTurnstileConfigurationFromEnvironment(
     PUBLIC_TURNSTILE_SITE_KEY: environment.PUBLIC_TURNSTILE_SITE_KEY,
     CPM_TURNSTILE_EXPECTED_HOSTNAME: environment.CPM_TURNSTILE_EXPECTED_HOSTNAME,
     CPM_TURNSTILE_EXPECTED_ACTION: environment.CPM_TURNSTILE_EXPECTED_ACTION,
+    ...(environment.PUBLIC_TURNSTILE_ACTION === undefined
+      ? {}
+      : { PUBLIC_TURNSTILE_ACTION: environment.PUBLIC_TURNSTILE_ACTION }),
   });
   if (!parsed.success) throw new SubmissionTurnstileConfigurationError();
 
@@ -76,7 +81,8 @@ export function createSubmissionTurnstileConfigurationFromEnvironment(
       verifier,
       client: {
         siteKey: parsed.data.PUBLIC_TURNSTILE_SITE_KEY,
-        action: parsed.data.CPM_TURNSTILE_EXPECTED_ACTION,
+        action:
+          parsed.data.PUBLIC_TURNSTILE_ACTION ?? parsed.data.CPM_TURNSTILE_EXPECTED_ACTION,
       },
       expectedHostname: parsed.data.CPM_TURNSTILE_EXPECTED_HOSTNAME,
     };

--- a/src/submissions/turnstile-environment.ts
+++ b/src/submissions/turnstile-environment.ts
@@ -81,8 +81,7 @@ export function createSubmissionTurnstileConfigurationFromEnvironment(
       verifier,
       client: {
         siteKey: parsed.data.PUBLIC_TURNSTILE_SITE_KEY,
-        action:
-          parsed.data.PUBLIC_TURNSTILE_ACTION ?? parsed.data.CPM_TURNSTILE_EXPECTED_ACTION,
+        action: parsed.data.PUBLIC_TURNSTILE_ACTION ?? parsed.data.CPM_TURNSTILE_EXPECTED_ACTION,
       },
       expectedHostname: parsed.data.CPM_TURNSTILE_EXPECTED_HOSTNAME,
     };

--- a/tests/submission-turnstile-environment.test.ts
+++ b/tests/submission-turnstile-environment.test.ts
@@ -12,7 +12,7 @@ const validEnvironment = {
   CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake',
 };
 
-describe('P5-02N Turnstile environment binding', () => {
+describe('P5-02N/P5-02R Turnstile environment binding', () => {
   it('binds server verification and returns only client-safe widget configuration', async () => {
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       expect(JSON.parse(String(init?.body))).toEqual({
@@ -44,6 +44,42 @@ describe('P5-02N Turnstile environment binding', () => {
       configuration.verifier.verify({
         requestId,
         token: 'turnstile-token',
+        remoteIp: '203.0.113.10',
+      }),
+    ).resolves.toEqual({ outcome: 'allow', reasonCode: 'challenge_verified' });
+  });
+
+  it('separates the browser action from strict Siteverify metadata when configured', async () => {
+    const configuration = createSubmissionTurnstileConfigurationFromEnvironment(
+      {
+        CPM_TURNSTILE_SECRET_KEY: '1x0000000000000000000000000000000AA',
+        PUBLIC_TURNSTILE_SITE_KEY: '1x00000000000000000000AA',
+        CPM_TURNSTILE_EXPECTED_HOSTNAME: 'localhost',
+        CPM_TURNSTILE_EXPECTED_ACTION: 'test',
+        PUBLIC_TURNSTILE_ACTION: 'submission_intake',
+      },
+      {
+        fetchImpl: (async () =>
+          new Response(
+            JSON.stringify({
+              success: true,
+              hostname: 'localhost',
+              action: 'test',
+            }),
+            { status: 200 },
+          )) as typeof fetch,
+      },
+    );
+
+    expect(configuration.client).toEqual({
+      siteKey: '1x00000000000000000000AA',
+      action: 'submission_intake',
+    });
+    expect(configuration.expectedHostname).toBe('localhost');
+    await expect(
+      configuration.verifier.verify({
+        requestId,
+        token: 'XXXX.DUMMY.TOKEN.XXXX',
         remoteIp: '203.0.113.10',
       }),
     ).resolves.toEqual({ outcome: 'allow', reasonCode: 'challenge_verified' });
@@ -103,6 +139,10 @@ describe('P5-02N Turnstile environment binding', () => {
     [
       'action with unsupported characters',
       { ...validEnvironment, CPM_TURNSTILE_EXPECTED_ACTION: 'submission intake' },
+    ],
+    [
+      'browser action with unsupported characters',
+      { ...validEnvironment, PUBLIC_TURNSTILE_ACTION: 'submission intake' },
     ],
   ])('rejects %s with one generic configuration error', (_name, environment) => {
     expect(() => createSubmissionTurnstileConfigurationFromEnvironment(environment)).toThrow(


### PR DESCRIPTION
## Implementation item

P5-02R audit finding — Turnstile test metadata

## Purpose

Remove a fixed-review-only contract mismatch that would make the synthetic live Suggest POST fail before intake.

Cloudflare's official always-pass test token validates with fixed Siteverify metadata:

```text
hostname: localhost
action: test
```

The public browser must still render the product action:

```text
submission_intake
```

## Scope

- add optional `PUBLIC_TURNSTILE_ACTION` browser configuration;
- preserve the existing behavior when browser and Siteverify actions are identical;
- keep strict Siteverify hostname/action matching;
- configure fixed review to expect official dummy metadata `localhost` / `test` while exposing browser action `submission_intake`;
- record the browser and Siteverify metadata separately in the deployment receipt;
- update environment documentation, runtime checks, focused tests, and deployment-contract checks.

## Security boundary

- production configurations remain strict and need no separate browser action when metadata matches;
- the verifier does not bypass hostname or action checks;
- the split is explicit and limited to configured environment values;
- no token, secret, IP, contact, Submission, Candidate, canonical, export, or publication data is exposed or mutated by this change.

## Validation

GitHub CI remains authoritative for formatting, lint, Astro/TypeScript, runtime schemas, Worker dry-run compilation, migration drift, all tests, build, accessibility, staging artifacts, and the configured deployment contract gate.

After merge, the fixed-review deployment receipt must return to `status: deployed` before the P5-02R synthetic intake runs.