### PR TITLE
P5-02R: record fixed-review dummy-token metadata discrepancy

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -407,10 +407,11 @@ P5-02R now audits:
 
 P5-02 remains in progress until P5-02R records repository and fixed-review audit evidence and an explicit handoff decision.
 
-The 2026-07-12 fixed-review audit found that the official always-pass widget token returns successful
-Siteverify metadata for `hostname: example.com` with no action, while the deployed application expects
-`localhost` and `test`. The route correctly rejects this mismatch with bounded HTTP 400. P5-02R and
-P5-02 remain in progress, and P5-03 remains blocked until the test-key contract is corrected without
+The corrected 2026-07-12 fixed-review audit directly validated Cloudflare's exact documented
+always-pass dummy token with the official test secret. Siteverify returned HTTP 200 and success but
+reported `hostname: example.com` with no action rather than the documented `localhost` and `test`.
+The probe stopped before the application route. P5-02R and P5-02 remain in progress, and P5-03 remains
+blocked until this documentation contradiction is resolved or explicitly reclassified without
 weakening hostname/action verification and the live replay/conflict journey passes.
 
 ### P5-03 — Payment and problem reports

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -410,9 +410,11 @@ P5-02 remains in progress until P5-02R records repository and fixed-review audit
 The corrected 2026-07-12 fixed-review audit directly validated Cloudflare's exact documented
 always-pass dummy token with the official test secret. Siteverify returned HTTP 200 and success but
 reported `hostname: example.com` with no action rather than the documented `localhost` and `test`.
-The probe stopped before the application route. P5-02R and P5-02 remain in progress, and P5-03 remains
-blocked until this documentation contradiction is resolved or explicitly reclassified without
-weakening hostname/action verification and the live replay/conflict journey passes.
+The result was identical for JSON and `application/x-www-form-urlencoded`, each with and without
+`idempotency_key`, so the discrepancy is transport-independent and not caused by that optional
+parameter. The probe stopped before the application route. P5-02R and P5-02 remain in progress, and
+P5-03 remains blocked until this documentation contradiction is resolved or explicitly reclassified
+without weakening hostname/action verification and the live replay/conflict journey passes.
 
 ### P5-03 — Payment and problem reports
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -407,6 +407,12 @@ P5-02R now audits:
 
 P5-02 remains in progress until P5-02R records repository and fixed-review audit evidence and an explicit handoff decision.
 
+The 2026-07-12 fixed-review audit found that the official always-pass widget token returns successful
+Siteverify metadata for `hostname: example.com` with no action, while the deployed application expects
+`localhost` and `test`. The route correctly rejects this mismatch with bounded HTTP 400. P5-02R and
+P5-02 remain in progress, and P5-03 remains blocked until the test-key contract is corrected without
+weakening hostname/action verification and the live replay/conflict journey passes.
+
 ### P5-03 — Payment and problem reports
 
 Add target-aware positive and negative payment reports plus factual, privacy, rights, duplicate, and other problem reports. Reports create review material and may trigger recheck priority; they do not automatically change Claim state.

--- a/docs/P5_02R_SUGGEST_INTEGRATION_AND_HANDOFF_AUDIT.md
+++ b/docs/P5_02R_SUGGEST_INTEGRATION_AND_HANDOFF_AUDIT.md
@@ -273,7 +273,9 @@ The authoritative `staging-review` receipt records `status: deployed` for main c
 `38da5d44605d8400a70ace4ba5a02ef7499823a1`, with all configured checks successful.
 
 The corrected live P5-02R probe directly submitted Cloudflare's exact documented always-pass dummy
-token to Siteverify with the official test secret before calling the application route. It found:
+token to Siteverify with the official test secret before calling the application route. A four-request
+transport matrix covered JSON and `application/x-www-form-urlencoded`, each with and without a fresh
+UUID `idempotency_key`. All four independent requests found:
 
 ```text
 exact token: official documented dummy token (not printed by the probe)
@@ -291,9 +293,10 @@ expected fixed-review metadata
 ```
 
 This directly contradicts Cloudflare's current testing documentation, which specifies `localhost`
-and `test` for this exact dummy-token validation. Because the prerequisite metadata did not match,
-the corrected probe did not call `/api/suggest`; it therefore made no intake, replay, conflict,
-rate-limit, canonical-mutation, or publication claim.
+and `test` for this exact dummy-token validation. The discrepancy is reproducible across both
+officially supported request formats and is independent of `idempotency_key`. Because the
+prerequisite metadata did not match, the corrected probe did not call `/api/suggest`; it therefore
+made no intake, replay, conflict, rate-limit, canonical-mutation, or publication claim.
 
 The synthetic request itself passes the repository's strict Suggest schema and uses only fictional
 Place content, no contact data, and an explicit P5-02R automated-review marker. No public receipt or

--- a/docs/P5_02R_SUGGEST_INTEGRATION_AND_HANDOFF_AUDIT.md
+++ b/docs/P5_02R_SUGGEST_INTEGRATION_AND_HANDOFF_AUDIT.md
@@ -263,6 +263,47 @@ It must not report request body content, challenge token, status secret, databas
 
 A failed audit must not advance P5-03. The failure must be corrected or explicitly reclassified through a documented decision.
 
+## 2026-07-12 fixed-review audit finding
+
+Repository integration checks pass for the complete Suggest path, including strict schema reuse,
+private persistence, exact replay, changed-content conflict, bounded HTTP mapping, protected review
+projection, guarded transitions, and accepted-as-Candidate transaction isolation.
+
+The authoritative `staging-review` receipt records `status: deployed` for main commit
+`38da5d44605d8400a70ace4ba5a02ef7499823a1`, with all configured checks successful.
+
+The first live P5-02R probe found a configured Turnstile metadata mismatch before private intake:
+
+```text
+deployed official always-pass widget token
+→ Cloudflare Siteverify success
+→ hostname example.com
+→ action absent
+
+configured application expectation
+→ hostname localhost
+→ action test
+
+public Suggest result
+→ HTTP 400 suggest_request_invalid
+```
+
+The synthetic request itself passes the repository's strict Suggest schema. The probe used only
+fictional Place content, no contact data, and an explicit P5-02R automated-review marker. No public
+receipt or status secret was returned. `/data/manifest.json` and `/version.json` remained byte-stable
+across each bounded attempt.
+
+The audit did not weaken Turnstile success, hostname, or action verification. Exact replay and
+changed-content live conflict therefore remain unproven, and P5-02 does not hand off to P5-03.
+The configured test-key contract must be corrected without weakening production verification, then
+the same fixed-review probe must prove HTTP 202, deterministic replay identity, HTTP 409 changed-body
+conflict, and stable public artifacts.
+
+Receipt and repository scanning found no Turnstile token, returned status secret, private payload,
+contact data, raw edge identity, database value, or derived key in tracked diagnostics or public
+artifacts. Authenticated Actions log download was unavailable to the audit identity (`HTTP 403`), so
+production or privileged log-stream inspection remains retained Launch work and is not claimed here.
+
 ## Completion result
 
 P5-02R completes when the repository and fixed-review evidence demonstrate that Suggest intake is a real private-review path with deterministic public-route replay/conflict behavior, preserved privacy boundaries, and no automatic public/canonical mutation.

--- a/docs/P5_02R_SUGGEST_INTEGRATION_AND_HANDOFF_AUDIT.md
+++ b/docs/P5_02R_SUGGEST_INTEGRATION_AND_HANDOFF_AUDIT.md
@@ -272,10 +272,11 @@ projection, guarded transitions, and accepted-as-Candidate transaction isolation
 The authoritative `staging-review` receipt records `status: deployed` for main commit
 `38da5d44605d8400a70ace4ba5a02ef7499823a1`, with all configured checks successful.
 
-The first live P5-02R probe found a configured Turnstile metadata mismatch before private intake:
+The corrected live P5-02R probe directly submitted Cloudflare's exact documented always-pass dummy
+token to Siteverify with the official test secret before calling the application route. It found:
 
 ```text
-deployed official always-pass widget token
+exact token: official documented dummy token (not printed by the probe)
 → Cloudflare Siteverify success
 → hostname example.com
 → action absent
@@ -284,20 +285,25 @@ configured application expectation
 → hostname localhost
 → action test
 
-public Suggest result
-→ HTTP 400 suggest_request_invalid
+expected fixed-review metadata
+→ hostname localhost
+→ action test
 ```
 
-The synthetic request itself passes the repository's strict Suggest schema. The probe used only
-fictional Place content, no contact data, and an explicit P5-02R automated-review marker. No public
-receipt or status secret was returned. `/data/manifest.json` and `/version.json` remained byte-stable
-across each bounded attempt.
+This directly contradicts Cloudflare's current testing documentation, which specifies `localhost`
+and `test` for this exact dummy-token validation. Because the prerequisite metadata did not match,
+the corrected probe did not call `/api/suggest`; it therefore made no intake, replay, conflict,
+rate-limit, canonical-mutation, or publication claim.
+
+The synthetic request itself passes the repository's strict Suggest schema and uses only fictional
+Place content, no contact data, and an explicit P5-02R automated-review marker. No public receipt or
+status secret was returned.
 
 The audit did not weaken Turnstile success, hostname, or action verification. Exact replay and
 changed-content live conflict therefore remain unproven, and P5-02 does not hand off to P5-03.
-The configured test-key contract must be corrected without weakening production verification, then
-the same fixed-review probe must prove HTTP 202, deterministic replay identity, HTTP 409 changed-body
-conflict, and stable public artifacts.
+The documented dummy-token metadata discrepancy must be resolved or explicitly reclassified without
+weakening production verification. The same fixed-review probe must then prove HTTP 202,
+deterministic replay identity, HTTP 409 changed-body conflict, and stable public artifacts.
 
 Receipt and repository scanning found no Turnstile token, returned status secret, private payload,
 contact data, raw edge identity, database value, or derived key in tracked diagnostics or public

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -76,6 +76,11 @@ P5-02Q  Configured Suggest review verification                          Complete
 P5-02R  Suggest integration and handoff audit                           In progress
 ```
 
+The first fixed-review P5-02R probe found a Turnstile test-key metadata mismatch: the official
+always-pass widget token validates with `hostname: example.com` and no action, while the deployed
+application correctly requires the configured `localhost` and `test` metadata. P5-02 and P5-02R
+remain in progress, and P5-03 remains blocked pending a bounded correction and successful rerun.
+
 P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, status-secret environment binding, contact protection, opaque bucket derivation, trusted edge identity extraction, distributed rate limiting, Turnstile environment binding, the public Suggest HTTP route, the public Suggest form/browser wiring, and configured fixed-review verification. The bounded P5-02 integration and handoff audit is now active.
 
 ---

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -79,9 +79,11 @@ P5-02R  Suggest integration and handoff audit                           In progr
 The corrected fixed-review P5-02R probe directly validated Cloudflare's exact documented always-pass
 dummy token with the official test secret. Siteverify returned HTTP 200 and success but reported
 `hostname: example.com` with no action rather than the documented `localhost` and `test`. The probe
-stopped before the application route. P5-02 and P5-02R remain in progress, and P5-03 remains blocked
-pending resolution or explicit reclassification of this documentation contradiction and a successful
-live journey rerun.
+reproduced this result for JSON and `application/x-www-form-urlencoded`, each with and without
+`idempotency_key`, so the discrepancy is transport-independent and not caused by that optional
+parameter. It stopped before the application route. P5-02 and P5-02R remain in progress, and P5-03
+remains blocked pending resolution or explicit reclassification of this documentation contradiction
+and a successful live journey rerun.
 
 P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, status-secret environment binding, contact protection, opaque bucket derivation, trusted edge identity extraction, distributed rate limiting, Turnstile environment binding, the public Suggest HTTP route, the public Suggest form/browser wiring, and configured fixed-review verification. The bounded P5-02 integration and handoff audit is now active.
 

--- a/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
+++ b/docs/PHASE5_IMPLEMENTATION_SEQUENCE.md
@@ -76,10 +76,12 @@ P5-02Q  Configured Suggest review verification                          Complete
 P5-02R  Suggest integration and handoff audit                           In progress
 ```
 
-The first fixed-review P5-02R probe found a Turnstile test-key metadata mismatch: the official
-always-pass widget token validates with `hostname: example.com` and no action, while the deployed
-application correctly requires the configured `localhost` and `test` metadata. P5-02 and P5-02R
-remain in progress, and P5-03 remains blocked pending a bounded correction and successful rerun.
+The corrected fixed-review P5-02R probe directly validated Cloudflare's exact documented always-pass
+dummy token with the official test secret. Siteverify returned HTTP 200 and success but reported
+`hostname: example.com` with no action rather than the documented `localhost` and `test`. The probe
+stopped before the application route. P5-02 and P5-02R remain in progress, and P5-03 remains blocked
+pending resolution or explicit reclassification of this documentation contradiction and a successful
+live journey rerun.
 
 P5-01 is repository-complete. P5-02 has established Suggest contract and normalization, private intake, read-only overlap signals, protected reviewer entry, guarded workflow transitions, information requests, time-bounded Hold, the accepted-as-Candidate transaction boundary, status-secret environment binding, contact protection, opaque bucket derivation, trusted edge identity extraction, distributed rate limiting, Turnstile environment binding, the public Suggest HTTP route, the public Suggest form/browser wiring, and configured fixed-review verification. The bounded P5-02 integration and handoff audit is now active.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -210,8 +210,10 @@ Complete P5-02R repository and fixed-review audit evidence. Then record the P5-0
 P5-02R directly validated Cloudflare's exact documented always-pass dummy token with the official
 test secret. Siteverify returned HTTP 200 and success but reported `hostname: example.com` with no
 action, rather than the documented and configured `hostname: localhost` and `action: test`. The
-corrected probe stopped before calling the application route and did not draw an intake or
-rate-limit conclusion.
+same result occurred for JSON and `application/x-www-form-urlencoded`, each with and without a fresh
+UUID `idempotency_key`. The discrepancy is therefore transport-independent and not caused by the
+optional idempotency parameter. The corrected probe stopped before calling the application route and
+did not draw an intake or rate-limit conclusion.
 
 P5-03 remains blocked until this direct contradiction with the current Cloudflare testing
 documentation is resolved or explicitly reclassified without weakening Turnstile hostname/action

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -207,7 +207,14 @@ Complete P5-02R repository and fixed-review audit evidence. Then record the P5-0
 
 ## Blocked
 
-No known repository blocker to beginning P5-02R.
+P5-02R found that the deployed official always-pass Turnstile widget token validates successfully at
+Siteverify but returns `hostname: example.com` with no action, while the configured application
+expects `hostname: localhost` and `action: test`. The public route correctly returns bounded HTTP 400
+instead of weakening exact metadata verification.
+
+P5-03 remains blocked until the fixed-review test-key contract is corrected without weakening
+Turnstile hostname/action enforcement and the P5-02R live first POST, exact replay, changed-content
+conflict, public-artifact comparison, and privacy checks pass.
 
 A live synthetic Suggest probe may reveal a Turnstile testing, migration, persistence, or route-composition gap. Such a result is an audit finding to correct, not a reason to mark the audit successful.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -207,14 +207,16 @@ Complete P5-02R repository and fixed-review audit evidence. Then record the P5-0
 
 ## Blocked
 
-P5-02R found that the deployed official always-pass Turnstile widget token validates successfully at
-Siteverify but returns `hostname: example.com` with no action, while the configured application
-expects `hostname: localhost` and `action: test`. The public route correctly returns bounded HTTP 400
-instead of weakening exact metadata verification.
+P5-02R directly validated Cloudflare's exact documented always-pass dummy token with the official
+test secret. Siteverify returned HTTP 200 and success but reported `hostname: example.com` with no
+action, rather than the documented and configured `hostname: localhost` and `action: test`. The
+corrected probe stopped before calling the application route and did not draw an intake or
+rate-limit conclusion.
 
-P5-03 remains blocked until the fixed-review test-key contract is corrected without weakening
-Turnstile hostname/action enforcement and the P5-02R live first POST, exact replay, changed-content
-conflict, public-artifact comparison, and privacy checks pass.
+P5-03 remains blocked until this direct contradiction with the current Cloudflare testing
+documentation is resolved or explicitly reclassified without weakening Turnstile hostname/action
+enforcement, and the P5-02R live first POST, exact replay, changed-content conflict, public-artifact
+comparison, and privacy checks pass.
 
 A live synthetic Suggest probe may reveal a Turnstile testing, migration, persistence, or route-composition gap. Such a result is an audit finding to correct, not a reason to mark the audit successful.
 

--- a/scripts/p5-02r-live-journey-result.mjs
+++ b/scripts/p5-02r-live-journey-result.mjs
@@ -1,0 +1,31 @@
+export function buildP502rLiveJourneyResult(checks) {
+  const succeeded =
+    checks.firstReceiptValid &&
+    checks.replayReceiptValid &&
+    checks.replayReferenceMatches &&
+    checks.replayStatusSecretMatches &&
+    checks.conflictShapeMatches &&
+    Object.values(checks.publicArtifactsUnchanged).every(Boolean);
+
+  return {
+    succeeded,
+    result: {
+      status: succeeded ? 'complete' : 'failed',
+      firstPost: {
+        httpStatus: checks.firstHttpStatus,
+        receiptShapeMatches: checks.firstReceiptValid,
+      },
+      exactReplay: {
+        httpStatus: checks.replayHttpStatus,
+        receiptShapeMatches: checks.replayReceiptValid,
+        publicReferenceMatches: checks.replayReferenceMatches,
+        statusSecretMatches: checks.replayStatusSecretMatches,
+      },
+      changedContent: {
+        httpStatus: checks.changedContentHttpStatus,
+        conflictShapeMatches: checks.conflictShapeMatches,
+      },
+      publicArtifactsUnchanged: checks.publicArtifactsUnchanged,
+    },
+  };
+}

--- a/scripts/p5-02r-synthetic-suggest-fixture.mjs
+++ b/scripts/p5-02r-synthetic-suggest-fixture.mjs
@@ -1,0 +1,60 @@
+export function p502rSyntheticSuggestRequest(challengeToken, name) {
+  return {
+    challengeToken,
+    submission: {
+      schemaVersion: 'submission-common-v1',
+      submissionType: 'suggest',
+      targetType: null,
+      targetId: null,
+      relationship: 'customer',
+      contact: null,
+      evidenceLinks: [],
+      originalPayload: {
+        schemaVersion: 'suggest-v1',
+        suggestionKind: 'physical_place',
+        entity: {
+          name,
+          legalName: null,
+          websiteUrl: 'https://p5-02r-automated-review-probe.invalid/',
+          countryCode: 'ZZ',
+        },
+        place: {
+          branchName: 'P5-02R automated review probe',
+          addressLine: '42 Fictional Audit Way',
+          locality: 'Example Borough',
+          region: 'Test Region',
+          postalCode: '00000',
+          countryCode: 'ZZ',
+          latitude: null,
+          longitude: null,
+          websiteUrl: null,
+          phone: null,
+          description:
+            'P5-02R automated review probe. Synthetic private review material; never publish as a real listing.',
+          openingHours: null,
+          amenities: [],
+          socialLinks: [],
+        },
+        categories: [],
+        paymentProposals: [
+          {
+            assetSlug: 'btc',
+            networkSlug: 'bitcoin',
+            routeType: 'direct_wallet',
+            paymentMethod: 'onchain',
+            processor: null,
+            contractAddress: null,
+            howToPay: 'Synthetic proposal for the automated private review probe.',
+            restrictions: 'Not a real listing or payment claim.',
+            isPrimary: true,
+          },
+        ],
+        observedAt: '2026-07-12',
+      },
+      acknowledgements: {
+        privacyNoticeAccepted: true,
+        submissionTermsAccepted: true,
+      },
+    },
+  };
+}

--- a/scripts/run-p5-02r-fixed-review-probe.mjs
+++ b/scripts/run-p5-02r-fixed-review-probe.mjs
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { buildP502rLiveJourneyResult } from './p5-02r-live-journey-result.mjs';
 import { p502rSyntheticSuggestRequest } from './p5-02r-synthetic-suggest-fixture.mjs';
 
 const defaultBaseUrl = 'https://review.cryptopaymap-staging.pages.dev';
@@ -169,28 +170,20 @@ const publicArtifactsUnchanged = Object.fromEntries(
   publicArtifactPaths.map((path) => [path, artifactsBefore[path] === artifactsAfter[path]]),
 );
 
-const result = {
-  status: 'complete',
-  firstPost: { httpStatus: first.status, receiptShapeMatches: firstReceiptValid },
-  exactReplay: {
-    httpStatus: replay.status,
-    receiptShapeMatches: replayReceiptValid,
-    publicReferenceMatches: replayReferenceMatches,
-    statusSecretMatches: replayStatusSecretMatches,
-  },
-  changedContent: { httpStatus: changed.status, conflictShapeMatches },
+const { succeeded, result } = buildP502rLiveJourneyResult({
+  firstHttpStatus: first.status,
+  firstReceiptValid,
+  replayHttpStatus: replay.status,
+  replayReceiptValid,
+  replayReferenceMatches,
+  replayStatusSecretMatches,
+  changedContentHttpStatus: changed.status,
+  conflictShapeMatches,
   publicArtifactsUnchanged,
-};
+});
 
 console.log(JSON.stringify(result, null, 2));
 
-if (
-  !firstReceiptValid ||
-  !replayReceiptValid ||
-  !replayReferenceMatches ||
-  !replayStatusSecretMatches ||
-  !conflictShapeMatches ||
-  Object.values(publicArtifactsUnchanged).includes(false)
-) {
+if (!succeeded) {
   process.exitCode = 1;
 }

--- a/scripts/run-p5-02r-fixed-review-probe.mjs
+++ b/scripts/run-p5-02r-fixed-review-probe.mjs
@@ -1,137 +1,43 @@
-import { spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { p502rSyntheticSuggestRequest } from './p5-02r-synthetic-suggest-fixture.mjs';
 
 const defaultBaseUrl = 'https://review.cryptopaymap-staging.pages.dev';
 const baseUrl = new URL(process.env.CPM_P5_02R_REVIEW_URL ?? defaultBaseUrl);
 const requestId = randomUUID();
+const challengeToken = 'XXXX.DUMMY.TOKEN.XXXX';
+const officialTestSecret = '1x0000000000000000000000000000000AA';
 const publicArtifactPaths = ['/data/manifest.json', '/version.json'];
-
-function chromeExecutable() {
-  return (
-    process.env.CPM_P5_02R_CHROME_PATH ??
-    (process.platform === 'darwin'
-      ? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-      : 'google-chrome')
-  );
-}
-
-function wait(milliseconds) {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-async function browserChallengeToken() {
-  const profile = mkdtempSync(join(tmpdir(), 'cpm-p5-02r-chrome-'));
-  const browser = spawn(
-    chromeExecutable(),
-    [
-      '--headless=new',
-      '--disable-gpu',
-      '--no-first-run',
-      '--no-default-browser-check',
-      '--remote-debugging-port=0',
-      `--user-data-dir=${profile}`,
-      'about:blank',
-    ],
-    { stdio: ['ignore', 'ignore', 'pipe'] },
-  );
-
-  try {
-    const browserWebSocketUrl = await new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error('browser_start_timeout')), 15_000);
-      browser.stderr.setEncoding('utf8');
-      browser.stderr.on('data', (chunk) => {
-        const match = /DevTools listening on (ws:\/\/\S+)/.exec(chunk);
-        if (match?.[1]) {
-          clearTimeout(timeout);
-          resolve(match[1]);
-        }
-      });
-      browser.once('exit', () => {
-        clearTimeout(timeout);
-        reject(new Error('browser_start_failed'));
-      });
-    });
-    const browserEndpoint = new URL(browserWebSocketUrl);
-    const targetResponse = await fetch(
-      `http://${browserEndpoint.host}/json/new?${encodeURIComponent(new URL('/suggest', baseUrl))}`,
-      { method: 'PUT' },
-    );
-    if (!targetResponse.ok) throw new Error('browser_target_failed');
-    const target = await targetResponse.json();
-    if (typeof target.webSocketDebuggerUrl !== 'string') {
-      throw new Error('browser_target_invalid');
-    }
-
-    const socket = new WebSocket(target.webSocketDebuggerUrl);
-    let commandId = 0;
-    const pending = new Map();
-    socket.addEventListener('message', (event) => {
-      const message = JSON.parse(event.data);
-      if (typeof message.id !== 'number') return;
-      const handler = pending.get(message.id);
-      if (handler) {
-        pending.delete(message.id);
-        handler(message);
-      }
-    });
-    await new Promise((resolve, reject) => {
-      socket.addEventListener('open', resolve, { once: true });
-      socket.addEventListener('error', () => reject(new Error('browser_socket_failed')), {
-        once: true,
-      });
-    });
-
-    const evaluate = (expression) =>
-      new Promise((resolve, reject) => {
-        const id = ++commandId;
-        const timeout = setTimeout(() => {
-          pending.delete(id);
-          reject(new Error('browser_command_timeout'));
-        }, 5_000);
-        pending.set(id, (message) => {
-          clearTimeout(timeout);
-          if (message.error) reject(new Error('browser_command_failed'));
-          else resolve(message.result);
-        });
-        socket.send(
-          JSON.stringify({
-            id,
-            method: 'Runtime.evaluate',
-            params: { expression, returnByValue: true },
-          }),
-        );
-      });
-
-    const deadline = Date.now() + 30_000;
-    while (Date.now() < deadline) {
-      const result = await evaluate(
-        `document.querySelector('input[name="cf-turnstile-response"]')?.value ?? ''`,
-      );
-      const token = result?.result?.value;
-      if (typeof token === 'string' && token.length > 0) {
-        socket.close();
-        return token;
-      }
-      await wait(250);
-    }
-    socket.close();
-    throw new Error('browser_challenge_timeout');
-  } finally {
-    if (browser.exitCode === null) {
-      const exited = new Promise((resolve) => browser.once('exit', resolve));
-      browser.kill('SIGTERM');
-      await Promise.race([exited, wait(5_000)]);
-    }
-    rmSync(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-  }
-}
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function validateOfficialDummyToken() {
+  const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      secret: officialTestSecret,
+      response: challengeToken,
+      idempotency_key: randomUUID(),
+    }),
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    // Only bounded metadata is returned to the caller.
+  }
+  const metadata = {
+    httpStatus: response.status,
+    success: payload?.success === true,
+    hostname: typeof payload?.hostname === 'string' ? payload.hostname : null,
+    action: typeof payload?.action === 'string' ? payload.action : null,
+    hostnameMatches: payload?.hostname === 'localhost',
+    actionMatches: payload?.action === 'test',
+  };
+  console.log(JSON.stringify({ dummyTokenValidation: metadata }, null, 2));
+  return metadata;
 }
 
 async function readPublicArtifacts() {
@@ -176,7 +82,16 @@ function isReceipt(value) {
 }
 
 const artifactsBefore = await readPublicArtifacts();
-const challengeToken = await browserChallengeToken();
+const dummyTokenValidation = await validateOfficialDummyToken();
+if (
+  dummyTokenValidation.httpStatus !== 200 ||
+  !dummyTokenValidation.success ||
+  !dummyTokenValidation.hostnameMatches ||
+  !dummyTokenValidation.actionMatches
+) {
+  process.exit(1);
+}
+
 const originalBody = p502rSyntheticSuggestRequest(challengeToken, 'P5-02R automated review probe');
 const first = await post(originalBody);
 const firstReceiptValid = first.status === 202 && isReceipt(first.payload);
@@ -190,7 +105,7 @@ if (!firstReceiptValid) {
     JSON.stringify(
       {
         status: 'failed',
-        failedStage: 'first_post',
+        failedStage: first.status === 429 ? 'rate_limit' : 'first_post',
         firstPost: { httpStatus: first.status, receiptShapeMatches: false },
         publicArtifactsUnchanged,
       },

--- a/scripts/run-p5-02r-fixed-review-probe.mjs
+++ b/scripts/run-p5-02r-fixed-review-probe.mjs
@@ -1,0 +1,256 @@
+import { spawn } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { p502rSyntheticSuggestRequest } from './p5-02r-synthetic-suggest-fixture.mjs';
+
+const defaultBaseUrl = 'https://review.cryptopaymap-staging.pages.dev';
+const baseUrl = new URL(process.env.CPM_P5_02R_REVIEW_URL ?? defaultBaseUrl);
+const requestId = randomUUID();
+const publicArtifactPaths = ['/data/manifest.json', '/version.json'];
+
+function chromeExecutable() {
+  return (
+    process.env.CPM_P5_02R_CHROME_PATH ??
+    (process.platform === 'darwin'
+      ? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+      : 'google-chrome')
+  );
+}
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function browserChallengeToken() {
+  const profile = mkdtempSync(join(tmpdir(), 'cpm-p5-02r-chrome-'));
+  const browser = spawn(
+    chromeExecutable(),
+    [
+      '--headless=new',
+      '--disable-gpu',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--remote-debugging-port=0',
+      `--user-data-dir=${profile}`,
+      'about:blank',
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] },
+  );
+
+  try {
+    const browserWebSocketUrl = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('browser_start_timeout')), 15_000);
+      browser.stderr.setEncoding('utf8');
+      browser.stderr.on('data', (chunk) => {
+        const match = /DevTools listening on (ws:\/\/\S+)/.exec(chunk);
+        if (match?.[1]) {
+          clearTimeout(timeout);
+          resolve(match[1]);
+        }
+      });
+      browser.once('exit', () => {
+        clearTimeout(timeout);
+        reject(new Error('browser_start_failed'));
+      });
+    });
+    const browserEndpoint = new URL(browserWebSocketUrl);
+    const targetResponse = await fetch(
+      `http://${browserEndpoint.host}/json/new?${encodeURIComponent(new URL('/suggest', baseUrl))}`,
+      { method: 'PUT' },
+    );
+    if (!targetResponse.ok) throw new Error('browser_target_failed');
+    const target = await targetResponse.json();
+    if (typeof target.webSocketDebuggerUrl !== 'string') {
+      throw new Error('browser_target_invalid');
+    }
+
+    const socket = new WebSocket(target.webSocketDebuggerUrl);
+    let commandId = 0;
+    const pending = new Map();
+    socket.addEventListener('message', (event) => {
+      const message = JSON.parse(event.data);
+      if (typeof message.id !== 'number') return;
+      const handler = pending.get(message.id);
+      if (handler) {
+        pending.delete(message.id);
+        handler(message);
+      }
+    });
+    await new Promise((resolve, reject) => {
+      socket.addEventListener('open', resolve, { once: true });
+      socket.addEventListener('error', () => reject(new Error('browser_socket_failed')), {
+        once: true,
+      });
+    });
+
+    const evaluate = (expression) =>
+      new Promise((resolve, reject) => {
+        const id = ++commandId;
+        const timeout = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error('browser_command_timeout'));
+        }, 5_000);
+        pending.set(id, (message) => {
+          clearTimeout(timeout);
+          if (message.error) reject(new Error('browser_command_failed'));
+          else resolve(message.result);
+        });
+        socket.send(
+          JSON.stringify({
+            id,
+            method: 'Runtime.evaluate',
+            params: { expression, returnByValue: true },
+          }),
+        );
+      });
+
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      const result = await evaluate(
+        `document.querySelector('input[name="cf-turnstile-response"]')?.value ?? ''`,
+      );
+      const token = result?.result?.value;
+      if (typeof token === 'string' && token.length > 0) {
+        socket.close();
+        return token;
+      }
+      await wait(250);
+    }
+    socket.close();
+    throw new Error('browser_challenge_timeout');
+  } finally {
+    if (browser.exitCode === null) {
+      const exited = new Promise((resolve) => browser.once('exit', resolve));
+      browser.kill('SIGTERM');
+      await Promise.race([exited, wait(5_000)]);
+    }
+    rmSync(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function readPublicArtifacts() {
+  return Object.fromEntries(
+    await Promise.all(
+      publicArtifactPaths.map(async (path) => {
+        const response = await fetch(new URL(path, baseUrl), { cache: 'no-store' });
+        if (!response.ok) throw new Error(`public_artifact_${response.status}`);
+        return [path, sha256(Buffer.from(await response.arrayBuffer()))];
+      }),
+    ),
+  );
+}
+
+async function post(body) {
+  const response = await fetch(new URL('/api/suggest', baseUrl), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': requestId,
+    },
+    body: JSON.stringify(body),
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    // Only response-shape booleans are reported below.
+  }
+  return { status: response.status, payload };
+}
+
+function isReceipt(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof value.submissionReference === 'string' &&
+    typeof value.statusSecret === 'string' &&
+    typeof value.submittedAt === 'string' &&
+    Object.keys(value).length === 3
+  );
+}
+
+const artifactsBefore = await readPublicArtifacts();
+const challengeToken = await browserChallengeToken();
+const originalBody = p502rSyntheticSuggestRequest(challengeToken, 'P5-02R automated review probe');
+const first = await post(originalBody);
+const firstReceiptValid = first.status === 202 && isReceipt(first.payload);
+
+if (!firstReceiptValid) {
+  const artifactsAfter = await readPublicArtifacts();
+  const publicArtifactsUnchanged = Object.fromEntries(
+    publicArtifactPaths.map((path) => [path, artifactsBefore[path] === artifactsAfter[path]]),
+  );
+  console.log(
+    JSON.stringify(
+      {
+        status: 'failed',
+        failedStage: 'first_post',
+        firstPost: { httpStatus: first.status, receiptShapeMatches: false },
+        publicArtifactsUnchanged,
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(1);
+}
+
+const replay = await post(originalBody);
+const changed = await post(
+  p502rSyntheticSuggestRequest(
+    challengeToken,
+    'P5-02R automated review probe changed-content check',
+  ),
+);
+const artifactsAfter = await readPublicArtifacts();
+
+const replayReceiptValid = replay.status === 202 && isReceipt(replay.payload);
+const replayReferenceMatches =
+  firstReceiptValid &&
+  replayReceiptValid &&
+  first.payload.submissionReference === replay.payload.submissionReference;
+const replayStatusSecretMatches =
+  firstReceiptValid &&
+  replayReceiptValid &&
+  first.payload.statusSecret === replay.payload.statusSecret;
+const conflictShapeMatches =
+  changed.status === 409 &&
+  changed.payload !== null &&
+  typeof changed.payload === 'object' &&
+  changed.payload.error === 'suggest_request_conflict' &&
+  Object.keys(changed.payload).length === 1;
+const publicArtifactsUnchanged = Object.fromEntries(
+  publicArtifactPaths.map((path) => [path, artifactsBefore[path] === artifactsAfter[path]]),
+);
+
+const result = {
+  status: 'complete',
+  firstPost: { httpStatus: first.status, receiptShapeMatches: firstReceiptValid },
+  exactReplay: {
+    httpStatus: replay.status,
+    receiptShapeMatches: replayReceiptValid,
+    publicReferenceMatches: replayReferenceMatches,
+    statusSecretMatches: replayStatusSecretMatches,
+  },
+  changedContent: { httpStatus: changed.status, conflictShapeMatches },
+  publicArtifactsUnchanged,
+};
+
+console.log(JSON.stringify(result, null, 2));
+
+if (
+  !firstReceiptValid ||
+  !replayReceiptValid ||
+  !replayReferenceMatches ||
+  !replayStatusSecretMatches ||
+  !conflictShapeMatches ||
+  Object.values(publicArtifactsUnchanged).includes(false)
+) {
+  process.exitCode = 1;
+}

--- a/scripts/run-p5-02r-fixed-review-probe.mjs
+++ b/scripts/run-p5-02r-fixed-review-probe.mjs
@@ -7,20 +7,25 @@ const requestId = randomUUID();
 const challengeToken = 'XXXX.DUMMY.TOKEN.XXXX';
 const officialTestSecret = '1x0000000000000000000000000000000AA';
 const publicArtifactPaths = ['/data/manifest.json', '/version.json'];
+const siteverifyEndpoint = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
 }
 
-async function validateOfficialDummyToken() {
-  const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+async function validateOfficialDummyToken(requestFormat, idempotencyIncluded) {
+  const values = {
+    secret: officialTestSecret,
+    response: challengeToken,
+    ...(idempotencyIncluded ? { idempotency_key: randomUUID() } : {}),
+  };
+  const isJson = requestFormat === 'json';
+  const response = await fetch(siteverifyEndpoint, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      secret: officialTestSecret,
-      response: challengeToken,
-      idempotency_key: randomUUID(),
-    }),
+    headers: {
+      'Content-Type': isJson ? 'application/json' : 'application/x-www-form-urlencoded',
+    },
+    body: isJson ? JSON.stringify(values) : new URLSearchParams(values),
   });
   let payload = null;
   try {
@@ -29,6 +34,8 @@ async function validateOfficialDummyToken() {
     // Only bounded metadata is returned to the caller.
   }
   const metadata = {
+    requestFormat,
+    idempotencyIncluded,
     httpStatus: response.status,
     success: payload?.success === true,
     hostname: typeof payload?.hostname === 'string' ? payload.hostname : null,
@@ -36,8 +43,20 @@ async function validateOfficialDummyToken() {
     hostnameMatches: payload?.hostname === 'localhost',
     actionMatches: payload?.action === 'test',
   };
-  console.log(JSON.stringify({ dummyTokenValidation: metadata }, null, 2));
   return metadata;
+}
+
+async function runSiteverifyTransportMatrix() {
+  const results = [];
+  for (const requestFormat of ['json', 'application/x-www-form-urlencoded']) {
+    for (const idempotencyIncluded of [false, true]) {
+      results.push(await validateOfficialDummyToken(requestFormat, idempotencyIncluded));
+    }
+  }
+  console.log(JSON.stringify({ siteverifyTransportMatrix: results }, null, 2));
+  if (results.some((result) => result.httpStatus !== 200 || !result.success)) {
+    process.exitCode = 1;
+  }
 }
 
 async function readPublicArtifacts() {
@@ -81,8 +100,14 @@ function isReceipt(value) {
   );
 }
 
+if (process.argv.includes('--siteverify-transport-matrix')) {
+  await runSiteverifyTransportMatrix();
+  process.exit(process.exitCode ?? 0);
+}
+
 const artifactsBefore = await readPublicArtifacts();
-const dummyTokenValidation = await validateOfficialDummyToken();
+const dummyTokenValidation = await validateOfficialDummyToken('json', true);
+console.log(JSON.stringify({ dummyTokenValidation }, null, 2));
 if (
   dummyTokenValidation.httpStatus !== 200 ||
   !dummyTokenValidation.success ||

--- a/tests/p5-02r-live-journey-result.test.ts
+++ b/tests/p5-02r-live-journey-result.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildP502rLiveJourneyResult } from '../scripts/p5-02r-live-journey-result.mjs';
+
+function passingChecks() {
+  return {
+    firstHttpStatus: 202,
+    firstReceiptValid: true,
+    replayHttpStatus: 202,
+    replayReceiptValid: true,
+    replayReferenceMatches: true,
+    replayStatusSecretMatches: true,
+    changedContentHttpStatus: 409,
+    conflictShapeMatches: true,
+    publicArtifactsUnchanged: {
+      '/data/manifest.json': true,
+      '/version.json': true,
+    },
+  };
+}
+
+describe('P5-02R live journey result', () => {
+  it('reports complete only when every required check passes', () => {
+    const outcome = buildP502rLiveJourneyResult(passingChecks());
+
+    expect(outcome.succeeded).toBe(true);
+    expect(outcome.result.status).toBe('complete');
+  });
+
+  it('reports failed when replay identity does not match', () => {
+    const outcome = buildP502rLiveJourneyResult({
+      ...passingChecks(),
+      replayReferenceMatches: false,
+    });
+
+    expect(outcome.succeeded).toBe(false);
+    expect(outcome.result.status).toBe('failed');
+  });
+
+  it('reports failed when changed content does not conflict', () => {
+    const outcome = buildP502rLiveJourneyResult({
+      ...passingChecks(),
+      conflictShapeMatches: false,
+    });
+
+    expect(outcome.succeeded).toBe(false);
+    expect(outcome.result.status).toBe('failed');
+  });
+
+  it('reports failed when one public artifact changes', () => {
+    const outcome = buildP502rLiveJourneyResult({
+      ...passingChecks(),
+      publicArtifactsUnchanged: {
+        ...passingChecks().publicArtifactsUnchanged,
+        '/version.json': false,
+      },
+    });
+
+    expect(outcome.succeeded).toBe(false);
+    expect(outcome.result.status).toBe('failed');
+  });
+});

--- a/tests/p5-02r-synthetic-suggest-fixture.test.ts
+++ b/tests/p5-02r-synthetic-suggest-fixture.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { p502rSyntheticSuggestRequest } from '../scripts/p5-02r-synthetic-suggest-fixture.mjs';
+import { suggestSubmissionIntakeSchema } from '../src/submissions/suggest-contract';
+
+describe('P5-02R synthetic fixed-review fixture', () => {
+  it('uses the strict Suggest contract and contains no contact or public target', () => {
+    const request = p502rSyntheticSuggestRequest('ephemeral-test-token', 'P5-02R probe');
+
+    expect(suggestSubmissionIntakeSchema.safeParse(request.submission).success).toBe(true);
+    expect(request.submission.contact).toBeNull();
+    expect(request.submission.targetType).toBeNull();
+    expect(request.submission.targetId).toBeNull();
+    expect(JSON.stringify(request.submission)).toContain('automated review probe');
+  });
+});


### PR DESCRIPTION
## Implementation item

P5-02R — Suggest integration and handoff audit

## Purpose

Record the corrected fixed-review audit result and retain a reusable, privacy-safe synthetic Suggest probe.

## Corrected finding

The audit directly validated Cloudflare's exact documented always-pass dummy token with the official test secret.

Observed Siteverify result:

- HTTP 200
- success: true
- hostname: example.com
- action: absent

The current Cloudflare testing documentation shows hostname `localhost` and action `test` for the documented successful dummy-token response.

Because the prerequisite metadata did not match, the corrected probe stopped before calling `/api/suggest`.

## Transport matrix evidence

All four independent Siteverify requests returned HTTP 200, success `true`, hostname `example.com`, and no action:

- JSON without `idempotency_key`: `example.com` / action absent;
- JSON with a fresh UUID `idempotency_key`: `example.com` / action absent;
- `application/x-www-form-urlencoded` without `idempotency_key`: `example.com` / action absent;
- `application/x-www-form-urlencoded` with a fresh UUID `idempotency_key`: `example.com` / action absent.

The discrepancy is reproducible across both officially supported request formats and is independent of `idempotency_key`. `/api/suggest` was not called during this diagnostic.

## Scope

- add a strict synthetic Suggest fixture;
- add a fixed-review probe using the exact documented dummy token;
- remove the earlier headless-browser token acquisition approach;
- add a bounded Siteverify transport-matrix diagnostic;
- align machine-readable live-journey status and process exit code through one pure success condition;
- record the observed documentation discrepancy;
- keep P5-02R and P5-02 open;
- keep P5-03 blocked.

## Security and privacy

- production hostname/action verification is not weakened;
- the Turnstile token is not printed;
- no status secret was returned or persisted;
- no real person, business, contact, address, payment claim, or wallet data is used;
- the application route was not called after the prerequisite mismatch;
- no canonical or public mutation is claimed.

## Validation

- focused P5-02R result and fixture tests pass;
- focused Suggest and Turnstile tests pass;
- formatting, lint, type, schema, and database checks pass;
- build, accessibility, and staging checks pass;
- unrelated local full-suite timeout failures pass when rerun in focused form;
- GitHub CI remains authoritative.

## Handoff decision

P5-02R remains open. P5-02 does not hand off to P5-03, and P5-03 remains blocked.

The dummy-token metadata discrepancy must be resolved or explicitly reclassified without weakening production verification. The fixed-review audit must then prove:

1. first POST returns HTTP 202;
2. exact replay returns the same public reference and status secret;
3. changed content under the same UUID returns HTTP 409;
4. stable public artifacts remain unchanged;
5. no private or secret leakage occurs.
