### PR TITLE
P5-02R: allow bounded official dummy metadata in fixed review

### DIFF
--- a/.github/workflows/p5-02r-fixed-review-live-audit.yml
+++ b/.github/workflows/p5-02r-fixed-review-live-audit.yml
@@ -1,0 +1,44 @@
+name: P5-02R fixed review live audit
+
+on:
+  workflow_run:
+    workflows:
+      - Staging review deploy
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      contains(github.event.workflow_run.head_commit.message, '[run-p5-02r-audit]')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out audited main commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Run bounded fixed-review Suggest audit
+        run: |
+          set -o pipefail
+          node scripts/run-p5-02r-fixed-review-probe.mjs \
+            2>&1 | tee p5-02r-fixed-review-live-audit.log
+
+      - name: Upload bounded audit evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: p5-02r-fixed-review-live-audit
+          path: p5-02r-fixed-review-live-audit.log
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/run-p5-02r-fixed-review-probe.mjs
+++ b/scripts/run-p5-02r-fixed-review-probe.mjs
@@ -47,6 +47,12 @@ async function validateOfficialDummyToken(requestFormat, idempotencyIncluded) {
   return metadata;
 }
 
+function officialDummyMetadataSupported(metadata) {
+  const documentedMetadata = metadata.hostname === 'localhost' && metadata.action === 'test';
+  const observedMetadata = metadata.hostname === 'example.com' && metadata.action === null;
+  return documentedMetadata || observedMetadata;
+}
+
 async function runSiteverifyTransportMatrix() {
   const results = [];
   for (const requestFormat of ['json', 'application/x-www-form-urlencoded']) {
@@ -112,8 +118,7 @@ console.log(JSON.stringify({ dummyTokenValidation }, null, 2));
 if (
   dummyTokenValidation.httpStatus !== 200 ||
   !dummyTokenValidation.success ||
-  !dummyTokenValidation.hostnameMatches ||
-  !dummyTokenValidation.actionMatches
+  !officialDummyMetadataSupported(dummyTokenValidation)
 ) {
   process.exit(1);
 }

--- a/src/submissions/turnstile-environment.ts
+++ b/src/submissions/turnstile-environment.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import type { SubmissionChallengeVerifier } from './challenge-verification';
 import { createTurnstileSiteverifyVerifier } from './turnstile-siteverify';
 
+const officialAlwaysPassTestSecret = '1x0000000000000000000000000000000AA';
+const officialAlwaysPassTestSiteKey = '1x00000000000000000000AA';
 const nonWhitespaceTokenSchema = z.string().min(1).max(512).regex(/^\S+$/);
 const hostnameSchema = z
   .string()
@@ -69,10 +71,16 @@ export function createSubmissionTurnstileConfigurationFromEnvironment(
   if (!parsed.success) throw new SubmissionTurnstileConfigurationError();
 
   try {
+    const officialAlwaysPassTestMode =
+      parsed.data.CPM_TURNSTILE_SECRET_KEY === officialAlwaysPassTestSecret &&
+      parsed.data.PUBLIC_TURNSTILE_SITE_KEY === officialAlwaysPassTestSiteKey &&
+      parsed.data.CPM_TURNSTILE_EXPECTED_HOSTNAME === 'localhost' &&
+      parsed.data.CPM_TURNSTILE_EXPECTED_ACTION === 'test';
     const verifier = createTurnstileSiteverifyVerifier({
       secretKey: parsed.data.CPM_TURNSTILE_SECRET_KEY,
       expectedHostname: parsed.data.CPM_TURNSTILE_EXPECTED_HOSTNAME,
       expectedAction: parsed.data.CPM_TURNSTILE_EXPECTED_ACTION,
+      ...(officialAlwaysPassTestMode ? { allowOfficialAlwaysPassTestMetadata: true } : {}),
       ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
       ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
     });

--- a/src/submissions/turnstile-siteverify.ts
+++ b/src/submissions/turnstile-siteverify.ts
@@ -5,6 +5,8 @@ import type {
 } from './challenge-verification';
 
 const defaultEndpoint = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+const officialAlwaysPassTestSecret = '1x0000000000000000000000000000000AA';
+const officialAlwaysPassDummyToken = 'XXXX.DUMMY.TOKEN.XXXX';
 
 const siteverifyResponseSchema = z
   .object({
@@ -29,6 +31,7 @@ export interface TurnstileSiteverifyOptions {
   secretKey: string;
   expectedHostname: string;
   expectedAction: string;
+  allowOfficialAlwaysPassTestMetadata?: boolean;
   endpoint?: string;
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
@@ -57,6 +60,11 @@ export function createTurnstileSiteverifyVerifier(
     throw new Error('Turnstile timeout must be an integer between 500 and 30000 ms.');
   }
   const fetchImpl = options.fetchImpl ?? fetch;
+  const officialAlwaysPassTestMode =
+    options.allowOfficialAlwaysPassTestMetadata === true &&
+    options.secretKey === officialAlwaysPassTestSecret &&
+    options.expectedHostname === 'localhost' &&
+    options.expectedAction === 'test';
 
   return {
     async verify(rawRequest) {
@@ -100,11 +108,19 @@ export function createTurnstileSiteverifyVerifier(
           return { outcome: 'deny', reasonCode: 'challenge_failed' };
         }
 
-        if (parsed.data.hostname !== options.expectedHostname) {
-          return { outcome: 'deny', reasonCode: 'challenge_hostname_mismatch' };
-        }
-        if (parsed.data.action !== options.expectedAction) {
-          return { outcome: 'deny', reasonCode: 'challenge_action_mismatch' };
+        const observedOfficialTestMetadata =
+          officialAlwaysPassTestMode &&
+          request.data.token === officialAlwaysPassDummyToken &&
+          parsed.data.hostname === 'example.com' &&
+          parsed.data.action === undefined;
+
+        if (!observedOfficialTestMetadata) {
+          if (parsed.data.hostname !== options.expectedHostname) {
+            return { outcome: 'deny', reasonCode: 'challenge_hostname_mismatch' };
+          }
+          if (parsed.data.action !== options.expectedAction) {
+            return { outcome: 'deny', reasonCode: 'challenge_action_mismatch' };
+          }
         }
 
         return { outcome: 'allow', reasonCode: 'challenge_verified' };

--- a/tests/submission-turnstile-environment.test.ts
+++ b/tests/submission-turnstile-environment.test.ts
@@ -11,6 +11,17 @@ const validEnvironment = {
   CPM_TURNSTILE_EXPECTED_HOSTNAME: 'review.example.test',
   CPM_TURNSTILE_EXPECTED_ACTION: 'submission_intake',
 };
+const officialTestEnvironment = {
+  CPM_TURNSTILE_SECRET_KEY: '1x0000000000000000000000000000000AA',
+  PUBLIC_TURNSTILE_SITE_KEY: '1x00000000000000000000AA',
+  CPM_TURNSTILE_EXPECTED_HOSTNAME: 'localhost',
+  CPM_TURNSTILE_EXPECTED_ACTION: 'test',
+  PUBLIC_TURNSTILE_ACTION: 'submission_intake',
+};
+
+function observedOfficialTestResponse(): Response {
+  return new Response(JSON.stringify({ success: true, hostname: 'example.com' }), { status: 200 });
+}
 
 describe('P5-02N/P5-02R Turnstile environment binding', () => {
   it('binds server verification and returns only client-safe widget configuration', async () => {
@@ -49,15 +60,9 @@ describe('P5-02N/P5-02R Turnstile environment binding', () => {
     ).resolves.toEqual({ outcome: 'allow', reasonCode: 'challenge_verified' });
   });
 
-  it('separates the browser action from strict Siteverify metadata when configured', async () => {
+  it('separates the browser action from strict documented Siteverify metadata', async () => {
     const configuration = createSubmissionTurnstileConfigurationFromEnvironment(
-      {
-        CPM_TURNSTILE_SECRET_KEY: '1x0000000000000000000000000000000AA',
-        PUBLIC_TURNSTILE_SITE_KEY: '1x00000000000000000000AA',
-        CPM_TURNSTILE_EXPECTED_HOSTNAME: 'localhost',
-        CPM_TURNSTILE_EXPECTED_ACTION: 'test',
-        PUBLIC_TURNSTILE_ACTION: 'submission_intake',
-      },
+      officialTestEnvironment,
       {
         fetchImpl: (async () =>
           new Response(
@@ -83,6 +88,51 @@ describe('P5-02N/P5-02R Turnstile environment binding', () => {
         remoteIp: '203.0.113.10',
       }),
     ).resolves.toEqual({ outcome: 'allow', reasonCode: 'challenge_verified' });
+  });
+
+  it('accepts observed Siteverify metadata only for the exact official dummy token and pair', async () => {
+    const configuration = createSubmissionTurnstileConfigurationFromEnvironment(
+      officialTestEnvironment,
+      { fetchImpl: (async () => observedOfficialTestResponse()) as typeof fetch },
+    );
+
+    await expect(
+      configuration.verifier.verify({
+        requestId,
+        token: 'XXXX.DUMMY.TOKEN.XXXX',
+        remoteIp: null,
+      }),
+    ).resolves.toEqual({ outcome: 'allow', reasonCode: 'challenge_verified' });
+  });
+
+  it('rejects observed test metadata for a non-dummy token', async () => {
+    const configuration = createSubmissionTurnstileConfigurationFromEnvironment(
+      officialTestEnvironment,
+      { fetchImpl: (async () => observedOfficialTestResponse()) as typeof fetch },
+    );
+
+    await expect(
+      configuration.verifier.verify({
+        requestId,
+        token: 'not-the-official-dummy-token',
+        remoteIp: null,
+      }),
+    ).resolves.toEqual({ outcome: 'deny', reasonCode: 'challenge_hostname_mismatch' });
+  });
+
+  it('rejects observed test metadata when the public site key is not the official pair', async () => {
+    const configuration = createSubmissionTurnstileConfigurationFromEnvironment(
+      { ...officialTestEnvironment, PUBLIC_TURNSTILE_SITE_KEY: 'different-public-site-key' },
+      { fetchImpl: (async () => observedOfficialTestResponse()) as typeof fetch },
+    );
+
+    await expect(
+      configuration.verifier.verify({
+        requestId,
+        token: 'XXXX.DUMMY.TOKEN.XXXX',
+        remoteIp: null,
+      }),
+    ).resolves.toEqual({ outcome: 'deny', reasonCode: 'challenge_hostname_mismatch' });
   });
 
   it('preserves exact hostname mismatch denial through the existing verifier', async () => {


### PR DESCRIPTION
## Implementation item

P5-02R — Suggest integration and handoff audit

## Root cause

Cloudflare's exact official always-pass dummy token currently validates successfully with `hostname: example.com` and no action, while the published example and fixed-review configuration use `localhost` and `test`.

The discrepancy was reproduced across JSON and form-encoded Siteverify requests, with and without `idempotency_key`.

## Fix

- preserve exact hostname/action verification by default;
- recognize the fixed-review test mode only when the official always-pass secret, site key, `localhost`, and `test` configuration all match exactly;
- in that bounded mode only, allow the observed `example.com` / absent-action metadata for the exact `XXXX.DUMMY.TOKEN.XXXX` token;
- reject the same metadata for any other token or any non-official key pair;
- continue accepting the documented `localhost` / `test` metadata;
- allow the P5-02R probe to proceed for either documented or reproduced official dummy metadata.

## One-shot live audit

Add a workflow that runs only after a successful `Staging review deploy` for a main commit whose message contains `[run-p5-02r-audit]`.

The workflow runs the existing privacy-bounded probe and verifies:

1. first POST returns HTTP 202;
2. exact replay returns HTTP 202 with the same public reference and status secret;
3. changed content under the same UUID returns HTTP 409;
4. `/data/manifest.json` and `/version.json` remain unchanged;
5. only bounded, non-secret evidence is retained.

## Security boundary

- production/default verification remains exact and unchanged;
- no wildcard hostname or action matching is introduced;
- the exception requires the exact public official test pair and exact dummy token;
- a non-dummy token with the same metadata is denied;
- no challenge token or returned status secret is printed;
- no Candidate, canonical, export, or publication authority changes.

## Validation

GitHub CI is authoritative for formatting, lint, TypeScript/Astro, runtime schemas, migration history, full tests, build, accessibility, staging artifacts, and migration drift.

P5-03 remains blocked until the post-merge one-shot live audit succeeds and the P5-02R handoff is recorded.