### PR TITLE
P5-02R: retain bounded fixed-review audit receipt

### DIFF
--- a/.github/workflows/p5-02r-fixed-review-live-audit.yml
+++ b/.github/workflows/p5-02r-fixed-review-live-audit.yml
@@ -8,7 +8,7 @@ on:
       - completed
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   audit:
@@ -29,16 +29,91 @@ jobs:
           node-version: 24
 
       - name: Run bounded fixed-review Suggest audit
+        id: live_audit
+        continue-on-error: true
         run: |
-          set -o pipefail
           node scripts/run-p5-02r-fixed-review-probe.mjs \
-            2>&1 | tee p5-02r-fixed-review-live-audit.log
+            > p5-02r-fixed-review-live-audit.json \
+            2> p5-02r-fixed-review-live-audit-error.log
+
+      - name: Write bounded audit receipt
+        if: always()
+        env:
+          AUDIT_OUTCOME: ${{ steps.live_audit.outcome }}
+          AUDITED_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+        run: |
+          node <<'NODE'
+          const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+          let result = null;
+          let resultParsed = false;
+          if (existsSync('p5-02r-fixed-review-live-audit.json')) {
+            try {
+              result = JSON.parse(readFileSync('p5-02r-fixed-review-live-audit.json', 'utf8'));
+              resultParsed = true;
+            } catch {
+              result = null;
+            }
+          }
+          const complete =
+            process.env.AUDIT_OUTCOME === 'success' &&
+            resultParsed &&
+            result?.status === 'complete';
+          const receipt = {
+            status: complete ? 'complete' : 'failed',
+            commit: process.env.AUDITED_COMMIT,
+            generatedAt: new Date().toISOString(),
+            workflowRunId: process.env.WORKFLOW_RUN_ID,
+            checks: {
+              liveJourney: process.env.AUDIT_OUTCOME,
+              resultParsed,
+            },
+            result,
+          };
+          writeFileSync(
+            'p5-02r-fixed-review-live-audit-receipt.json',
+            `${JSON.stringify(receipt, null, 2)}\n`,
+          );
+          NODE
 
       - name: Upload bounded audit evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: p5-02r-fixed-review-live-audit
-          path: p5-02r-fixed-review-live-audit.log
-          if-no-files-found: error
+          path: |
+            p5-02r-fixed-review-live-audit.json
+            p5-02r-fixed-review-live-audit-error.log
+            p5-02r-fixed-review-live-audit-receipt.json
+          if-no-files-found: warn
           retention-days: 30
+
+      - name: Publish audit receipt to status branch
+        if: always()
+        env:
+          STATUS_WORKTREE: ${{ runner.temp }}/cryptopaymap-p5-02r-audit-status
+        run: |
+          set -euo pipefail
+          rm -rf "$STATUS_WORKTREE"
+          git fetch origin staging-review:refs/remotes/origin/staging-review
+          git worktree add --detach "$STATUS_WORKTREE" refs/remotes/origin/staging-review
+          trap 'git worktree remove --force "$STATUS_WORKTREE" >/dev/null 2>&1 || true' EXIT
+
+          mkdir -p "$STATUS_WORKTREE/config/staging-review"
+          cp p5-02r-fixed-review-live-audit-receipt.json \
+            "$STATUS_WORKTREE/config/staging-review/p5-02r-live-audit-receipt.json"
+
+          git -C "$STATUS_WORKTREE" config user.name 'github-actions[bot]'
+          git -C "$STATUS_WORKTREE" config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git -C "$STATUS_WORKTREE" add config/staging-review/p5-02r-live-audit-receipt.json
+          if git -C "$STATUS_WORKTREE" diff --cached --quiet; then
+            echo 'P5-02R audit receipt is unchanged.'
+            exit 0
+          fi
+          git -C "$STATUS_WORKTREE" commit -m 'Record P5-02R fixed-review live audit receipt'
+          git -C "$STATUS_WORKTREE" push origin HEAD:staging-review
+
+      - name: Enforce live audit success
+        if: always()
+        run: |
+          node -e "const r=require('./p5-02r-fixed-review-live-audit-receipt.json'); if(r.status!=='complete') process.exit(1)"

--- a/scripts/run-p5-02r-fixed-review-probe.mjs
+++ b/scripts/run-p5-02r-fixed-review-probe.mjs
@@ -114,12 +114,22 @@ if (process.argv.includes('--siteverify-transport-matrix')) {
 
 const artifactsBefore = await readPublicArtifacts();
 const dummyTokenValidation = await validateOfficialDummyToken('json', true);
-console.log(JSON.stringify({ dummyTokenValidation }, null, 2));
 if (
   dummyTokenValidation.httpStatus !== 200 ||
   !dummyTokenValidation.success ||
   !officialDummyMetadataSupported(dummyTokenValidation)
 ) {
+  console.log(
+    JSON.stringify(
+      {
+        status: 'failed',
+        failedStage: 'dummy_token_validation',
+        dummyTokenValidation,
+      },
+      null,
+      2,
+    ),
+  );
   process.exit(1);
 }
 
@@ -137,6 +147,7 @@ if (!firstReceiptValid) {
       {
         status: 'failed',
         failedStage: first.status === 429 ? 'rate_limit' : 'first_post',
+        dummyTokenValidation,
         firstPost: { httpStatus: first.status, receiptShapeMatches: false },
         publicArtifactsUnchanged,
       },
@@ -187,7 +198,7 @@ const { succeeded, result } = buildP502rLiveJourneyResult({
   publicArtifactsUnchanged,
 });
 
-console.log(JSON.stringify(result, null, 2));
+console.log(JSON.stringify({ dummyTokenValidation, ...result }, null, 2));
 
 if (!succeeded) {
   process.exitCode = 1;


### PR DESCRIPTION
## Purpose

Make the post-deploy P5-02R live audit independently inspectable without local Codex or manual log copying.

## Changes

- emit one valid bounded JSON object from the normal fixed-review probe;
- retain the direct dummy-token metadata alongside the live journey booleans;
- keep all token, secret, private payload, database, and edge identity values out of output;
- write a bounded audit receipt after the workflow run;
- upload authenticated evidence;
- publish the receipt to `staging-review` at `config/staging-review/p5-02r-live-audit-receipt.json`;
- fail the workflow unless the receipt reports `status: complete`.

## Expected receipt evidence

- first POST HTTP 202 and receipt shape valid;
- exact replay HTTP 202 with matching public reference and status secret;
- changed content HTTP 409 with the expected conflict shape;
- `/data/manifest.json` unchanged;
- `/version.json` unchanged.

## Security boundary

The receipt contains only bounded status codes, metadata fields already approved for the audit, and boolean comparisons. It does not retain the dummy token, test secret, returned status secret, public reference, request body, contact data, edge identity, database value, or derived key.

## Validation

GitHub CI is authoritative. After merge, the commit marker `[run-p5-02r-audit]` will trigger staging deployment followed by the receipt-producing live audit.