### PR TITLE
P5-02R: diagnose fixed-review Submission schema

### DIFF
--- a/.github/workflows/p5-02r-fixed-review-live-audit.yml
+++ b/.github/workflows/p5-02r-fixed-review-live-audit.yml
@@ -27,9 +27,24 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Check fixed-review Submission schema
+        id: schema_probe
+        continue-on-error: true
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          node scripts/check-p5-02r-review-schema.mjs \
+            > p5-02r-review-schema.json \
+            2> p5-02r-review-schema-error.log
 
       - name: Run bounded fixed-review Suggest audit
         id: live_audit
+        if: steps.schema_probe.outcome == 'success'
         continue-on-error: true
         run: |
           node scripts/run-p5-02r-fixed-review-probe.mjs \
@@ -39,34 +54,49 @@ jobs:
       - name: Write bounded audit receipt
         if: always()
         env:
+          SCHEMA_OUTCOME: ${{ steps.schema_probe.outcome }}
           AUDIT_OUTCOME: ${{ steps.live_audit.outcome }}
           AUDITED_COMMIT: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
         run: |
           node <<'NODE'
           const { existsSync, readFileSync, writeFileSync } = require('node:fs');
-          let result = null;
-          let resultParsed = false;
-          if (existsSync('p5-02r-fixed-review-live-audit.json')) {
+          function readJson(path) {
+            if (!existsSync(path)) return { parsed: false, value: null };
             try {
-              result = JSON.parse(readFileSync('p5-02r-fixed-review-live-audit.json', 'utf8'));
-              resultParsed = true;
+              return { parsed: true, value: JSON.parse(readFileSync(path, 'utf8')) };
             } catch {
-              result = null;
+              return { parsed: false, value: null };
             }
           }
-          const complete =
+          const schema = readJson('p5-02r-review-schema.json');
+          const audit = readJson('p5-02r-fixed-review-live-audit.json');
+          const schemaReady =
+            process.env.SCHEMA_OUTCOME === 'success' &&
+            schema.parsed &&
+            schema.value?.status === 'ready';
+          const auditComplete =
             process.env.AUDIT_OUTCOME === 'success' &&
-            resultParsed &&
-            result?.status === 'complete';
+            audit.parsed &&
+            audit.value?.status === 'complete';
+          const complete = schemaReady && auditComplete;
+          const result = schemaReady
+            ? audit.value
+            : {
+                status: 'failed',
+                failedStage: 'database_schema',
+                schema: schema.value,
+              };
           const receipt = {
             status: complete ? 'complete' : 'failed',
             commit: process.env.AUDITED_COMMIT,
             generatedAt: new Date().toISOString(),
             workflowRunId: process.env.WORKFLOW_RUN_ID,
             checks: {
+              databaseSchema: process.env.SCHEMA_OUTCOME,
+              schemaResultParsed: schema.parsed,
               liveJourney: process.env.AUDIT_OUTCOME,
-              resultParsed,
+              auditResultParsed: audit.parsed,
             },
             result,
           };
@@ -82,6 +112,8 @@ jobs:
         with:
           name: p5-02r-fixed-review-live-audit
           path: |
+            p5-02r-review-schema.json
+            p5-02r-review-schema-error.log
             p5-02r-fixed-review-live-audit.json
             p5-02r-fixed-review-live-audit-error.log
             p5-02r-fixed-review-live-audit-receipt.json

--- a/scripts/check-p5-02r-review-schema.mjs
+++ b/scripts/check-p5-02r-review-schema.mjs
@@ -1,0 +1,38 @@
+import { neon } from '@neondatabase/serverless';
+
+const databaseUrl = process.env.DATABASE_URL;
+if (typeof databaseUrl !== 'string' || databaseUrl.length === 0) {
+  throw new Error('P5-02R review schema check requires DATABASE_URL.');
+}
+
+const expectedTables = [
+  'submission_public_reference_counters',
+  'submissions',
+  'submission_payloads',
+  'submission_contacts',
+  'submission_events',
+];
+
+const sql = neon(databaseUrl);
+const rows = await sql`
+  select table_name
+  from information_schema.tables
+  where table_schema = 'public'
+    and table_name = any(${expectedTables})
+`;
+const present = new Set(rows.map((row) => row.table_name));
+const tables = Object.fromEntries(expectedTables.map((name) => [name, present.has(name)]));
+const ready = Object.values(tables).every(Boolean);
+
+console.log(
+  JSON.stringify(
+    {
+      status: ready ? 'ready' : 'missing_schema',
+      tables,
+    },
+    null,
+    2,
+  ),
+);
+
+if (!ready) process.exitCode = 1;


### PR DESCRIPTION
## Purpose

Differentiate the current fixed-review HTTP 503 without exposing backend details or writing to the database.

## Changes

- add a read-only `information_schema.tables` check for the five P5-02 Submission tables;
- run it with the configured fixed-review `DATABASE_URL` before any live POST;
- stop the live journey when schema is missing;
- publish only table-presence booleans in the bounded P5-02R receipt;
- retain the existing live audit when the schema check passes.

## Safety

- no migration is run;
- no table or row is created, modified, or deleted;
- `DATABASE_URL` is never printed;
- no private row data is queried;
- the diagnostic reports only boolean presence for known repository table names.

## Expected decision

If required tables are missing, P5-02R remains blocked and no migration is applied automatically. If all tables exist, the same workflow proceeds to the 202 → replay 202 → 409 live audit.