### PR TITLE
P5-02R: add guarded fresh review database initialization

### DIFF
--- a/.github/workflows/initialize-fixed-review-database.yml
+++ b/.github/workflows/initialize-fixed-review-database.yml
@@ -1,0 +1,60 @@
+name: Initialize fixed review database
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Type INITIALIZE_FIXED_REVIEW_DATABASE
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  initialize:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate explicit confirmation
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          if [ "$CONFIRMATION" != 'INITIALIZE_FIXED_REVIEW_DATABASE' ]; then
+            echo 'Exact fixed-review initialization confirmation is required.' >&2
+            exit 1
+          fi
+
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Require a fresh empty fixed-review database
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: node scripts/check-empty-fixed-review-database.mjs
+
+      - name: Apply repository migrations to fixed-review database
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npm run db:migrate
+
+      - name: Verify Submission schema and migration ledger
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: node scripts/check-p5-02r-review-schema.mjs
+
+      - name: Trigger configured staging-review deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run staging-review-deploy.yml --ref main

--- a/docs/P5_02R_FIXED_REVIEW_DATABASE_RECOVERY.md
+++ b/docs/P5_02R_FIXED_REVIEW_DATABASE_RECOVERY.md
@@ -1,0 +1,60 @@
+# P5-02R fixed-review database recovery
+
+**Status:** Active blocker recovery  
+**Last updated:** 2026-07-12
+
+## Confirmed evidence
+
+The configured fixed-review deployment is healthy for credentials, derived configuration, the rate-limit Durable Object, Pages secrets, Pages deployment, readiness, and CSP.
+
+The bounded P5-02R audit then confirmed:
+
+- the exact official Turnstile dummy token validates successfully;
+- the bounded fixed-review Turnstile exception reaches the public Suggest route;
+- the first Suggest POST returns HTTP 503;
+- `/data/manifest.json` and `/version.json` remain unchanged.
+
+A read-only database diagnostic identified the cause:
+
+- `drizzle.__cpm_migrations` does not exist;
+- migration `0023_solid_scourge` is not recorded;
+- the existing `submissions` table is not the P5-02 Submission table;
+- it has only `id` and `updated_at` among the required P5-02 columns;
+- all four enums introduced by migration 0023 are absent;
+- `submission_public_reference_counters`, `submission_payloads`, `submission_contacts`, and `submission_events` are absent.
+
+The live audit remains stopped before private intake. P5-03 remains blocked.
+
+## Why the existing database is not repaired in place
+
+The current database has no repository migration ledger and contains an unrelated legacy table named `submissions`. Running all migrations against it would collide with existing unmanaged objects. Applying only part of migration 0023 would leave the review database outside the repository migration contract.
+
+The recovery path therefore does not rename, drop, truncate, or alter the legacy database.
+
+## Safe recovery path
+
+1. Create a new empty PostgreSQL database dedicated to the fixed-review environment.
+2. Replace the repository secret `DATABASE_URL` with that database connection string.
+3. Run the guarded `Initialize fixed review database` workflow.
+4. Enter the exact confirmation text:
+
+```text
+INITIALIZE_FIXED_REVIEW_DATABASE
+```
+
+The workflow refuses any database that already contains a public base table or a Drizzle migration table. On an empty database only, it:
+
+1. applies all repository migrations through `0023_solid_scourge`;
+2. verifies the five P5-02 Submission tables, expected columns, enums, and migration ledger;
+3. triggers the configured staging-review deployment;
+4. allows the existing one-shot P5-02R audit to verify HTTP 202, exact replay, HTTP 409 conflict, public artifact stability, and bounded privacy-safe evidence.
+
+## Prohibited shortcuts
+
+Do not:
+
+- run migration 0023 directly against the legacy database;
+- rename or drop the legacy `submissions` table without a separate data-ownership decision;
+- fabricate migration-ledger rows;
+- weaken Turnstile, rate-limit, privacy, or publication boundaries;
+- treat database connectivity readiness as proof that the private Submission schema exists.

--- a/scripts/check-empty-fixed-review-database.mjs
+++ b/scripts/check-empty-fixed-review-database.mjs
@@ -1,0 +1,40 @@
+import { neon } from '@neondatabase/serverless';
+
+const databaseUrl = process.env.DATABASE_URL;
+if (typeof databaseUrl !== 'string' || databaseUrl.length === 0) {
+  throw new Error('Fixed-review database preflight requires DATABASE_URL.');
+}
+
+const sql = neon(databaseUrl);
+const tableRows = await sql`
+  select count(*)::integer as table_count
+  from information_schema.tables
+  where table_schema = 'public'
+    and table_type = 'BASE TABLE'
+`;
+const migrationRows = await sql`
+  select exists (
+    select 1
+    from information_schema.tables
+    where table_schema = 'drizzle'
+      and table_name = '__cpm_migrations'
+  ) as exists
+`;
+
+const publicTableCount = tableRows[0]?.table_count ?? null;
+const migrationTableExists = migrationRows[0]?.exists === true;
+const empty = publicTableCount === 0 && !migrationTableExists;
+
+console.log(
+  JSON.stringify(
+    {
+      status: empty ? 'empty' : 'not_empty',
+      publicTableCount,
+      migrationTableExists,
+    },
+    null,
+    2,
+  ),
+);
+
+if (!empty) process.exitCode = 1;


### PR DESCRIPTION
## Purpose

Recover P5-02R without modifying the unmanaged legacy fixed-review database.

## Confirmed blocker

The current fixed-review database has no Drizzle migration ledger, an unrelated legacy `submissions` table, none of the four migration-0023 enums, and four missing P5-02 Submission tables.

## Changes

- add a preflight that accepts only a completely empty fixed-review database;
- add an explicitly confirmed manual workflow that applies all repository migrations;
- verify the P5-02 tables, columns, enums, and migration ledger after migration;
- trigger the configured staging-review deployment after successful initialization;
- document the safe recovery path and prohibited shortcuts.

## Safety

- the current legacy database is not modified;
- the workflow refuses any database containing a public base table or migration table;
- exact confirmation text is required;
- no destructive reset, drop, rename, truncate, or fabricated migration record is used;
- production is not targeted;
- P5-03 remains blocked until the post-deploy live audit succeeds.

## Required external step after merge

Create a new empty PostgreSQL database for fixed review and replace the repository `DATABASE_URL` secret. Then run `Initialize fixed review database` with `INITIALIZE_FIXED_REVIEW_DATABASE`.