### PR TITLE
P5-02R: chain fresh database initialization through live audit

### DIFF
--- a/.github/workflows/initialize-fixed-review-database.yml
+++ b/.github/workflows/initialize-fixed-review-database.yml
@@ -57,4 +57,31 @@ jobs:
       - name: Trigger configured staging-review deployment
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run staging-review-deploy.yml --ref main
+        run: |
+          gh workflow run staging-review-deploy.yml --ref main
+          sleep 5
+          deploy_run_id="$(gh run list \
+            --workflow staging-review-deploy.yml \
+            --branch main \
+            --event workflow_dispatch \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')"
+          test -n "$deploy_run_id"
+          gh run watch "$deploy_run_id" --exit-status
+
+      - name: Run fixed-review live audit after deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run p5-02r-fixed-review-live-audit.yml --ref main
+          sleep 5
+          audit_run_id="$(gh run list \
+            --workflow p5-02r-fixed-review-live-audit.yml \
+            --branch main \
+            --event workflow_dispatch \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')"
+          test -n "$audit_run_id"
+          gh run watch "$audit_run_id" --exit-status

--- a/.github/workflows/p5-02r-fixed-review-live-audit.yml
+++ b/.github/workflows/p5-02r-fixed-review-live-audit.yml
@@ -1,6 +1,7 @@
 name: P5-02R fixed review live audit
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows:
       - Staging review deploy
@@ -13,15 +14,16 @@ permissions:
 jobs:
   audit:
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
-      contains(github.event.workflow_run.head_commit.message, '[run-p5-02r-audit]')
+      contains(github.event.workflow_run.head_commit.message, '[run-p5-02r-audit]'))
     runs-on: ubuntu-24.04
     steps:
       - name: Check out audited main commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -56,7 +58,7 @@ jobs:
         env:
           SCHEMA_OUTCOME: ${{ steps.schema_probe.outcome }}
           AUDIT_OUTCOME: ${{ steps.live_audit.outcome }}
-          AUDITED_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          AUDITED_COMMIT: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
         run: |
           node <<'NODE'


### PR DESCRIPTION
## Purpose

Complete the guarded fresh fixed-review database workflow without requiring a second manual workflow run.

## Changes

- allow the bounded P5-02R live audit workflow to be dispatched explicitly;
- retain the existing marker-gated post-deploy trigger;
- after migration verification, dispatch the staging-review deployment and wait for success;
- then dispatch the live audit and wait for its final result.

## Safety

- database initialization still requires exact confirmation;
- only a completely empty fixed-review database is accepted;
- the legacy database remains untouched;
- deploy or audit failure stops the initializer;
- no production target, secret output, or verification weakening is introduced.

## Result

After the new `DATABASE_URL` is installed, one `Initialize fixed review database` run performs migration, schema verification, deployment, and the complete 202 → replay 202 → 409 audit chain.