### PR TITLE
P5-03I: add configured report integration audit

### DIFF
--- a/.github/workflows/p5-03i-fixed-review-live-audit.yml
+++ b/.github/workflows/p5-03i-fixed-review-live-audit.yml
@@ -1,0 +1,155 @@
+name: P5-03I fixed review live audit
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Staging review deploy
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  audit:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      contains(github.event.workflow_run.head_commit.message, '[run-p5-03i-audit]'))
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out audited main commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Check fixed-review Submission schema
+        id: schema_probe
+        continue-on-error: true
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          node scripts/check-p5-02r-review-schema.mjs \
+            > p5-03i-review-schema.json \
+            2> p5-03i-review-schema-error.log
+
+      - name: Run bounded fixed-review report audit
+        id: live_audit
+        if: steps.schema_probe.outcome == 'success'
+        continue-on-error: true
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          node scripts/run-p5-03i-fixed-review-probe.mjs \
+            > p5-03i-fixed-review-live-audit.json \
+            2> p5-03i-fixed-review-live-audit-error.log
+
+      - name: Write bounded audit receipt
+        if: always()
+        env:
+          SCHEMA_OUTCOME: ${{ steps.schema_probe.outcome }}
+          AUDIT_OUTCOME: ${{ steps.live_audit.outcome }}
+          AUDITED_COMMIT: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+        run: |
+          node <<'NODE'
+          const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+          function readJson(path) {
+            if (!existsSync(path)) return { parsed: false, value: null };
+            try {
+              return { parsed: true, value: JSON.parse(readFileSync(path, 'utf8')) };
+            } catch {
+              return { parsed: false, value: null };
+            }
+          }
+          const schema = readJson('p5-03i-review-schema.json');
+          const audit = readJson('p5-03i-fixed-review-live-audit.json');
+          const schemaReady =
+            process.env.SCHEMA_OUTCOME === 'success' &&
+            schema.parsed &&
+            schema.value?.status === 'ready';
+          const auditComplete =
+            process.env.AUDIT_OUTCOME === 'success' &&
+            audit.parsed &&
+            audit.value?.status === 'complete';
+          const complete = schemaReady && auditComplete;
+          const result = schemaReady
+            ? audit.value
+            : {
+                status: 'failed',
+                failedStage: 'database_schema',
+                schema: schema.value,
+              };
+          const receipt = {
+            status: complete ? 'complete' : 'failed',
+            commit: process.env.AUDITED_COMMIT,
+            generatedAt: new Date().toISOString(),
+            workflowRunId: process.env.WORKFLOW_RUN_ID,
+            checks: {
+              databaseSchema: process.env.SCHEMA_OUTCOME,
+              schemaResultParsed: schema.parsed,
+              liveJourney: process.env.AUDIT_OUTCOME,
+              auditResultParsed: audit.parsed,
+            },
+            result,
+          };
+          writeFileSync(
+            'p5-03i-fixed-review-live-audit-receipt.json',
+            `${JSON.stringify(receipt, null, 2)}\n`,
+          );
+          NODE
+
+      - name: Upload bounded audit evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: p5-03i-fixed-review-live-audit
+          path: |
+            p5-03i-review-schema.json
+            p5-03i-review-schema-error.log
+            p5-03i-fixed-review-live-audit.json
+            p5-03i-fixed-review-live-audit-error.log
+            p5-03i-fixed-review-live-audit-receipt.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish audit receipt to status branch
+        if: always()
+        env:
+          STATUS_WORKTREE: ${{ runner.temp }}/cryptopaymap-p5-03i-audit-status
+        run: |
+          set -euo pipefail
+          rm -rf "$STATUS_WORKTREE"
+          git fetch origin staging-review:refs/remotes/origin/staging-review
+          git worktree add --detach "$STATUS_WORKTREE" refs/remotes/origin/staging-review
+          trap 'git worktree remove --force "$STATUS_WORKTREE" >/dev/null 2>&1 || true' EXIT
+
+          mkdir -p "$STATUS_WORKTREE/config/staging-review"
+          cp p5-03i-fixed-review-live-audit-receipt.json \
+            "$STATUS_WORKTREE/config/staging-review/p5-03i-live-audit-receipt.json"
+
+          git -C "$STATUS_WORKTREE" config user.name 'github-actions[bot]'
+          git -C "$STATUS_WORKTREE" config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git -C "$STATUS_WORKTREE" add config/staging-review/p5-03i-live-audit-receipt.json
+          if git -C "$STATUS_WORKTREE" diff --cached --quiet; then
+            echo 'P5-03I audit receipt is unchanged.'
+            exit 0
+          fi
+          git -C "$STATUS_WORKTREE" commit -m 'Record P5-03I fixed-review live audit receipt'
+          git -C "$STATUS_WORKTREE" push origin HEAD:staging-review
+
+      - name: Enforce live audit success
+        if: always()
+        run: |
+          node -e "const r=require('./p5-03i-fixed-review-live-audit-receipt.json'); if(r.status!=='complete') process.exit(1)"

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,43 +8,22 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-03H — Public payment and problem report routes and forms
+P5-03I — Configured review and integration audit
 
 ## Current repository state
 
-- Phase 0 public specifications and development control are complete.
-- Phase 1 foundation repository work is complete.
-- Phase 2 data core is complete.
-- Phase 3 administration and review repository work is complete through P3-12.
-- Phase 4 public MVP-A and P4-18 closure are complete for the Phase 5 handoff.
+- Phase 0 through Phase 4 are complete for the Phase 5 handoff.
 - P5-01 shared Submission foundation is complete through #150–#155.
-- P5-02A Suggest contract and review-safe normalization is complete through #156.
-- P5-02B Suggest private intake integration is complete through #157.
-- P5-02C read-only Candidate overlap and canonical target signal generation is complete through #158.
-- P5-02D protected Suggest reviewer queue and detail entry is complete through #159.
-- P5-02E guarded received→triage and triage→in_review transitions are complete through #160.
-- P5-02F bounded in_review→needs_information request boundary is complete through #161.
-- P5-02G bounded in_review→on_hold operation with 30/60/90 day next-review timing is complete through #162.
-- P5-02H atomic accepted-as-Candidate transaction boundary is complete through #163.
-- P5-02I Submission status-secret environment binding is complete through #167.
-- P5-02J Submission contact protection is complete through #168.
-- P5-02K opaque Submission rate-limit bucket derivation is complete through #169.
-- P5-02L trusted Cloudflare edge identity extraction is complete through #170.
-- P5-02M Durable Object distributed Submission rate limiting is complete through #171.
-- P5-02N Turnstile environment binding is complete through #172.
-- P5-02O public Suggest HTTP composition and safe response mapping are complete through #173.
-- P5-02P public Suggest form, browser Turnstile wiring, and scoped CSP are complete through #174.
-- P5-02Q configured Suggest review deployment and readiness verification are complete through #175–#183.
-- P5-02R Suggest integration and handoff audit is complete through #185–#192.
-- P5-02 Suggest Place and Online Service is complete and handed off to P5-03.
-- P5-03A payment/problem report contract and review-safe normalization is complete through #194.
-- P5-03B idempotent payment/problem report private intake integration is complete through #195.
-- P5-03C canonical report target snapshot and Claim-context signals are complete through #196.
-- P5-03D protected report reviewer queue and detail entry is complete through #197.
-- P5-03E positive payment Evidence and reconfirmation decision boundary is complete through #198.
-- P5-03F negative Evidence and priority-recheck decision boundary is complete through #199.
-- P5-03G problem correction and urgent visibility decision boundaries are complete through #200.
-- P5-03H public payment and problem report routes and forms are in progress.
+- P5-02 Suggest Place and Online Service is complete through #156–#192.
+- P5-03A payment/problem report contract and normalization is complete through #194.
+- P5-03B private report intake is complete through #195.
+- P5-03C target context is complete through #196.
+- P5-03D protected reviewer entry is complete through #197.
+- P5-03E positive payment Evidence decision is complete through #198.
+- P5-03F negative Evidence and recheck priority decision is complete through #199.
+- P5-03G correction and urgent visibility decisions are complete through #200.
+- P5-03H separate `/payment-report` and `/report` public routes and forms are complete through #201.
+- P5-03I configured review and integration audit is in progress.
 
 ## Fixed review environment
 
@@ -52,201 +31,67 @@ Review URL:
 
 `https://review.cryptopaymap-staging.pages.dev`
 
-The current fixed-review deployment receipt for main commit:
+The last complete configured Suggest deployment/live-audit receipt belongs to main commit:
 
 `699cff048fa80113d3b05bcdf4f385c229a4d41d`
 
-records `status: deployed` and success for credentials, configured inputs, Durable Object Worker deployment, Pages secret synchronization, Pages deployment, and configured verification. The bounded P5-02R live-audit receipt for the same commit records `status: complete`.
+Later repository merges must not be assumed deployed or configured correctly until a new fixed-review receipt identifies the intended main commit and records successful checks.
 
-Deployment receipt state must still be checked whenever review-environment state matters. A later repository merge must not be assumed visible or configured correctly at the fixed URL until the receipt records the intended `main` commit and successful configured verification.
+## P5-03I required evidence
 
-P5-03 repository implementation may continue while Cloudflare and Neon operator access is unavailable. P5-03 configured Access, deployed Functions, live Neon execution, and integrated public-route verification remain assigned to P5-03I and must not be inferred from repository checks.
+P5-03I must prove against the fixed review environment:
 
-## Required current references
+1. the intended main commit is deployed;
+2. `/payment-report` and `/report` expose the expected runtime configuration and security headers;
+3. one synthetic payment report and one synthetic problem report are accepted;
+4. exact replay returns the same private receipt;
+5. changed content under the same request UUID returns the bounded conflict;
+6. protected reviewer reads can resolve both report families;
+7. stable public artifacts remain unchanged;
+8. retained receipts contain no challenge token, returned status secret, private payload, contact data, raw edge identity, database URL, or derived key;
+9. no automatic Evidence, Claim, canonical, export, or publication mutation occurs.
 
-Before P5-03 implementation or review, read:
+## Current references
 
-1. `docs/IMPLEMENTATION_PLAN.md`;
-2. `docs/PHASE5_IMPLEMENTATION_SEQUENCE.md`;
-3. `docs/SUBMISSION_WORKFLOW.md`;
-4. `docs/DATA_MODEL.md`;
-5. `docs/SECURITY_AND_PRIVACY.md`;
-6. `docs/P5_01A_SUBMISSION_CONTRACT_AND_PRIVACY_MODEL.md`;
-7. `docs/P5_01B_SUBMISSION_PERSISTENCE_FOUNDATION.md`;
-8. `docs/P5_01C_IDEMPOTENT_PRIVATE_INTAKE.md`;
-9. `docs/P5_01D_ABUSE_CONTROL_AND_TURNSTILE.md`;
-10. `docs/P5_01E_SUBMISSION_FOUNDATION_AUDIT.md`;
-11. `docs/P5_01F_PRIVATE_FOLLOWUP_STATUS_READ.md`;
-12. `docs/P5_02A_SUGGEST_CONTRACT_AND_NORMALIZATION.md`;
-13. `docs/P5_02B_SUGGEST_PRIVATE_INTAKE_INTEGRATION.md`;
-14. `docs/P5_02C_SUGGEST_REVIEW_SIGNALS.md`;
-15. `docs/P5_02D_SUGGEST_REVIEWER_ENTRY.md`;
-16. `docs/P5_02E_GUARDED_SUGGEST_REVIEW_TRANSITIONS.md`;
-17. `docs/P5_02F_SUGGEST_INFORMATION_REQUEST.md`;
-18. `docs/P5_02G_TIME_BOUNDED_HOLD.md`;
-19. `docs/P5_02H_ACCEPTED_AS_CANDIDATE.md`;
-20. `docs/P5_02I_SUBMISSION_STATUS_SECRET_ENVIRONMENT_BINDING.md`;
-21. `docs/P5_02J_SUBMISSION_CONTACT_PROTECTION.md`;
-22. `docs/P5_02K_OPAQUE_RATE_LIMIT_BUCKET_DERIVATION.md`;
-23. `docs/P5_02L_CLOUDFLARE_EDGE_IDENTITY.md`;
-24. `docs/P5_02M_DURABLE_OBJECT_RATE_LIMIT.md`;
-25. `docs/P5_02N_TURNSTILE_ENVIRONMENT_BINDING.md`;
-26. `docs/P5_02O_SUGGEST_HTTP_ROUTE.md`;
-27. `docs/P5_02P_SUGGEST_FORM_TURNSTILE.md`;
-28. `docs/P5_02Q_CONFIGURED_SUGGEST_REVIEW_VERIFICATION.md`;
-29. `docs/P5_02R_SUGGEST_INTEGRATION_AND_HANDOFF_AUDIT.md`;
-30. `docs/P5_03A_REPORT_CONTRACT_AND_NORMALIZATION.md`;
-31. `docs/P5_03B_REPORT_PRIVATE_INTAKE_INTEGRATION.md`;
-32. `docs/P5_03C_REPORT_TARGET_CONTEXT.md`;
-33. `docs/P5_03D_REPORT_REVIEWER_ENTRY.md`;
-34. `docs/P5_03E_POSITIVE_PAYMENT_EVIDENCE.md`;
-35. `docs/P5_03F_NEGATIVE_EVIDENCE_AND_RECHECK_PRIORITY.md`;
-36. `docs/P5_03G_PROBLEM_CORRECTION_AND_URGENT_VISIBILITY.md`;
-37. `docs/P5_03H_PUBLIC_REPORT_ROUTES_AND_FORMS.md`;
-38. `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`.
-
-Media work must also read `docs/MEDIA_POLICY.md`.
+- `docs/IMPLEMENTATION_PLAN.md`
+- `docs/PHASE5_IMPLEMENTATION_SEQUENCE.md`
+- `docs/SUBMISSION_WORKFLOW.md`
+- `docs/DATA_MODEL.md`
+- `docs/SECURITY_AND_PRIVACY.md`
+- `docs/P5_03A_REPORT_CONTRACT_AND_NORMALIZATION.md`
+- `docs/P5_03B_REPORT_PRIVATE_INTAKE_INTEGRATION.md`
+- `docs/P5_03C_REPORT_TARGET_CONTEXT.md`
+- `docs/P5_03D_REPORT_REVIEWER_ENTRY.md`
+- `docs/P5_03E_POSITIVE_PAYMENT_EVIDENCE.md`
+- `docs/P5_03F_NEGATIVE_EVIDENCE_AND_RECHECK_PRIORITY.md`
+- `docs/P5_03G_PROBLEM_CORRECTION_AND_URGENT_VISIBILITY.md`
+- `docs/P5_03H_PUBLIC_REPORT_ROUTES_AND_FORMS.md`
+- `docs/P5_03I_CONFIGURED_REVIEW_AND_INTEGRATION_AUDIT.md`
+- `docs/P4_18_E_LIVE_REVIEW_AND_HANDOFF_AUDIT.md`
 
 ## Phase 5 sequence
 
 1. P5-01 — Shared submission foundation — Completed through #150–#155
 2. P5-02 — Suggest Place and Online Service — Completed through #156–#192
-3. P5-03 — Payment and problem reports — In progress at P5-03H
+3. P5-03 — Payment and problem reports — In progress at P5-03I
 4. P5-04 — Business and service claims — Planned
 5. P5-05 — Photo and Media submission intake — Planned
 6. P5-06 — Review workflow extensions — Planned
 7. P5-07 — Canonical application transactions and retention — Planned
 8. P5-08 — MVP-B integration audit — Planned
 
-## P5-02 and P5-03 execution sequence
-
-```text
-P5-02A  Suggest type-specific contract and review-safe normalization       Completed #156
-    ↓
-P5-02B  Suggest private intake integration                               Completed #157
-    ↓
-P5-02C  Duplicate Candidate and existing-target read-only signals        Completed #158
-    ↓
-P5-02D  Protected Suggest reviewer queue and detail entry                 Completed #159
-    ↓
-P5-02E  Guarded received→triage and triage→in_review transitions          Completed #160
-    ↓
-P5-02F  Guarded in_review→needs_information request                       Completed #161
-    ↓
-P5-02G  Guarded time-bounded in_review→on_hold operation                  Completed #162
-    ↓
-P5-02H  Atomic accepted-as-Candidate outcome                              Completed #163
-    ↓
-P5-02I  Submission status-secret environment binding                     Completed #167
-    ↓
-P5-02J  Submission contact protection                                    Completed #168
-    ↓
-P5-02K  Opaque Submission rate-limit bucket derivation                    Completed #169
-    ↓
-P5-02L  Trusted Cloudflare edge identity extraction                       Completed #170
-    ↓
-P5-02M  Durable Object distributed Submission rate limiting               Completed #171
-    ↓
-P5-02N  Turnstile environment binding                                    Completed #172
-    ↓
-P5-02O  Public Suggest HTTP route and safe response mapping               Completed #173
-    ↓
-P5-02P  Public Suggest form and Turnstile browser wiring                  Completed #174
-    ↓
-P5-02Q  Configured Suggest review verification                           Completed #175–#183
-    ↓
-P5-02R  Suggest integration and handoff audit                            Completed #185–#192
-P5-03A  Payment/problem report contract and normalization                 Completed #194
-P5-03B  Idempotent payment/problem report private intake                  Completed #195
-P5-03C  Canonical report target snapshot and Claim-context signals        Completed #196
-P5-03D  Protected report reviewer queue and detail entry                  Completed #197
-P5-03E  Positive payment Evidence and reconfirmation decision             Completed #198
-P5-03F  Negative Evidence and priority-recheck decision                   Completed #199
-P5-03G  Problem correction and urgent visibility decisions               Completed #200
-P5-03H  Public payment/problem report routes and forms                    In progress
-```
-
-## P5-02Q completion evidence
-
-The fixed-review receipt for commit `513dc7f543ac27fe512319a3cc24cc16c3de4302` proves:
-
-- Cloudflare credentials accepted;
-- configured review inputs present;
-- stable review-secret derivation accepted;
-- SQLite-backed rate-limit Durable Object Worker deployed;
-- Pages preview secrets synchronized;
-- Pages review deployment succeeded;
-- runtime client configuration returned the expected site key and action;
-- Neon accepted a lightweight query;
-- Pages resolved and called the bound Durable Object health path;
-- `/suggest` returned the required Function-applied Turnstile CSP.
-
-P5-02Q does not prove a successful public Suggest POST, deterministic live replay, changed-content live conflict, configured live 429 behavior, or protected reviewer execution.
-
-## P5-02R completion evidence
-
-The fixed-review deployment receipt records `status: deployed` for main commit `699cff048fa80113d3b05bcdf4f385c229a4d41d`, with credentials, configured inputs, Durable Object Worker, Pages secrets, Pages deployment, and configured verification all successful.
-
-The bounded live-audit receipt records `status: complete` for the same commit and proves:
-
-- fixed-review Submission schema and migration ledger verification succeeded;
-- first public Suggest POST returned HTTP 202 with the expected receipt shape;
-- exact replay returned HTTP 202 with the same public reference and status secret;
-- changed content under the same idempotency UUID returned HTTP 409 with the expected conflict shape;
-- `/data/manifest.json` and `/version.json` were unchanged;
-- no challenge token, returned status secret, private payload, contact data, raw edge identity, database value, or derived key entered the retained receipt.
-
-The Cloudflare dummy-token metadata discrepancy is explicitly reclassified only inside the fixed-review official-test-key boundary. Production/default hostname and action verification remain strict.
-
-## P5-02R handoff gate
-
-P5-03 may begin only after:
-
-1. P5-02 repository integration checks are green;
-2. the configured fixed-review receipt remains successful;
-3. the synthetic live intake path is accepted or an explicit approved retained gate exists;
-4. exact replay and changed-content conflict are proven at the public route;
-5. stable public artifacts remain unchanged by intake;
-6. no private or secret leakage is found;
-7. residual work is assigned to the correct later Phase 5 or Launch gate;
-8. the P5-02R audit records an explicit handoff decision.
-
-All eight conditions are satisfied by the deployment and live-audit receipts for commit `699cff048fa80113d3b05bcdf4f385c229a4d41d`. P5-02 hands off to P5-03.
-
 ## Retained Launch work
 
-Starting or completing Phase 5 does not waive retained Launch work, including:
-
-- live Cloudflare Access and identity verification;
-- actual allowlist and deployed Admin environment verification;
-- live Neon migration-state verification;
-- representative protected Admin journeys with configured data;
-- configured accepted-as-Candidate execution requiring source/capability configuration;
-- canonical query → complete candidate generation → private upload → release-review handoff;
-- corrected canonical value → generation → release → activation flow;
-- concrete R2 publication conditional-write verification;
-- production restore persistence, invocation, R2 adapter wiring, durable restore Audit source, reconciliation runbook, and drills.
-
-Launch readiness must not be claimed until the relevant launch criteria and retained Launch work are complete.
-
-## Current active scope — P5-03H public payment and problem reports
-
-P5-03H exposes `/report`, `POST /api/reports`, and client-safe Turnstile configuration for target-aware payment and problem report intake. The route reuses the existing private Submission, status-secret, contact-protection, trusted edge identity, opaque rate-limit, Durable Object, and Turnstile boundaries.
-
-The form supports payment success/failure, factual corrections, duplicates, closure, privacy, rights, and other problem categories. Public and restricted evidence remain separated, and successful intake returns only the private follow-up receipt.
-
-Repository implementation and GitHub validation do not prove the configured fixed-review journey. Deployed Function, live Neon, real Turnstile, first acceptance, replay, conflict, artifact stability, and protected reviewer execution remain assigned to P5-03I.
+P5-03I does not waive retained Launch work, including production Access verification, production Turnstile behavior, configured live 429 timing, full protected Admin journeys, production migration/restore checks, R2 publication conditional writes, reconciliation, and restore drills.
 
 ## Next
 
-Complete P5-03H HTTP composition, browser form, CSP, bounded public errors, schema/unit/artifact validation, and tracking. Then proceed to P5-03I configured review and integration audit.
+Implement the fixed-review deployment and bounded P5-03I live-audit chain. Do not hand off to P5-04 until the configured receipt records complete evidence for both public report families.
 
 ## Blocked
 
-No repository blocker to P5-03H is known. Configured Cloudflare/Neon execution is intentionally deferred to P5-03I; retained Launch work remains unchanged and launch readiness is not claimed.
+No repository blocker is known. Configured Cloudflare/Neon execution may fail closed if the fixed review environment or required credentials are unavailable; such a failure must remain recorded as incomplete rather than converted into a pass.
 
 ## Verification rule
 
-Repository reality is determined by current `main`, merged pull requests, actual CI results, and the fixed-review deployment receipt. Current work order is determined by `docs/PROJECT_STATUS.md`, `docs/IMPLEMENTATION_PLAN.md`, and the active phase specification.
-
-Do not claim live verification from repository checks alone. Do not claim visual acceptance from screenshot generation alone; relevant images must be inspected directly.
+Repository reality is determined by current `main`, merged pull requests, actual CI results, and fixed-review receipts. Repository checks alone do not prove live configuration or launch readiness.

--- a/scripts/p5-03i-live-journey-result.mjs
+++ b/scripts/p5-03i-live-journey-result.mjs
@@ -1,0 +1,51 @@
+export function buildP503iLiveJourneyResult(checks) {
+  const succeeded =
+    checks.clientConfigurationMatches &&
+    checks.paymentPageHeadersMatch &&
+    checks.problemPageHeadersMatch &&
+    checks.paymentFirstReceiptValid &&
+    checks.paymentReplayReceiptValid &&
+    checks.paymentReplayReferenceMatches &&
+    checks.paymentReplayStatusSecretMatches &&
+    checks.paymentConflictShapeMatches &&
+    checks.problemFirstReceiptValid &&
+    checks.problemReplayReceiptValid &&
+    checks.problemReplayReferenceMatches &&
+    checks.problemReplayStatusSecretMatches &&
+    checks.databasePaymentProjectionMatches &&
+    checks.databaseProblemProjectionMatches &&
+    Object.values(checks.publicArtifactsUnchanged).every(Boolean);
+
+  return {
+    succeeded,
+    result: {
+      status: succeeded ? 'complete' : 'failed',
+      clientConfigurationMatches: checks.clientConfigurationMatches,
+      publicPages: {
+        paymentHeadersMatch: checks.paymentPageHeadersMatch,
+        problemHeadersMatch: checks.problemPageHeadersMatch,
+      },
+      paymentReport: {
+        firstHttpStatus: checks.paymentFirstHttpStatus,
+        firstReceiptShapeMatches: checks.paymentFirstReceiptValid,
+        replayHttpStatus: checks.paymentReplayHttpStatus,
+        replayReceiptShapeMatches: checks.paymentReplayReceiptValid,
+        replayReferenceMatches: checks.paymentReplayReferenceMatches,
+        replayStatusSecretMatches: checks.paymentReplayStatusSecretMatches,
+        changedContentHttpStatus: checks.paymentChangedContentHttpStatus,
+        conflictShapeMatches: checks.paymentConflictShapeMatches,
+        databaseProjectionMatches: checks.databasePaymentProjectionMatches,
+      },
+      problemReport: {
+        firstHttpStatus: checks.problemFirstHttpStatus,
+        firstReceiptShapeMatches: checks.problemFirstReceiptValid,
+        replayHttpStatus: checks.problemReplayHttpStatus,
+        replayReceiptShapeMatches: checks.problemReplayReceiptValid,
+        replayReferenceMatches: checks.problemReplayReferenceMatches,
+        replayStatusSecretMatches: checks.problemReplayStatusSecretMatches,
+        databaseProjectionMatches: checks.databaseProblemProjectionMatches,
+      },
+      publicArtifactsUnchanged: checks.publicArtifactsUnchanged,
+    },
+  };
+}

--- a/scripts/p5-03i-synthetic-report-fixtures.mjs
+++ b/scripts/p5-03i-synthetic-report-fixtures.mjs
@@ -1,0 +1,65 @@
+export function p503iSyntheticPaymentReport(targetId, challengeToken, observedSteps) {
+  return {
+    challengeToken,
+    submission: {
+      schemaVersion: 'submission-common-v1',
+      submissionType: 'payment_report',
+      targetType: 'entity',
+      targetId,
+      relationship: null,
+      contact: null,
+      evidenceLinks: [],
+      originalPayload: {
+        schemaVersion: 'payment-report-v1',
+        result: 'successful',
+        paymentDate: '2026-07-13',
+        payment: {
+          assetSlug: 'bitcoin',
+          networkSlug: 'lightning',
+          routeType: 'direct_wallet',
+          paymentMethod: 'lightning_invoice',
+          processor: null,
+          context: 'qr_code',
+          observedSteps,
+        },
+        privateTransactionUrl: null,
+        notes: null,
+      },
+      acknowledgements: {
+        privacyNoticeAccepted: true,
+        submissionTermsAccepted: true,
+      },
+    },
+  };
+}
+
+export function p503iSyntheticProblemReport(targetId, challengeToken) {
+  return {
+    challengeToken,
+    submission: {
+      schemaVersion: 'submission-common-v1',
+      submissionType: 'problem_report',
+      targetType: 'entity',
+      targetId,
+      relationship: null,
+      contact: null,
+      evidenceLinks: [],
+      originalPayload: {
+        schemaVersion: 'problem-report-v1',
+        reportType: 'wrong_instructions',
+        observedAt: '2026-07-13',
+        explanation: 'P5-03I synthetic fixed-review problem report.',
+        proposedCorrection: {
+          kind: 'instructions',
+          howToPay: 'Ask staff to display the current Lightning invoice before scanning.',
+        },
+        duplicateTarget: null,
+        privateEvidenceUrl: null,
+      },
+      acknowledgements: {
+        privacyNoticeAccepted: true,
+        submissionTermsAccepted: true,
+      },
+    },
+  };
+}

--- a/scripts/run-p5-03i-fixed-review-probe.mjs
+++ b/scripts/run-p5-03i-fixed-review-probe.mjs
@@ -1,0 +1,249 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { neon } from '@neondatabase/serverless';
+import { buildP503iLiveJourneyResult } from './p5-03i-live-journey-result.mjs';
+import {
+  p503iSyntheticPaymentReport,
+  p503iSyntheticProblemReport,
+} from './p5-03i-synthetic-report-fixtures.mjs';
+
+const defaultBaseUrl = 'https://review.cryptopaymap-staging.pages.dev';
+const baseUrl = new URL(process.env.CPM_P5_03I_REVIEW_URL ?? defaultBaseUrl);
+const databaseUrl = process.env.DATABASE_URL;
+const challengeToken = 'XXXX.DUMMY.TOKEN.XXXX';
+const expectedSiteKey = '1x00000000000000000000AA';
+const expectedAction = 'submission_intake';
+const publicArtifactPaths = ['/data/manifest.json', '/version.json'];
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function isReceipt(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof value.submissionReference === 'string' &&
+    typeof value.statusSecret === 'string' &&
+    typeof value.submittedAt === 'string' &&
+    Object.keys(value).length === 3
+  );
+}
+
+function cspMatches(value) {
+  return (
+    typeof value === 'string' &&
+    value.includes('https://challenges.cloudflare.com') &&
+    value.includes("form-action 'self'") &&
+    value.includes("frame-ancestors 'none'")
+  );
+}
+
+async function readPublicArtifacts() {
+  return Object.fromEntries(
+    await Promise.all(
+      publicArtifactPaths.map(async (path) => {
+        const response = await fetch(new URL(path, baseUrl), { cache: 'no-store' });
+        if (!response.ok) throw new Error('public_artifact_unavailable');
+        return [path, sha256(Buffer.from(await response.arrayBuffer()))];
+      }),
+    ),
+  );
+}
+
+async function inspectPage(path) {
+  const response = await fetch(new URL(path, baseUrl), { cache: 'no-store' });
+  return {
+    httpStatus: response.status,
+    matches:
+      response.status === 200 &&
+      response.headers.get('cache-control')?.includes('no-store') === true &&
+      response.headers.get('referrer-policy') === 'no-referrer' &&
+      cspMatches(response.headers.get('content-security-policy')),
+  };
+}
+
+async function readClientConfiguration() {
+  const response = await fetch(new URL('/api/reports/config', baseUrl), { cache: 'no-store' });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    // Only bounded comparison booleans are retained.
+  }
+  return {
+    httpStatus: response.status,
+    matches:
+      response.status === 200 &&
+      payload !== null &&
+      typeof payload === 'object' &&
+      payload.siteKey === expectedSiteKey &&
+      payload.action === expectedAction &&
+      Object.keys(payload).length === 2,
+  };
+}
+
+async function postReport(requestId, body) {
+  const response = await fetch(new URL('/api/reports', baseUrl), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': requestId,
+    },
+    body: JSON.stringify(body),
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    // Only bounded response checks are retained.
+  }
+  return { status: response.status, payload };
+}
+
+async function verifyDatabaseProjections(paymentReference, problemReference) {
+  if (!databaseUrl || !paymentReference || !problemReference) {
+    return { paymentMatches: false, problemMatches: false };
+  }
+
+  const sql = neon(databaseUrl);
+  const rows = await sql`
+    select
+      s.public_id,
+      s.submission_type,
+      s.target_type,
+      p.normalized_payload
+    from submissions s
+    join submission_payloads p on p.submission_id = s.id
+    where s.public_id = ${paymentReference}
+       or s.public_id = ${problemReference}
+  `;
+
+  const payment = rows.find((row) => row.public_id === paymentReference);
+  const problem = rows.find((row) => row.public_id === problemReference);
+  return {
+    paymentMatches:
+      payment?.submission_type === 'payment_report' &&
+      payment?.target_type === 'entity' &&
+      payment?.normalized_payload?.reportKind === 'payment_report',
+    problemMatches:
+      problem?.submission_type === 'problem_report' &&
+      problem?.target_type === 'entity' &&
+      problem?.normalized_payload?.reportKind === 'problem_report',
+  };
+}
+
+async function main() {
+  const artifactsBefore = await readPublicArtifacts();
+  const clientConfiguration = await readClientConfiguration();
+  const paymentPage = await inspectPage('/payment-report');
+  const problemPage = await inspectPage('/report');
+
+  const paymentRequestId = randomUUID();
+  const paymentTargetId = randomUUID();
+  const paymentBody = p503iSyntheticPaymentReport(
+    paymentTargetId,
+    challengeToken,
+    'P5-03I synthetic payment report.',
+  );
+  const paymentFirst = await postReport(paymentRequestId, paymentBody);
+  const paymentFirstValid = paymentFirst.status === 202 && isReceipt(paymentFirst.payload);
+  const paymentReplay = await postReport(paymentRequestId, paymentBody);
+  const paymentReplayValid = paymentReplay.status === 202 && isReceipt(paymentReplay.payload);
+  const paymentChanged = await postReport(
+    paymentRequestId,
+    p503iSyntheticPaymentReport(
+      paymentTargetId,
+      challengeToken,
+      'P5-03I changed-content conflict probe.',
+    ),
+  );
+
+  const problemRequestId = randomUUID();
+  const problemBody = p503iSyntheticProblemReport(randomUUID(), challengeToken);
+  const problemFirst = await postReport(problemRequestId, problemBody);
+  const problemFirstValid = problemFirst.status === 202 && isReceipt(problemFirst.payload);
+  const problemReplay = await postReport(problemRequestId, problemBody);
+  const problemReplayValid = problemReplay.status === 202 && isReceipt(problemReplay.payload);
+
+  const database = await verifyDatabaseProjections(
+    paymentFirstValid ? paymentFirst.payload.submissionReference : null,
+    problemFirstValid ? problemFirst.payload.submissionReference : null,
+  );
+  const artifactsAfter = await readPublicArtifacts();
+  const publicArtifactsUnchanged = Object.fromEntries(
+    publicArtifactPaths.map((path) => [path, artifactsBefore[path] === artifactsAfter[path]]),
+  );
+
+  const paymentConflictShapeMatches =
+    paymentChanged.status === 409 &&
+    paymentChanged.payload !== null &&
+    typeof paymentChanged.payload === 'object' &&
+    paymentChanged.payload.error === 'report_request_conflict' &&
+    Object.keys(paymentChanged.payload).length === 1;
+
+  const { succeeded, result } = buildP503iLiveJourneyResult({
+    clientConfigurationMatches: clientConfiguration.matches,
+    paymentPageHeadersMatch: paymentPage.matches,
+    problemPageHeadersMatch: problemPage.matches,
+    paymentFirstHttpStatus: paymentFirst.status,
+    paymentFirstReceiptValid: paymentFirstValid,
+    paymentReplayHttpStatus: paymentReplay.status,
+    paymentReplayReceiptValid: paymentReplayValid,
+    paymentReplayReferenceMatches:
+      paymentFirstValid &&
+      paymentReplayValid &&
+      paymentFirst.payload.submissionReference === paymentReplay.payload.submissionReference,
+    paymentReplayStatusSecretMatches:
+      paymentFirstValid &&
+      paymentReplayValid &&
+      paymentFirst.payload.statusSecret === paymentReplay.payload.statusSecret,
+    paymentChangedContentHttpStatus: paymentChanged.status,
+    paymentConflictShapeMatches,
+    problemFirstHttpStatus: problemFirst.status,
+    problemFirstReceiptValid: problemFirstValid,
+    problemReplayHttpStatus: problemReplay.status,
+    problemReplayReceiptValid: problemReplayValid,
+    problemReplayReferenceMatches:
+      problemFirstValid &&
+      problemReplayValid &&
+      problemFirst.payload.submissionReference === problemReplay.payload.submissionReference,
+    problemReplayStatusSecretMatches:
+      problemFirstValid &&
+      problemReplayValid &&
+      problemFirst.payload.statusSecret === problemReplay.payload.statusSecret,
+    databasePaymentProjectionMatches: database.paymentMatches,
+    databaseProblemProjectionMatches: database.problemMatches,
+    publicArtifactsUnchanged,
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        clientConfigurationHttpStatus: clientConfiguration.httpStatus,
+        paymentPageHttpStatus: paymentPage.httpStatus,
+        problemPageHttpStatus: problemPage.httpStatus,
+        ...result,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!succeeded) process.exitCode = 1;
+}
+
+try {
+  await main();
+} catch {
+  console.log(
+    JSON.stringify(
+      {
+        status: 'failed',
+        failedStage: 'probe_runtime',
+      },
+      null,
+      2,
+    ),
+  );
+  process.exitCode = 1;
+}

--- a/tests/p5-03i-live-journey-result.test.mjs
+++ b/tests/p5-03i-live-journey-result.test.mjs
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildP503iLiveJourneyResult } from '../scripts/p5-03i-live-journey-result.mjs';
+
+function completeChecks() {
+  return {
+    clientConfigurationMatches: true,
+    paymentPageHeadersMatch: true,
+    problemPageHeadersMatch: true,
+    paymentFirstHttpStatus: 202,
+    paymentFirstReceiptValid: true,
+    paymentReplayHttpStatus: 202,
+    paymentReplayReceiptValid: true,
+    paymentReplayReferenceMatches: true,
+    paymentReplayStatusSecretMatches: true,
+    paymentChangedContentHttpStatus: 409,
+    paymentConflictShapeMatches: true,
+    problemFirstHttpStatus: 202,
+    problemFirstReceiptValid: true,
+    problemReplayHttpStatus: 202,
+    problemReplayReceiptValid: true,
+    problemReplayReferenceMatches: true,
+    problemReplayStatusSecretMatches: true,
+    databasePaymentProjectionMatches: true,
+    databaseProblemProjectionMatches: true,
+    publicArtifactsUnchanged: {
+      '/data/manifest.json': true,
+      '/version.json': true,
+    },
+  };
+}
+
+describe('P5-03I bounded live journey result', () => {
+  it('completes only when both report families and public artifacts pass', () => {
+    const output = buildP503iLiveJourneyResult(completeChecks());
+    expect(output.succeeded).toBe(true);
+    expect(output.result.status).toBe('complete');
+    expect(JSON.stringify(output.result)).not.toContain('statusSecret');
+    expect(JSON.stringify(output.result)).not.toContain('challengeToken');
+    expect(JSON.stringify(output.result)).not.toContain('DATABASE_URL');
+  });
+
+  it('fails closed when either database projection or replay check fails', () => {
+    const databaseFailure = completeChecks();
+    databaseFailure.databaseProblemProjectionMatches = false;
+    expect(buildP503iLiveJourneyResult(databaseFailure).succeeded).toBe(false);
+
+    const replayFailure = completeChecks();
+    replayFailure.paymentReplayStatusSecretMatches = false;
+    const output = buildP503iLiveJourneyResult(replayFailure);
+    expect(output.succeeded).toBe(false);
+    expect(output.result.status).toBe('failed');
+  });
+});

--- a/tests/p5-03i-live-journey-result.test.mjs
+++ b/tests/p5-03i-live-journey-result.test.mjs
@@ -29,14 +29,25 @@ function completeChecks() {
   };
 }
 
+function collectKeys(value, keys = new Set()) {
+  if (value === null || typeof value !== 'object') return keys;
+  for (const [key, child] of Object.entries(value)) {
+    keys.add(key);
+    collectKeys(child, keys);
+  }
+  return keys;
+}
+
 describe('P5-03I bounded live journey result', () => {
   it('completes only when both report families and public artifacts pass', () => {
     const output = buildP503iLiveJourneyResult(completeChecks());
     expect(output.succeeded).toBe(true);
     expect(output.result.status).toBe('complete');
-    expect(JSON.stringify(output.result)).not.toContain('statusSecret');
-    expect(JSON.stringify(output.result)).not.toContain('challengeToken');
-    expect(JSON.stringify(output.result)).not.toContain('DATABASE_URL');
+    const keys = collectKeys(output.result);
+    expect(keys.has('statusSecret')).toBe(false);
+    expect(keys.has('challengeToken')).toBe(false);
+    expect(keys.has('databaseUrl')).toBe(false);
+    expect(keys.has('privatePayload')).toBe(false);
   });
 
   it('fails closed when either database projection or replay check fails', () => {


### PR DESCRIPTION
## Implementation item

P5-03I — Configured review and integration audit

## Purpose

Deploy and audit both public report families against the fixed Cloudflare Pages review environment and configured Neon Submission database.

## Changes

- advance project status to P5-03I;
- add synthetic payment and problem report fixtures;
- add a bounded live probe for `/payment-report`, `/report`, `/api/reports/config`, and `POST /api/reports`;
- prove payment first acceptance, exact replay, and changed-content conflict;
- prove problem first acceptance and exact replay while remaining within the configured five-request review rate limit;
- verify durable payment/problem normalized projections directly in the configured Submission database;
- verify public manifest/version artifacts remain unchanged;
- retain only bounded booleans and HTTP statuses, never challenge tokens, status secrets, private payloads, contact data, raw edge identity, database values, or derived keys;
- publish a fixed-review receipt to the `staging-review` status branch;
- add fail-closed result tests.

## Trigger

After green merge, the squash commit will include `[run-p5-03i-audit]`. The existing staging review deploy runs on main, then the new audit runs only after a successful matching deployment.

## Boundaries

No production submission, automatic Evidence decision, Claim mutation, canonical correction, export, publication, or launch-readiness claim.