### PR TITLE
P5-04A: harden business claim privacy and correction semantics

### DIFF
--- a/docs/P5_04A_BUSINESS_CLAIM_CONTRACT_AND_NORMALIZATION.md
+++ b/docs/P5_04A_BUSINESS_CLAIM_CONTRACT_AND_NORMALIZATION.md
@@ -90,7 +90,7 @@ The contract can carry:
 - explicit empty arrays for clearing amenities or social links;
 - structured payment proposals using the existing Asset, Network, route, method, processor, How-to-pay, and restriction contract.
 
-Optional correction fields distinguish “not proposed” from a deliberate nullable or empty-list correction. Coordinate corrections require a complete latitude/longitude pair.
+Each profile correction includes a bounded `changedFields` list. Fields outside that list must contain null placeholders, so hidden undeclared values cannot enter review. A listed nullable field may use null to request clearing; a listed list field may use an empty array. Country code and Entity name cannot be cleared. Coordinate corrections require both latitude and longitude.
 
 The contract deliberately excludes status, visibility, verification result, ownership status, canonical version, export, and publication fields.
 

--- a/docs/P5_04A_BUSINESS_CLAIM_CONTRACT_AND_NORMALIZATION.md
+++ b/docs/P5_04A_BUSINESS_CLAIM_CONTRACT_AND_NORMALIZATION.md
@@ -61,7 +61,7 @@ assisted_verification
 
 Method-specific minimums are enforced:
 
-- official-domain email requires a declared domain and an email on that domain or subdomain;
+- official-domain email requires a declared domain and protected follow-up contact on that domain or a subdomain;
 - website code requires an official HTTPS website URL;
 - DNS TXT requires an official domain;
 - official social verification requires an official social URL;
@@ -71,14 +71,15 @@ P5-04A records the requested method only. It does not issue a code, query DNS, a
 
 ## Private values
 
+Official-domain email is not stored inside `submission_payloads.original_payload`. It must use the common protected contact field so P5-04B can persist it through the existing encrypted `submission_contacts` boundary.
+
 The original private payload may contain:
 
-- official contact email;
 - protected proof URL;
 - assisted verifier reference;
 - authority statement.
 
-The review-safe normalized projection never contains the contact email or proof URL. It exposes only bounded review signals such as method, declared public domain/URLs, and presence booleans.
+The review-safe normalized projection never contains the contact email, proof URL, or assisted verifier reference value. It exposes only bounded review signals such as method, declared public domain or URLs, and presence booleans.
 
 ## Proposed changes
 
@@ -86,7 +87,10 @@ The contract can carry:
 
 - bounded Entity profile corrections;
 - bounded Location practical-profile corrections;
+- explicit empty arrays for clearing amenities or social links;
 - structured payment proposals using the existing Asset, Network, route, method, processor, How-to-pay, and restriction contract.
+
+Optional correction fields distinguish “not proposed” from a deliberate nullable or empty-list correction. Coordinate corrections require a complete latitude/longitude pair.
 
 The contract deliberately excludes status, visibility, verification result, ownership status, canonical version, export, and publication fields.
 
@@ -111,4 +115,4 @@ public record changed
 
 ## Next
 
-P5-04B will integrate the strict Claim parser and review-safe normalized projection with idempotent private Submission persistence. Verification state, adapters, protected reviewer entry, relationship decisions, expiration/revocation, public route, and configured audit remain separate later slices.
+P5-04B will integrate the strict Claim parser and review-safe normalized projection with idempotent private Submission persistence and encrypted contact handling. Verification state, adapters, protected reviewer entry, relationship decisions, expiration/revocation, public route, and configured audit remain separate later slices.

--- a/scripts/check-business-claim-contract.ts
+++ b/scripts/check-business-claim-contract.ts
@@ -9,16 +9,18 @@ const claim = {
   targetType: 'entity',
   targetId: '10000000-0000-4000-8000-000000000001',
   relationship: 'owner_or_authorized_representative',
-  contact: null,
+  contact: {
+    email: 'owner@merchant.example',
+    contactAllowed: true,
+  },
   evidenceLinks: [],
   originalPayload: {
     schemaVersion: 'business-claim-v1',
     claimantRole: 'authorized_representative',
     requestedScopes: ['representative_relationship'],
     verification: {
-      method: 'dns_txt',
+      method: 'official_domain_email',
       officialDomain: 'merchant.example',
-      officialContactEmail: null,
       officialWebsiteUrl: 'https://merchant.example',
       officialSocialUrl: null,
       assistedVerifierReference: null,
@@ -39,11 +41,15 @@ const claim = {
 
 businessClaimSubmissionIntakeSchema.parse(claim);
 const projection = normalizeBusinessClaimSubmissionIntake(claim);
-if (projection.verification.officialContactEmailPresent) {
-  throw new Error('Unexpected official contact email exposure state.');
+if (!projection.verification.protectedContactPresent) {
+  throw new Error('Expected protected claim contact presence signal.');
 }
-if ('privateProofUrl' in projection.verification) {
-  throw new Error('Private ownership proof must not enter the review-safe projection.');
+if ('email' in projection.verification || 'privateProofUrl' in projection.verification) {
+  throw new Error('Private ownership contact or proof must not enter the review-safe projection.');
+}
+const serialized = JSON.stringify(projection);
+if (serialized.includes('owner@merchant.example')) {
+  throw new Error('Protected contact value leaked into the review-safe projection.');
 }
 
 console.log('P5-04A business claim contract and review-safe projection are valid.');

--- a/src/submissions/business-claim-contract.ts
+++ b/src/submissions/business-claim-contract.ts
@@ -71,7 +71,6 @@ export const businessClaimVerificationRequestSchema = z
   .object({
     method: ownershipVerificationMethodSchema,
     officialDomain: officialDomainSchema.nullable(),
-    officialContactEmail: z.email().max(320).nullable(),
     officialWebsiteUrl: httpsUrlSchema.nullable(),
     officialSocialUrl: httpsUrlSchema.nullable(),
     assistedVerifierReference: boundedText(200).nullable(),
@@ -79,22 +78,12 @@ export const businessClaimVerificationRequestSchema = z
   })
   .strict()
   .superRefine((request, context) => {
-    if (request.method === 'official_domain_email') {
-      if (request.officialDomain === null || request.officialContactEmail === null) {
-        context.addIssue({
-          code: 'custom',
-          message: 'Official-domain email verification requires a domain and contact email.',
-        });
-      } else {
-        const domain = emailDomain(request.officialContactEmail);
-        if (domain !== request.officialDomain && !domain.endsWith(`.${request.officialDomain}`)) {
-          context.addIssue({
-            code: 'custom',
-            path: ['officialContactEmail'],
-            message: 'The official contact email must belong to the declared official domain.',
-          });
-        }
-      }
+    if (request.method === 'official_domain_email' && request.officialDomain === null) {
+      context.addIssue({
+        code: 'custom',
+        path: ['officialDomain'],
+        message: 'Official-domain email verification requires an official domain.',
+      });
     }
     if (request.method === 'website_code' && request.officialWebsiteUrl === null) {
       context.addIssue({
@@ -128,35 +117,36 @@ export const businessClaimVerificationRequestSchema = z
 
 export const businessClaimEntityCorrectionSchema = z
   .object({
-    name: boundedText(160).nullable(),
-    legalName: boundedText(200).nullable(),
-    websiteUrl: httpsUrlSchema.nullable(),
-    countryCode: countryCodeSchema.nullable(),
+    name: boundedText(160).optional(),
+    legalName: boundedText(200).nullable().optional(),
+    websiteUrl: httpsUrlSchema.nullable().optional(),
+    countryCode: countryCodeSchema.nullable().optional(),
   })
   .strict()
   .refine(
-    (correction) => Object.values(correction).some((value) => value !== null),
+    (correction) => Object.keys(correction).length > 0,
     'Entity corrections require at least one proposed field.',
   );
 
 export const businessClaimLocationCorrectionSchema = z
   .object({
-    name: boundedText(160).nullable(),
-    addressLine: boundedText(500).nullable(),
-    locality: boundedText(120).nullable(),
-    region: boundedText(120).nullable(),
-    postalCode: boundedText(32).nullable(),
-    countryCode: countryCodeSchema.nullable(),
-    latitude: z.number().finite().min(-90).max(90).nullable(),
-    longitude: z.number().finite().min(-180).max(180).nullable(),
-    websiteUrl: httpsUrlSchema.nullable(),
-    phone: boundedText(64).nullable(),
-    description: boundedText(5_000).nullable(),
-    openingHours: boundedText(2_000).nullable(),
+    name: boundedText(160).nullable().optional(),
+    addressLine: boundedText(500).nullable().optional(),
+    locality: boundedText(120).nullable().optional(),
+    region: boundedText(120).nullable().optional(),
+    postalCode: boundedText(32).nullable().optional(),
+    countryCode: countryCodeSchema.optional(),
+    latitude: z.number().finite().min(-90).max(90).optional(),
+    longitude: z.number().finite().min(-180).max(180).optional(),
+    websiteUrl: httpsUrlSchema.nullable().optional(),
+    phone: boundedText(64).nullable().optional(),
+    description: boundedText(5_000).nullable().optional(),
+    openingHours: boundedText(2_000).nullable().optional(),
     amenities: z
       .array(boundedText(80))
       .max(100)
-      .transform((values) => [...new Set(values)]),
+      .transform((values) => [...new Set(values)])
+      .optional(),
     socialLinks: z
       .array(canonicalLocationSocialLinkSchema)
       .max(30)
@@ -173,35 +163,20 @@ export const businessClaimLocationCorrectionSchema = z
           }
           seen.add(key);
         });
-      }),
+      })
+      .optional(),
   })
   .strict()
   .superRefine((correction, context) => {
-    const scalarValues = [
-      correction.name,
-      correction.addressLine,
-      correction.locality,
-      correction.region,
-      correction.postalCode,
-      correction.countryCode,
-      correction.latitude,
-      correction.longitude,
-      correction.websiteUrl,
-      correction.phone,
-      correction.description,
-      correction.openingHours,
-    ];
-    if (
-      scalarValues.every((value) => value === null) &&
-      correction.amenities.length === 0 &&
-      correction.socialLinks.length === 0
-    ) {
+    if (Object.keys(correction).length === 0) {
       context.addIssue({
         code: 'custom',
         message: 'Location corrections require at least one proposed field.',
       });
     }
-    if ((correction.latitude === null) !== (correction.longitude === null)) {
+    const hasLatitude = correction.latitude !== undefined;
+    const hasLongitude = correction.longitude !== undefined;
+    if (hasLatitude !== hasLongitude) {
       context.addIssue({
         code: 'custom',
         path: ['latitude'],
@@ -239,7 +214,27 @@ export const businessClaimSubmissionIntakeSchema = commonSubmissionIntakeSchema
   })
   .strict()
   .superRefine((intake, context) => {
-    const { requestedScopes, proposedChanges } = intake.originalPayload;
+    const { requestedScopes, proposedChanges, verification } = intake.originalPayload;
+
+    if (verification.method === 'official_domain_email') {
+      if (intake.contact === null || !intake.contact.contactAllowed) {
+        context.addIssue({
+          code: 'custom',
+          path: ['contact'],
+          message: 'Official-domain email verification requires protected follow-up contact.',
+        });
+      } else if (verification.officialDomain !== null) {
+        const domain = emailDomain(intake.contact.email);
+        if (domain !== verification.officialDomain && !domain.endsWith(`.${verification.officialDomain}`)) {
+          context.addIssue({
+            code: 'custom',
+            path: ['contact', 'email'],
+            message: 'The protected contact email must belong to the declared official domain.',
+          });
+        }
+      }
+    }
+
     if (intake.targetType === 'entity') {
       if (requestedScopes.includes('location_profile') || proposedChanges.location !== null) {
         context.addIssue({
@@ -292,7 +287,7 @@ export interface BusinessClaimReviewProjection {
   verification: Readonly<{
     method: z.infer<typeof ownershipVerificationMethodSchema>;
     officialDomain: string | null;
-    officialContactEmailPresent: boolean;
+    protectedContactPresent: boolean;
     officialWebsiteUrl: string | null;
     officialSocialUrl: string | null;
     assistedVerifierReferencePresent: boolean;
@@ -317,7 +312,7 @@ export function normalizeParsedBusinessClaimSubmissionIntake(
     verification: {
       method: payload.verification.method,
       officialDomain: payload.verification.officialDomain,
-      officialContactEmailPresent: payload.verification.officialContactEmail !== null,
+      protectedContactPresent: intake.contact !== null,
       officialWebsiteUrl: payload.verification.officialWebsiteUrl,
       officialSocialUrl: payload.verification.officialSocialUrl,
       assistedVerifierReferencePresent: payload.verification.assistedVerifierReference !== null,

--- a/src/submissions/business-claim-contract.ts
+++ b/src/submissions/business-claim-contract.ts
@@ -232,10 +232,7 @@ export const businessClaimLocationCorrectionSchema = z
       }
     }
 
-    if (
-      correction.changedFields.includes('countryCode') &&
-      correction.countryCode === null
-    ) {
+    if (correction.changedFields.includes('countryCode') && correction.countryCode === null) {
       context.addIssue({
         code: 'custom',
         path: ['countryCode'],
@@ -252,10 +249,7 @@ export const businessClaimLocationCorrectionSchema = z
         message: 'Latitude and longitude corrections must be requested together.',
       });
     }
-    if (
-      changesLatitude &&
-      (correction.latitude === null || correction.longitude === null)
-    ) {
+    if (changesLatitude && (correction.latitude === null || correction.longitude === null)) {
       context.addIssue({
         code: 'custom',
         path: ['latitude'],

--- a/src/submissions/business-claim-contract.ts
+++ b/src/submissions/business-claim-contract.ts
@@ -115,38 +115,90 @@ export const businessClaimVerificationRequestSchema = z
     }
   });
 
+export const businessClaimEntityFieldValues = [
+  'name',
+  'legalName',
+  'websiteUrl',
+  'countryCode',
+] as const;
+export const businessClaimEntityFieldSchema = z.enum(businessClaimEntityFieldValues);
+
 export const businessClaimEntityCorrectionSchema = z
   .object({
-    name: boundedText(160).optional(),
-    legalName: boundedText(200).nullable().optional(),
-    websiteUrl: httpsUrlSchema.nullable().optional(),
-    countryCode: countryCodeSchema.nullable().optional(),
+    changedFields: z
+      .array(businessClaimEntityFieldSchema)
+      .min(1)
+      .max(businessClaimEntityFieldValues.length)
+      .transform((values) => [...new Set(values)]),
+    name: boundedText(160).nullable(),
+    legalName: boundedText(200).nullable(),
+    websiteUrl: httpsUrlSchema.nullable(),
+    countryCode: countryCodeSchema.nullable(),
   })
   .strict()
-  .refine(
-    (correction) => Object.keys(correction).length > 0,
-    'Entity corrections require at least one proposed field.',
-  );
+  .superRefine((correction, context) => {
+    for (const field of businessClaimEntityFieldValues) {
+      const changed = correction.changedFields.includes(field);
+      const value = correction[field];
+      if (!changed && value !== null) {
+        context.addIssue({
+          code: 'custom',
+          path: [field],
+          message: 'Unchanged Entity fields must use null placeholders.',
+        });
+      }
+    }
+    if (correction.changedFields.includes('name') && correction.name === null) {
+      context.addIssue({
+        code: 'custom',
+        path: ['name'],
+        message: 'Entity name cannot be cleared.',
+      });
+    }
+  });
+
+export const businessClaimLocationFieldValues = [
+  'name',
+  'addressLine',
+  'locality',
+  'region',
+  'postalCode',
+  'countryCode',
+  'latitude',
+  'longitude',
+  'websiteUrl',
+  'phone',
+  'description',
+  'openingHours',
+  'amenities',
+  'socialLinks',
+] as const;
+export const businessClaimLocationFieldSchema = z.enum(businessClaimLocationFieldValues);
 
 export const businessClaimLocationCorrectionSchema = z
   .object({
-    name: boundedText(160).nullable().optional(),
-    addressLine: boundedText(500).nullable().optional(),
-    locality: boundedText(120).nullable().optional(),
-    region: boundedText(120).nullable().optional(),
-    postalCode: boundedText(32).nullable().optional(),
-    countryCode: countryCodeSchema.optional(),
-    latitude: z.number().finite().min(-90).max(90).optional(),
-    longitude: z.number().finite().min(-180).max(180).optional(),
-    websiteUrl: httpsUrlSchema.nullable().optional(),
-    phone: boundedText(64).nullable().optional(),
-    description: boundedText(5_000).nullable().optional(),
-    openingHours: boundedText(2_000).nullable().optional(),
+    changedFields: z
+      .array(businessClaimLocationFieldSchema)
+      .min(1)
+      .max(businessClaimLocationFieldValues.length)
+      .transform((values) => [...new Set(values)]),
+    name: boundedText(160).nullable(),
+    addressLine: boundedText(500).nullable(),
+    locality: boundedText(120).nullable(),
+    region: boundedText(120).nullable(),
+    postalCode: boundedText(32).nullable(),
+    countryCode: countryCodeSchema.nullable(),
+    latitude: z.number().finite().min(-90).max(90).nullable(),
+    longitude: z.number().finite().min(-180).max(180).nullable(),
+    websiteUrl: httpsUrlSchema.nullable(),
+    phone: boundedText(64).nullable(),
+    description: boundedText(5_000).nullable(),
+    openingHours: boundedText(2_000).nullable(),
     amenities: z
       .array(boundedText(80))
       .max(100)
       .transform((values) => [...new Set(values)])
-      .optional(),
+      .nullable(),
     socialLinks: z
       .array(canonicalLocationSocialLinkSchema)
       .max(30)
@@ -164,23 +216,50 @@ export const businessClaimLocationCorrectionSchema = z
           seen.add(key);
         });
       })
-      .optional(),
+      .nullable(),
   })
   .strict()
   .superRefine((correction, context) => {
-    if (Object.keys(correction).length === 0) {
+    for (const field of businessClaimLocationFieldValues) {
+      const changed = correction.changedFields.includes(field);
+      const value = correction[field];
+      if (!changed && value !== null) {
+        context.addIssue({
+          code: 'custom',
+          path: [field],
+          message: 'Unchanged Location fields must use null placeholders.',
+        });
+      }
+    }
+
+    if (
+      correction.changedFields.includes('countryCode') &&
+      correction.countryCode === null
+    ) {
       context.addIssue({
         code: 'custom',
-        message: 'Location corrections require at least one proposed field.',
+        path: ['countryCode'],
+        message: 'Location country code cannot be cleared.',
       });
     }
-    const hasLatitude = correction.latitude !== undefined;
-    const hasLongitude = correction.longitude !== undefined;
-    if (hasLatitude !== hasLongitude) {
+
+    const changesLatitude = correction.changedFields.includes('latitude');
+    const changesLongitude = correction.changedFields.includes('longitude');
+    if (changesLatitude !== changesLongitude) {
+      context.addIssue({
+        code: 'custom',
+        path: ['changedFields'],
+        message: 'Latitude and longitude corrections must be requested together.',
+      });
+    }
+    if (
+      changesLatitude &&
+      (correction.latitude === null || correction.longitude === null)
+    ) {
       context.addIssue({
         code: 'custom',
         path: ['latitude'],
-        message: 'Latitude and longitude corrections must be supplied together.',
+        message: 'Latitude and longitude corrections require a complete coordinate pair.',
       });
     }
   });
@@ -225,7 +304,10 @@ export const businessClaimSubmissionIntakeSchema = commonSubmissionIntakeSchema
         });
       } else if (verification.officialDomain !== null) {
         const domain = emailDomain(intake.contact.email);
-        if (domain !== verification.officialDomain && !domain.endsWith(`.${verification.officialDomain}`)) {
+        if (
+          domain !== verification.officialDomain &&
+          !domain.endsWith(`.${verification.officialDomain}`)
+        ) {
           context.addIssue({
             code: 'custom',
             path: ['contact', 'email'],

--- a/tests/business-claim-contract.test.ts
+++ b/tests/business-claim-contract.test.ts
@@ -13,7 +13,10 @@ function entityClaim(): any {
     targetType: 'entity',
     targetId,
     relationship: 'owner_or_authorized_representative',
-    contact: null,
+    contact: {
+      email: 'owner@merchant.example',
+      contactAllowed: true,
+    },
     evidenceLinks: [],
     originalPayload: {
       schemaVersion: 'business-claim-v1',
@@ -22,7 +25,6 @@ function entityClaim(): any {
       verification: {
         method: 'official_domain_email',
         officialDomain: 'merchant.example',
-        officialContactEmail: 'owner@merchant.example',
         officialWebsiteUrl: 'https://merchant.example',
         officialSocialUrl: null,
         assistedVerifierReference: null,
@@ -31,7 +33,6 @@ function entityClaim(): any {
       proposedChanges: {
         entity: {
           name: 'Merchant Example',
-          legalName: null,
           websiteUrl: 'https://merchant.example',
           countryCode: 'JP',
         },
@@ -72,7 +73,7 @@ describe('P5-04A business claim contract', () => {
       verification: {
         method: 'official_domain_email',
         officialDomain: 'merchant.example',
-        officialContactEmailPresent: true,
+        protectedContactPresent: true,
         officialWebsiteUrl: 'https://merchant.example',
         officialSocialUrl: null,
         assistedVerifierReferencePresent: false,
@@ -85,10 +86,18 @@ describe('P5-04A business claim contract', () => {
     expect(serialized).not.toContain('private-owner-proof');
   });
 
-  it('requires official email to belong to the declared domain', () => {
-    const input = structuredClone(entityClaim());
-    input.originalPayload.verification.officialContactEmail = 'owner@unrelated.example';
-    expect(() => businessClaimSubmissionIntakeSchema.parse(input)).toThrow();
+  it('requires official email to use protected contact storage and match the declared domain', () => {
+    const missingContact = structuredClone(entityClaim());
+    missingContact.contact = null;
+    expect(() => businessClaimSubmissionIntakeSchema.parse(missingContact)).toThrow();
+
+    const noFollowUp = structuredClone(entityClaim());
+    noFollowUp.contact.contactAllowed = false;
+    expect(() => businessClaimSubmissionIntakeSchema.parse(noFollowUp)).toThrow();
+
+    const wrongDomain = structuredClone(entityClaim());
+    wrongDomain.contact.email = 'owner@unrelated.example';
+    expect(() => businessClaimSubmissionIntakeSchema.parse(wrongDomain)).toThrow();
   });
 
   it('requires method-specific verification material', () => {
@@ -112,43 +121,22 @@ describe('P5-04A business claim contract', () => {
     const input = structuredClone(entityClaim());
     input.originalPayload.requestedScopes.push('location_profile');
     input.originalPayload.proposedChanges.location = {
-      name: 'Branch',
       addressLine: '1 Example Street',
       locality: 'Tokyo',
-      region: null,
-      postalCode: null,
       countryCode: 'JP',
-      latitude: null,
-      longitude: null,
-      websiteUrl: null,
-      phone: null,
-      description: null,
-      openingHours: null,
-      amenities: [],
-      socialLinks: [],
     };
     expect(() => businessClaimSubmissionIntakeSchema.parse(input)).toThrow();
   });
 
-  it('accepts a location claim with profile scope but rejects entity profile changes', () => {
+  it('accepts a location claim with profile scope and explicit clear-list proposals', () => {
     const input = structuredClone(entityClaim());
     input.targetType = 'location';
     input.originalPayload.requestedScopes = ['representative_relationship', 'location_profile'];
     input.originalPayload.proposedChanges.entity = null;
     input.originalPayload.proposedChanges.paymentProposals = null;
     input.originalPayload.proposedChanges.location = {
-      name: null,
       addressLine: '2 Corrected Street',
-      locality: 'Tokyo',
-      region: null,
-      postalCode: null,
       countryCode: 'JP',
-      latitude: null,
-      longitude: null,
-      websiteUrl: null,
-      phone: null,
-      description: null,
-      openingHours: null,
       amenities: [],
       socialLinks: [],
     };
@@ -157,10 +145,17 @@ describe('P5-04A business claim contract', () => {
     input.originalPayload.requestedScopes.push('entity_profile');
     input.originalPayload.proposedChanges.entity = {
       name: 'Wrongly scoped entity change',
-      legalName: null,
-      websiteUrl: null,
-      countryCode: null,
     };
+    expect(() => businessClaimSubmissionIntakeSchema.parse(input)).toThrow();
+  });
+
+  it('requires coordinate corrections as a complete pair', () => {
+    const input = structuredClone(entityClaim());
+    input.targetType = 'location';
+    input.originalPayload.requestedScopes = ['representative_relationship', 'location_profile'];
+    input.originalPayload.proposedChanges.entity = null;
+    input.originalPayload.proposedChanges.paymentProposals = null;
+    input.originalPayload.proposedChanges.location = { latitude: 35.6812 };
     expect(() => businessClaimSubmissionIntakeSchema.parse(input)).toThrow();
   });
 

--- a/tests/business-claim-contract.test.ts
+++ b/tests/business-claim-contract.test.ts
@@ -6,6 +6,38 @@ import {
 
 const targetId = '10000000-0000-4000-8000-000000000001';
 
+function entityCorrection(changedFields: string[], values: Record<string, unknown> = {}) {
+  return {
+    changedFields,
+    name: null,
+    legalName: null,
+    websiteUrl: null,
+    countryCode: null,
+    ...values,
+  };
+}
+
+function locationCorrection(changedFields: string[], values: Record<string, unknown> = {}) {
+  return {
+    changedFields,
+    name: null,
+    addressLine: null,
+    locality: null,
+    region: null,
+    postalCode: null,
+    countryCode: null,
+    latitude: null,
+    longitude: null,
+    websiteUrl: null,
+    phone: null,
+    description: null,
+    openingHours: null,
+    amenities: null,
+    socialLinks: null,
+    ...values,
+  };
+}
+
 function entityClaim(): any {
   return {
     schemaVersion: 'submission-common-v1',
@@ -31,11 +63,11 @@ function entityClaim(): any {
         privateProofUrl: 'https://evidence.example/private-owner-proof',
       },
       proposedChanges: {
-        entity: {
+        entity: entityCorrection(['name', 'websiteUrl', 'countryCode'], {
           name: 'Merchant Example',
           websiteUrl: 'https://merchant.example',
           countryCode: 'JP',
-        },
+        }),
         location: null,
         paymentProposals: [
           {
@@ -120,11 +152,14 @@ describe('P5-04A business claim contract', () => {
   it('rejects location changes on an entity-targeted claim', () => {
     const input = structuredClone(entityClaim());
     input.originalPayload.requestedScopes.push('location_profile');
-    input.originalPayload.proposedChanges.location = {
-      addressLine: '1 Example Street',
-      locality: 'Tokyo',
-      countryCode: 'JP',
-    };
+    input.originalPayload.proposedChanges.location = locationCorrection(
+      ['addressLine', 'locality', 'countryCode'],
+      {
+        addressLine: '1 Example Street',
+        locality: 'Tokyo',
+        countryCode: 'JP',
+      },
+    );
     expect(() => businessClaimSubmissionIntakeSchema.parse(input)).toThrow();
   });
 
@@ -134,18 +169,21 @@ describe('P5-04A business claim contract', () => {
     input.originalPayload.requestedScopes = ['representative_relationship', 'location_profile'];
     input.originalPayload.proposedChanges.entity = null;
     input.originalPayload.proposedChanges.paymentProposals = null;
-    input.originalPayload.proposedChanges.location = {
-      addressLine: '2 Corrected Street',
-      countryCode: 'JP',
-      amenities: [],
-      socialLinks: [],
-    };
+    input.originalPayload.proposedChanges.location = locationCorrection(
+      ['addressLine', 'countryCode', 'amenities', 'socialLinks'],
+      {
+        addressLine: '2 Corrected Street',
+        countryCode: 'JP',
+        amenities: [],
+        socialLinks: [],
+      },
+    );
     expect(businessClaimSubmissionIntakeSchema.parse(input).targetType).toBe('location');
 
     input.originalPayload.requestedScopes.push('entity_profile');
-    input.originalPayload.proposedChanges.entity = {
+    input.originalPayload.proposedChanges.entity = entityCorrection(['name'], {
       name: 'Wrongly scoped entity change',
-    };
+    });
     expect(() => businessClaimSubmissionIntakeSchema.parse(input)).toThrow();
   });
 
@@ -155,7 +193,15 @@ describe('P5-04A business claim contract', () => {
     input.originalPayload.requestedScopes = ['representative_relationship', 'location_profile'];
     input.originalPayload.proposedChanges.entity = null;
     input.originalPayload.proposedChanges.paymentProposals = null;
-    input.originalPayload.proposedChanges.location = { latitude: 35.6812 };
+    input.originalPayload.proposedChanges.location = locationCorrection(['latitude'], {
+      latitude: 35.6812,
+    });
+    expect(() => businessClaimSubmissionIntakeSchema.parse(input)).toThrow();
+  });
+
+  it('rejects hidden values outside changedFields', () => {
+    const input = entityClaim();
+    input.originalPayload.proposedChanges.entity.legalName = 'Hidden legal name';
     expect(() => businessClaimSubmissionIntakeSchema.parse(input)).toThrow();
   });
 


### PR DESCRIPTION
## Implementation item

P5-04A — Business claim contract and review-safe normalization hardening

## Purpose

Correct the initial P5-04A contract before private persistence work begins.

## Changes

- move official-domain email out of plaintext `original_payload` and require the existing protected/encrypted common contact boundary;
- require follow-up permission and declared-domain matching for official-domain email verification;
- keep contact email, ownership-proof URL, and assisted verifier reference values out of review-safe normalization;
- distinguish omitted correction fields from deliberate nullable or empty-list corrections;
- allow explicit clearing of amenities and social links;
- require latitude and longitude corrections as a complete pair;
- update focused runtime and unit coverage plus implementation documentation.

## Boundaries

This PR does not verify identity, approve a representative relationship, grant editing rights, accept Evidence, mutate canonical data, export data, or publish anything.

## Replaces

Replaces conflicted draft #205.