### PR TITLE
P5-05B: add private Photos intake and quarantine linkage

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -145,7 +145,7 @@ P4-18E closed the Phase 5 handoff gate while preserving unavailable configured-e
 | P5-02 | Suggest Place and Online Service | Completed through #156–#192 | P5-01 |
 | P5-03 | Payment and problem reports | In progress at P5-03G | P5-01, P5-02 target conventions |
 | P5-04 | Business and service claims | Planned | P5-01, practical-profile correction path |
-| P5-05 | Photo and Media submission intake | In progress at P5-05B | P5-01, P3-10 Media review boundary |
+| P5-05 | Photo and Media submission intake | In progress at P5-05C; P5-05B completed #217 | P5-01, P3-10 Media review boundary |
 | P5-06 | Review workflow extensions | Planned | P5-02 through P5-05 |
 | P5-07 | Canonical application transactions and retention | Planned | P5-06, P4-18B correction boundary |
 | P5-08 | MVP-B integration audit | Planned | P5-01 through P5-07 |

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -145,7 +145,7 @@ P4-18E closed the Phase 5 handoff gate while preserving unavailable configured-e
 | P5-02 | Suggest Place and Online Service | Completed through #156–#192 | P5-01 |
 | P5-03 | Payment and problem reports | In progress at P5-03G | P5-01, P5-02 target conventions |
 | P5-04 | Business and service claims | Planned | P5-01, practical-profile correction path |
-| P5-05 | Photo and Media submission intake | Planned | P5-01, P3-10 Media review boundary |
+| P5-05 | Photo and Media submission intake | In progress at P5-05B | P5-01, P3-10 Media review boundary |
 | P5-06 | Review workflow extensions | Planned | P5-02 through P5-05 |
 | P5-07 | Canonical application transactions and retention | Planned | P5-06, P4-18B correction boundary |
 | P5-08 | MVP-B integration audit | Planned | P5-01 through P5-07 |

--- a/docs/P5_05B_PHOTO_PRIVATE_INTAKE.md
+++ b/docs/P5_05B_PHOTO_PRIVATE_INTAKE.md
@@ -1,0 +1,49 @@
+# P5-05B private Photos intake and quarantine linkage
+
+**Implementation item:** P5-05B  
+**Status:** In progress  
+**Started:** 2026-07-15
+
+## Purpose
+
+Persist a valid P5-05A Photos Submission privately and consume its upload reservations in the same database transaction. This slice does not sign uploads, access R2, validate image bytes, create Media records, or publish content.
+
+## Existing reservation investigation
+
+The P5-05B baseline contained no quarantine upload reservation table, service, migration, or durable ownership/expiry state. Existing `media_assets` and `media_files` model reviewed Media metadata and storage files; they are not upload reservations and were not reused as if they were.
+
+P5-05B therefore adds the minimum replaceable private reservation model. A reservation contains only its opaque UUID, owning intake request UUID, explicit purpose, expiry, optional consuming Submission, and consumption timestamps. It contains no storage key, URL, filename, credential, or object payload. Upload signing and object validation remain later work.
+
+## Transaction boundary
+
+The shared Submission persistence batch now optionally receives opaque reservation UUIDs. For Photos intake, one transaction writes:
+
+- the Submission envelope and status-token hash;
+- original private payload and review-safe normalized projection;
+- protected contact ciphertext and hash when contact is present;
+- the private `submission_received` event;
+- conditional consumption of every requested reservation.
+
+The conditional update requires every reservation to exist, belong to the same intake request, have `public_gallery_candidate` purpose, remain strictly unexpired, and remain unconsumed. An affected-row guard aborts the transaction unless the complete requested set is consumed. PostgreSQL row locking and the conditional update prevent concurrent reassignment.
+
+## Replay and conflicts
+
+The existing shared canonical fingerprint and deterministic status-secret provider remain authoritative. An identical request UUID and body returns the original public reference, timestamp, and deterministically reproduced status secret without another write or consume. Reusing the UUID with changed content returns the existing generalized idempotency conflict and does not mutate prior state.
+
+Reservation absence, ownership mismatch, purpose mismatch, expiry, prior consumption, or concurrent loss produces a generalized private persistence conflict. The response does not identify which private reservation property failed.
+
+## Privacy boundary
+
+Status-secret plaintext is returned only on accepted intake or deterministic replay; only its verifier hash is stored. Contact plaintext passes through the shared encryption/hash boundary. Review projection and errors contain no contact plaintext, storage location, signed URL, filename, EXIF, GPS, wallet, receipt, ownership secret, object URL, encryption material, or raw request body.
+
+## Explicit non-effects
+
+P5-05B does not add R2 signing or access, binary upload, MIME-byte inspection, image decoding, EXIF processing, derivative generation, Media Asset or Media File creation, approval, gallery ordering, canonical mutation, export, publication, or deployment.
+
+## Validation
+
+Focused tests cover commit, deterministic replay, changed-content conflict, protected contact and status-secret leakage, ownership, expiry, purpose, prior-consumption rollback, and competing consumption. The schema check executes the exported reservation schema and Photos private-intake service. Migration and full repository checks are recorded before completion.
+
+## Next bounded item
+
+P5-05C is the next bounded Photo and Media intake item after P5-05B is merged. Its exact scope remains controlled by the Phase 5 implementation sequence and must not be started as part of this change.

--- a/docs/P5_05B_PHOTO_PRIVATE_INTAKE.md
+++ b/docs/P5_05B_PHOTO_PRIVATE_INTAKE.md
@@ -1,8 +1,9 @@
 # P5-05B private Photos intake and quarantine linkage
 
 **Implementation item:** P5-05B  
-**Status:** In progress  
+**Status:** Completed through #217
 **Started:** 2026-07-15
+**Completed:** 2026-07-15
 
 ## Purpose
 
@@ -40,9 +41,11 @@ Status-secret plaintext is returned only on accepted intake or deterministic rep
 
 P5-05B does not add R2 signing or access, binary upload, MIME-byte inspection, image decoding, EXIF processing, derivative generation, Media Asset or Media File creation, approval, gallery ordering, canonical mutation, export, publication, or deployment.
 
-## Validation
+## Completion evidence
 
-Focused tests cover commit, deterministic replay, changed-content conflict, protected contact and status-secret leakage, ownership, expiry, purpose, prior-consumption rollback, and competing consumption. The schema check executes the exported reservation schema and Photos private-intake service. Migration and full repository checks are recorded before completion.
+Pull request #217 adds the private Photos intake, minimum reservation model, migration 0024, atomic conditional consumption, shared contact and status-secret handling, executable schema validation, and focused commit, replay, changed-content conflict, ownership, expiry, purpose, prior-consumption, concurrency, rollback, and leakage tests.
+
+The final implementation validation passed `npm run quality` with a sandbox-safe Wrangler log path. This covered format, lint, Astro type checking, executable schemas, migration drift, 216 test files and 1,064 tests, build, accessibility, and staging validation. GitHub Actions results for the final documentation head are recorded on #217.
 
 ## Next bounded item
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # CryptoPayMap project status
 
-**Last verified:** 2026-07-14
+**Last verified:** 2026-07-15
 
 ## Current phase
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-05B — Idempotent private Photos intake and quarantine reservation linkage
+P5-05C — Next bounded Photo and Media intake slice
 
 ## Current repository state
 
@@ -29,7 +29,8 @@ P5-05B — Idempotent private Photos intake and quarantine reservation linkage
 - P5-04H3 protected reviewer workspace/API, one-time application guard, and integration audit completed in #215 at main commit `5a8d6a1d40db415931a11941e2a23869157eacfd`.
 - P5-04 Business and service claims are repository-complete.
 - P5-05A Photo and Media contracts and review-safe normalization completed through #216.
-- P5-05B idempotent private Photos intake and quarantine reservation linkage are next.
+- P5-05B idempotent private Photos intake and quarantine reservation linkage completed in #217.
+- P5-05C is next; its exact bounded scope must be established from the remaining P5-05 contract before implementation begins.
 
 ## P5-05A completion result
 
@@ -48,9 +49,9 @@ P5-05A provides:
 - rejection of storage keys, signed URLs, original filenames, EXIF, GPS, wallet, receipt, status-secret, and undeclared fields;
 - no R2 access, Media creation, canonical mutation, export, or publication.
 
-## P5-05B active scope
+## P5-05B completion result
 
-P5-05B will add:
+P5-05B provides:
 
 - idempotent private Photos Submission intake;
 - one durable Submission and normalized payload transaction;
@@ -86,14 +87,14 @@ P5-05B will add:
 2. P5-02 — Suggest Place and Online Service — Completed through #156–#192
 3. P5-03 — Payment and problem reports — Completed through #194–#202
 4. P5-04 — Business and service claims — Completed through #203–#215
-5. P5-05 — Photo and Media submission intake — In progress at P5-05B
+5. P5-05 — Photo and Media submission intake — In progress at P5-05C; P5-05B completed #217
 6. P5-06 — Review workflow extensions — Planned
 7. P5-07 — Canonical application transactions and retention — Planned
 8. P5-08 — MVP-B integration audit — Planned
 
 ## Next
 
-Implement and validate P5-05B private Photos intake, quarantine reservation ownership and expiry guards, atomic Submission linkage, deterministic replay/conflict handling, private status-token issuance, privacy/leakage tests, and executable schema validation.
+Define the next bounded P5-05C slice from the remaining upload authorization, private object validation, processing, and protected Media handoff contract. Do not treat P5-05B reservation intake as R2 signing, binary validation, Media creation, or publication.
 
 ## Blocked
 

--- a/drizzle/0024_kind_rawhide_kid.sql
+++ b/drizzle/0024_kind_rawhide_kid.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "public"."quarantine_upload_reservation_purpose" AS ENUM('evidence_image', 'owner_verification_proof', 'public_gallery_candidate');--> statement-breakpoint
+CREATE TABLE "quarantine_upload_reservations" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"intake_request_id" uuid NOT NULL,
+	"purpose" "quarantine_upload_reservation_purpose" NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_by_submission_id" uuid,
+	"consumed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "quarantine_upload_reservations_consumption_pair" CHECK (("quarantine_upload_reservations"."consumed_by_submission_id" is null and "quarantine_upload_reservations"."consumed_at" is null) or ("quarantine_upload_reservations"."consumed_by_submission_id" is not null and "quarantine_upload_reservations"."consumed_at" is not null)),
+	CONSTRAINT "quarantine_upload_reservations_time_order" CHECK ("quarantine_upload_reservations"."created_at" < "quarantine_upload_reservations"."expires_at" and ("quarantine_upload_reservations"."consumed_at" is null or "quarantine_upload_reservations"."created_at" <= "quarantine_upload_reservations"."consumed_at"))
+);
+--> statement-breakpoint
+ALTER TABLE "quarantine_upload_reservations" ADD CONSTRAINT "quarantine_upload_reservations_consumed_by_submission_id_submissions_id_fk" FOREIGN KEY ("consumed_by_submission_id") REFERENCES "public"."submissions"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "quarantine_upload_reservations_owner_expiry_idx" ON "quarantine_upload_reservations" USING btree ("intake_request_id","expires_at");--> statement-breakpoint
+CREATE INDEX "quarantine_upload_reservations_consumed_submission_idx" ON "quarantine_upload_reservations" USING btree ("consumed_by_submission_id");

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,8686 @@
+{
+  "id": "ecb41e04-08cd-4ac3-8625-db4bedf1b8cc",
+  "prevId": "7a46b5f6-2371-4543-b8ea-930446a19a54",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.acceptance_claims": {
+      "name": "acceptance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_scope": {
+          "name": "claim_scope",
+          "type": "claim_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_type": {
+          "name": "route_type",
+          "type": "route_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptance_scope": {
+          "name": "acceptance_scope",
+          "type": "acceptance_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_checkout'"
+        },
+        "claim_status": {
+          "name": "claim_status",
+          "type": "acceptance_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "claim_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hidden'"
+        },
+        "customer_pays_crypto": {
+          "name": "customer_pays_crypto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merchant_explicitly_accepts_crypto": {
+          "name": "merchant_explicitly_accepts_crypto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "processor_id": {
+          "name": "processor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "how_to_pay": {
+          "name": "how_to_pay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions_language": {
+          "name": "instructions_language",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "merchant_receives": {
+          "name": "merchant_receives",
+          "type": "merchant_receives",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_publicly_confirmed'"
+        },
+        "restrictions": {
+          "name": "restrictions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_confirmed_at": {
+          "name": "first_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "acceptance_claims_entity_idx": {
+          "name": "acceptance_claims_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acceptance_claims_location_idx": {
+          "name": "acceptance_claims_location_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acceptance_claims_processor_idx": {
+          "name": "acceptance_claims_processor_idx",
+          "columns": [
+            {
+              "expression": "processor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acceptance_claims_status_idx": {
+          "name": "acceptance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "claim_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acceptance_claims_review_idx": {
+          "name": "acceptance_claims_review_idx",
+          "columns": [
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acceptance_claims_entity_id_entities_id_fk": {
+          "name": "acceptance_claims_entity_id_entities_id_fk",
+          "tableFrom": "acceptance_claims",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acceptance_claims_location_id_locations_id_fk": {
+          "name": "acceptance_claims_location_id_locations_id_fk",
+          "tableFrom": "acceptance_claims",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "acceptance_claims_processor_id_entities_id_fk": {
+          "name": "acceptance_claims_processor_id_entities_id_fk",
+          "tableFrom": "acceptance_claims",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "processor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acceptance_claims_location_scope": {
+          "name": "acceptance_claims_location_scope",
+          "value": "(\"acceptance_claims\".\"claim_scope\" = 'location_specific' and \"acceptance_claims\".\"location_id\" is not null) or (\"acceptance_claims\".\"claim_scope\" <> 'location_specific' and \"acceptance_claims\".\"location_id\" is null)"
+        },
+        "acceptance_claims_processor_route": {
+          "name": "acceptance_claims_processor_route",
+          "value": "\"acceptance_claims\".\"route_type\" <> 'processor_checkout' or \"acceptance_claims\".\"processor_id\" is not null"
+        },
+        "acceptance_claims_ended_timestamp": {
+          "name": "acceptance_claims_ended_timestamp",
+          "value": "\"acceptance_claims\".\"claim_status\" <> 'ended' or \"acceptance_claims\".\"ended_at\" is not null"
+        },
+        "acceptance_claims_confirmed_requirements": {
+          "name": "acceptance_claims_confirmed_requirements",
+          "value": "\"acceptance_claims\".\"claim_status\" <> 'confirmed' or (\"acceptance_claims\".\"how_to_pay\" is not null and length(trim(\"acceptance_claims\".\"how_to_pay\")) > 0 and \"acceptance_claims\".\"first_confirmed_at\" is not null and \"acceptance_claims\".\"last_confirmed_at\" is not null)"
+        },
+        "acceptance_claims_public_status": {
+          "name": "acceptance_claims_public_status",
+          "value": "\"acceptance_claims\".\"visibility\" <> 'public' or \"acceptance_claims\".\"claim_status\" in ('confirmed', 'stale', 'ended')"
+        },
+        "acceptance_claims_public_payment_flags": {
+          "name": "acceptance_claims_public_payment_flags",
+          "value": "\"acceptance_claims\".\"visibility\" <> 'public' or (\"acceptance_claims\".\"customer_pays_crypto\" = true and \"acceptance_claims\".\"merchant_explicitly_accepts_crypto\" = true)"
+        },
+        "acceptance_claims_confirmation_order": {
+          "name": "acceptance_claims_confirmation_order",
+          "value": "\"acceptance_claims\".\"first_confirmed_at\" is null or \"acceptance_claims\".\"last_confirmed_at\" is null or \"acceptance_claims\".\"first_confirmed_at\" <= \"acceptance_claims\".\"last_confirmed_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.claim_regions": {
+      "name": "claim_regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_code": {
+          "name": "region_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inclusion_type": {
+          "name": "inclusion_type",
+          "type": "claim_region_inclusion",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_regions_identity_unique": {
+          "name": "claim_regions_identity_unique",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inclusion_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claim_regions_claim_idx": {
+          "name": "claim_regions_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_regions_claim_id_acceptance_claims_id_fk": {
+          "name": "claim_regions_claim_id_acceptance_claims_id_fk",
+          "tableFrom": "claim_regions",
+          "tableTo": "acceptance_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_stablecoin": {
+          "name": "is_stablecoin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_wrapped": {
+          "name": "is_wrapped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_decimals": {
+          "name": "default_decimals",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_slug_unique": {
+          "name": "assets_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_symbol_idx": {
+          "name": "assets_symbol_idx",
+          "columns": [
+            {
+              "expression": "symbol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_status_idx": {
+          "name": "assets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_duplicate_decisions": {
+      "name": "candidate_duplicate_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_group_id": {
+          "name": "duplicate_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "candidate_duplicate_decision_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_candidate_id": {
+          "name": "primary_candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_candidate_ids": {
+          "name": "member_candidate_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_member_states": {
+          "name": "previous_member_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "candidate_duplicate_decision_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_group_updated_at": {
+          "name": "expected_group_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_fingerprint": {
+          "name": "decision_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_duplicate_decisions_request_unique": {
+          "name": "candidate_duplicate_decisions_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_duplicate_decisions_group_unique": {
+          "name": "candidate_duplicate_decisions_group_unique",
+          "columns": [
+            {
+              "expression": "duplicate_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_duplicate_decisions_fingerprint_unique": {
+          "name": "candidate_duplicate_decisions_fingerprint_unique",
+          "columns": [
+            {
+              "expression": "decision_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_duplicate_decisions_actor_idx": {
+          "name": "candidate_duplicate_decisions_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_duplicate_decisions_primary_idx": {
+          "name": "candidate_duplicate_decisions_primary_idx",
+          "columns": [
+            {
+              "expression": "primary_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "candidate_duplicate_decisions_duplicate_group_id_candidate_duplicate_groups_id_fk": {
+          "name": "candidate_duplicate_decisions_duplicate_group_id_candidate_duplicate_groups_id_fk",
+          "tableFrom": "candidate_duplicate_decisions",
+          "tableTo": "candidate_duplicate_groups",
+          "columnsFrom": [
+            "duplicate_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "candidate_duplicate_decisions_primary_candidate_id_source_candidates_id_fk": {
+          "name": "candidate_duplicate_decisions_primary_candidate_id_source_candidates_id_fk",
+          "tableFrom": "candidate_duplicate_decisions",
+          "tableTo": "source_candidates",
+          "columnsFrom": [
+            "primary_candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "candidate_duplicate_decisions_actor_nonempty": {
+          "name": "candidate_duplicate_decisions_actor_nonempty",
+          "value": "length(trim(\"candidate_duplicate_decisions\".\"actor_id\")) > 0"
+        },
+        "candidate_duplicate_decisions_note_nonempty": {
+          "name": "candidate_duplicate_decisions_note_nonempty",
+          "value": "\"candidate_duplicate_decisions\".\"note\" is null or length(trim(\"candidate_duplicate_decisions\".\"note\")) > 0"
+        },
+        "candidate_duplicate_decisions_members_array": {
+          "name": "candidate_duplicate_decisions_members_array",
+          "value": "jsonb_typeof(\"candidate_duplicate_decisions\".\"member_candidate_ids\") = 'array' and jsonb_array_length(\"candidate_duplicate_decisions\".\"member_candidate_ids\") between 2 and 50"
+        },
+        "candidate_duplicate_decisions_previous_states_array": {
+          "name": "candidate_duplicate_decisions_previous_states_array",
+          "value": "jsonb_typeof(\"candidate_duplicate_decisions\".\"previous_member_states\") = 'array' and jsonb_array_length(\"candidate_duplicate_decisions\".\"previous_member_states\") = jsonb_array_length(\"candidate_duplicate_decisions\".\"member_candidate_ids\")"
+        },
+        "candidate_duplicate_decisions_action_shape": {
+          "name": "candidate_duplicate_decisions_action_shape",
+          "value": "(\"candidate_duplicate_decisions\".\"action\" = 'confirm_duplicate' and \"candidate_duplicate_decisions\".\"primary_candidate_id\" is not null) or (\"candidate_duplicate_decisions\".\"action\" = 'dismiss_signal' and \"candidate_duplicate_decisions\".\"primary_candidate_id\" is null)"
+        },
+        "candidate_duplicate_decisions_fingerprint_sha256": {
+          "name": "candidate_duplicate_decisions_fingerprint_sha256",
+          "value": "\"candidate_duplicate_decisions\".\"decision_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.candidate_duplicate_signals": {
+      "name": "candidate_duplicate_signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "duplicate_group_id": {
+          "name": "duplicate_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "left_candidate_id": {
+          "name": "left_candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "right_candidate_id": {
+          "name": "right_candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "candidate_duplicate_signal_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength": {
+          "name": "strength",
+          "type": "candidate_duplicate_signal_strength",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_duplicate_signals_identity_unique": {
+          "name": "candidate_duplicate_signals_identity_unique",
+          "columns": [
+            {
+              "expression": "duplicate_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "left_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "right_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_duplicate_signals_group_idx": {
+          "name": "candidate_duplicate_signals_group_idx",
+          "columns": [
+            {
+              "expression": "duplicate_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_duplicate_signals_left_idx": {
+          "name": "candidate_duplicate_signals_left_idx",
+          "columns": [
+            {
+              "expression": "left_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_duplicate_signals_right_idx": {
+          "name": "candidate_duplicate_signals_right_idx",
+          "columns": [
+            {
+              "expression": "right_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_duplicate_signals_import_batch_idx": {
+          "name": "candidate_duplicate_signals_import_batch_idx",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "candidate_duplicate_signals_duplicate_group_id_candidate_duplicate_groups_id_fk": {
+          "name": "candidate_duplicate_signals_duplicate_group_id_candidate_duplicate_groups_id_fk",
+          "tableFrom": "candidate_duplicate_signals",
+          "tableTo": "candidate_duplicate_groups",
+          "columnsFrom": [
+            "duplicate_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "candidate_duplicate_signals_left_candidate_id_source_candidates_id_fk": {
+          "name": "candidate_duplicate_signals_left_candidate_id_source_candidates_id_fk",
+          "tableFrom": "candidate_duplicate_signals",
+          "tableTo": "source_candidates",
+          "columnsFrom": [
+            "left_candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "candidate_duplicate_signals_right_candidate_id_source_candidates_id_fk": {
+          "name": "candidate_duplicate_signals_right_candidate_id_source_candidates_id_fk",
+          "tableFrom": "candidate_duplicate_signals",
+          "tableTo": "source_candidates",
+          "columnsFrom": [
+            "right_candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "candidate_duplicate_signals_import_batch_id_import_batches_id_fk": {
+          "name": "candidate_duplicate_signals_import_batch_id_import_batches_id_fk",
+          "tableFrom": "candidate_duplicate_signals",
+          "tableTo": "import_batches",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "candidate_duplicate_signals_distinct_candidates": {
+          "name": "candidate_duplicate_signals_distinct_candidates",
+          "value": "\"candidate_duplicate_signals\".\"left_candidate_id\" <> \"candidate_duplicate_signals\".\"right_candidate_id\""
+        },
+        "candidate_duplicate_signals_ordered_candidates": {
+          "name": "candidate_duplicate_signals_ordered_candidates",
+          "value": "\"candidate_duplicate_signals\".\"left_candidate_id\" < \"candidate_duplicate_signals\".\"right_candidate_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.candidate_promotion_decisions": {
+      "name": "candidate_promotion_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_asset_ids": {
+          "name": "claim_asset_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_ids": {
+          "name": "source_record_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_candidate_updated_at": {
+          "name": "expected_candidate_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_promotion_decisions_request_unique": {
+          "name": "candidate_promotion_decisions_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_promotion_decisions_candidate_unique": {
+          "name": "candidate_promotion_decisions_candidate_unique",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_promotion_decisions_claim_unique": {
+          "name": "candidate_promotion_decisions_claim_unique",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_promotion_decisions_entity_idx": {
+          "name": "candidate_promotion_decisions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_promotion_decisions_location_idx": {
+          "name": "candidate_promotion_decisions_location_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidate_promotion_decisions_actor_idx": {
+          "name": "candidate_promotion_decisions_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "promoted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "candidate_promotion_decisions_candidate_id_source_candidates_id_fk": {
+          "name": "candidate_promotion_decisions_candidate_id_source_candidates_id_fk",
+          "tableFrom": "candidate_promotion_decisions",
+          "tableTo": "source_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "candidate_promotion_decisions_entity_id_entities_id_fk": {
+          "name": "candidate_promotion_decisions_entity_id_entities_id_fk",
+          "tableFrom": "candidate_promotion_decisions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "candidate_promotion_decisions_location_id_locations_id_fk": {
+          "name": "candidate_promotion_decisions_location_id_locations_id_fk",
+          "tableFrom": "candidate_promotion_decisions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "candidate_promotion_decisions_claim_id_acceptance_claims_id_fk": {
+          "name": "candidate_promotion_decisions_claim_id_acceptance_claims_id_fk",
+          "tableFrom": "candidate_promotion_decisions",
+          "tableTo": "acceptance_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "candidate_promotion_decisions_claim_assets_array": {
+          "name": "candidate_promotion_decisions_claim_assets_array",
+          "value": "jsonb_typeof(\"candidate_promotion_decisions\".\"claim_asset_ids\") = 'array' and jsonb_array_length(\"candidate_promotion_decisions\".\"claim_asset_ids\") between 1 and 100"
+        },
+        "candidate_promotion_decisions_source_records_array": {
+          "name": "candidate_promotion_decisions_source_records_array",
+          "value": "jsonb_typeof(\"candidate_promotion_decisions\".\"source_record_ids\") = 'array' and jsonb_array_length(\"candidate_promotion_decisions\".\"source_record_ids\") between 1 and 100"
+        },
+        "candidate_promotion_decisions_canonical_path_format": {
+          "name": "candidate_promotion_decisions_canonical_path_format",
+          "value": "\"candidate_promotion_decisions\".\"canonical_path\" ~ '^/(place|service)/[^/?#]+$'"
+        },
+        "candidate_promotion_decisions_actor_nonempty": {
+          "name": "candidate_promotion_decisions_actor_nonempty",
+          "value": "length(trim(\"candidate_promotion_decisions\".\"actor_id\")) > 0"
+        },
+        "candidate_promotion_decisions_fingerprint_nonempty": {
+          "name": "candidate_promotion_decisions_fingerprint_nonempty",
+          "value": "length(\"candidate_promotion_decisions\".\"request_fingerprint\") > 0"
+        },
+        "candidate_promotion_decisions_time_order": {
+          "name": "candidate_promotion_decisions_time_order",
+          "value": "\"candidate_promotion_decisions\".\"expected_candidate_updated_at\" <= \"candidate_promotion_decisions\".\"promoted_at\""
+        },
+        "candidate_promotion_decisions_location_shape": {
+          "name": "candidate_promotion_decisions_location_shape",
+          "value": "(\"candidate_promotion_decisions\".\"canonical_path\" like '/place/%' and \"candidate_promotion_decisions\".\"location_id\" is not null) or (\"candidate_promotion_decisions\".\"canonical_path\" like '/service/%' and \"candidate_promotion_decisions\".\"location_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.claim_assets": {
+      "name": "claim_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claim_assets_without_contract_unique": {
+          "name": "claim_assets_without_contract_unique",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"claim_assets\".\"contract_address\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claim_assets_with_contract_unique": {
+          "name": "claim_assets_with_contract_unique",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contract_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"claim_assets\".\"contract_address\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claim_assets_primary_per_claim_unique": {
+          "name": "claim_assets_primary_per_claim_unique",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"claim_assets\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claim_assets_claim_idx": {
+          "name": "claim_assets_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claim_assets_asset_network_idx": {
+          "name": "claim_assets_asset_network_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "claim_assets_payment_method_idx": {
+          "name": "claim_assets_payment_method_idx",
+          "columns": [
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "claim_assets_claim_id_acceptance_claims_id_fk": {
+          "name": "claim_assets_claim_id_acceptance_claims_id_fk",
+          "tableFrom": "claim_assets",
+          "tableTo": "acceptance_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claim_assets_asset_id_assets_id_fk": {
+          "name": "claim_assets_asset_id_assets_id_fk",
+          "tableFrom": "claim_assets",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "claim_assets_network_id_networks_id_fk": {
+          "name": "claim_assets_network_id_networks_id_fk",
+          "tableFrom": "claim_assets",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "claim_assets_payment_method_id_payment_methods_id_fk": {
+          "name": "claim_assets_payment_method_id_payment_methods_id_fk",
+          "tableFrom": "claim_assets",
+          "tableTo": "payment_methods",
+          "columnsFrom": [
+            "payment_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "claim_assets_contract_address_nonempty": {
+          "name": "claim_assets_contract_address_nonempty",
+          "value": "\"claim_assets\".\"contract_address\" is null or length(trim(\"claim_assets\".\"contract_address\")) > 0"
+        },
+        "claim_assets_notes_nonempty": {
+          "name": "claim_assets_notes_nonempty",
+          "value": "\"claim_assets\".\"notes\" is null or length(trim(\"claim_assets\".\"notes\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_status": {
+          "name": "entity_status",
+          "type": "entity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "claim_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hidden'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "entities_slug_unique": {
+          "name": "entities_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_type_idx": {
+          "name": "entities_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_status_idx": {
+          "name": "entities_status_idx",
+          "columns": [
+            {
+              "expression": "entity_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_visibility_idx": {
+          "name": "entities_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence": {
+      "name": "evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_class": {
+          "name": "evidence_class",
+          "type": "evidence_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "evidence_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_role": {
+          "name": "origin_role",
+          "type": "evidence_origin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polarity": {
+          "name": "polarity",
+          "type": "evidence_polarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'supporting'"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_native_id": {
+          "name": "source_native_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "evidence_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "evidence_review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "archive_url": {
+          "name": "archive_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_id": {
+          "name": "license_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "independence_key": {
+          "name": "independence_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "evidence_claim_idx": {
+          "name": "evidence_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_submission_idx": {
+          "name": "evidence_submission_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_source_record_idx": {
+          "name": "evidence_source_record_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_review_idx": {
+          "name": "evidence_review_idx",
+          "columns": [
+            {
+              "expression": "review_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_observed_idx": {
+          "name": "evidence_observed_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_content_hash_idx": {
+          "name": "evidence_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_license_idx": {
+          "name": "evidence_license_idx",
+          "columns": [
+            {
+              "expression": "license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidence_claim_id_acceptance_claims_id_fk": {
+          "name": "evidence_claim_id_acceptance_claims_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "acceptance_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "evidence_source_record_id_source_records_id_fk": {
+          "name": "evidence_source_record_id_source_records_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "evidence_license_id_licenses_id_fk": {
+          "name": "evidence_license_id_licenses_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "licenses",
+          "columnsFrom": [
+            "license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "evidence_parent_required": {
+          "name": "evidence_parent_required",
+          "value": "\"evidence\".\"claim_id\" is not null or \"evidence\".\"submission_id\" is not null or \"evidence\".\"source_record_id\" is not null"
+        },
+        "evidence_public_reviewed": {
+          "name": "evidence_public_reviewed",
+          "value": "\"evidence\".\"visibility\" <> 'public' or \"evidence\".\"review_status\" = 'accepted'"
+        },
+        "evidence_accepted_observation": {
+          "name": "evidence_accepted_observation",
+          "value": "\"evidence\".\"review_status\" <> 'accepted' or \"evidence\".\"evidence_class\" = 'c' or \"evidence\".\"observed_at\" is not null"
+        },
+        "evidence_accepted_b_independence": {
+          "name": "evidence_accepted_b_independence",
+          "value": "\"evidence\".\"review_status\" <> 'accepted' or \"evidence\".\"evidence_class\" <> 'b' or \"evidence\".\"independence_key\" is not null"
+        },
+        "evidence_summary_nonempty": {
+          "name": "evidence_summary_nonempty",
+          "value": "length(trim(\"evidence\".\"summary\")) > 0"
+        },
+        "evidence_source_name_nonempty": {
+          "name": "evidence_source_name_nonempty",
+          "value": "\"evidence\".\"source_name\" is null or length(trim(\"evidence\".\"source_name\")) > 0"
+        },
+        "evidence_source_url_nonempty": {
+          "name": "evidence_source_url_nonempty",
+          "value": "\"evidence\".\"source_url\" is null or length(trim(\"evidence\".\"source_url\")) > 0"
+        },
+        "evidence_archive_url_nonempty": {
+          "name": "evidence_archive_url_nonempty",
+          "value": "\"evidence\".\"archive_url\" is null or length(trim(\"evidence\".\"archive_url\")) > 0"
+        },
+        "evidence_content_hash_nonempty": {
+          "name": "evidence_content_hash_nonempty",
+          "value": "\"evidence\".\"content_hash\" is null or length(trim(\"evidence\".\"content_hash\")) > 0"
+        },
+        "evidence_independence_key_nonempty": {
+          "name": "evidence_independence_key_nonempty",
+          "value": "\"evidence\".\"independence_key\" is null or length(trim(\"evidence\".\"independence_key\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.evidence_review_decisions": {
+      "name": "evidence_review_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_id": {
+          "name": "evidence_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "evidence_review_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "evidence_review_finding",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_action": {
+          "name": "claim_action",
+          "type": "evidence_review_claim_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_review_status": {
+          "name": "evidence_review_status",
+          "type": "evidence_review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_claim_status": {
+          "name": "from_claim_status",
+          "type": "acceptance_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_claim_status": {
+          "name": "to_claim_status",
+          "type": "acceptance_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_visibility": {
+          "name": "claim_visibility",
+          "type": "claim_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_event_id": {
+          "name": "verification_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_evidence_updated_at": {
+          "name": "expected_evidence_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_claim_updated_at": {
+          "name": "expected_claim_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_accepted_evidence_ids": {
+          "name": "expected_accepted_evidence_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_claim_asset_ids": {
+          "name": "expected_claim_asset_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_summary": {
+          "name": "public_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evidence_review_decisions_request_unique": {
+          "name": "evidence_review_decisions_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_review_decisions_evidence_idx": {
+          "name": "evidence_review_decisions_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_review_decisions_claim_idx": {
+          "name": "evidence_review_decisions_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_review_decisions_actor_idx": {
+          "name": "evidence_review_decisions_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidence_review_decisions_event_idx": {
+          "name": "evidence_review_decisions_event_idx",
+          "columns": [
+            {
+              "expression": "verification_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidence_review_decisions_evidence_id_evidence_id_fk": {
+          "name": "evidence_review_decisions_evidence_id_evidence_id_fk",
+          "tableFrom": "evidence_review_decisions",
+          "tableTo": "evidence",
+          "columnsFrom": [
+            "evidence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "evidence_review_decisions_claim_id_acceptance_claims_id_fk": {
+          "name": "evidence_review_decisions_claim_id_acceptance_claims_id_fk",
+          "tableFrom": "evidence_review_decisions",
+          "tableTo": "acceptance_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "evidence_review_decisions_verification_event_id_verification_events_id_fk": {
+          "name": "evidence_review_decisions_verification_event_id_verification_events_id_fk",
+          "tableFrom": "evidence_review_decisions",
+          "tableTo": "verification_events",
+          "columnsFrom": [
+            "verification_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "evidence_review_decisions_expected_set_array": {
+          "name": "evidence_review_decisions_expected_set_array",
+          "value": "jsonb_typeof(\"evidence_review_decisions\".\"expected_accepted_evidence_ids\") = 'array' and jsonb_array_length(\"evidence_review_decisions\".\"expected_accepted_evidence_ids\") between 0 and 100"
+        },
+        "evidence_review_decisions_expected_claim_asset_set_array": {
+          "name": "evidence_review_decisions_expected_claim_asset_set_array",
+          "value": "jsonb_typeof(\"evidence_review_decisions\".\"expected_claim_asset_ids\") = 'array' and jsonb_array_length(\"evidence_review_decisions\".\"expected_claim_asset_ids\") between 0 and 100"
+        },
+        "evidence_review_decisions_actor_nonempty": {
+          "name": "evidence_review_decisions_actor_nonempty",
+          "value": "length(trim(\"evidence_review_decisions\".\"actor_id\")) > 0"
+        },
+        "evidence_review_decisions_reason_nonempty": {
+          "name": "evidence_review_decisions_reason_nonempty",
+          "value": "length(trim(\"evidence_review_decisions\".\"reason_code\")) > 0"
+        },
+        "evidence_review_decisions_fingerprint_nonempty": {
+          "name": "evidence_review_decisions_fingerprint_nonempty",
+          "value": "length(\"evidence_review_decisions\".\"request_fingerprint\") > 0"
+        },
+        "evidence_review_decisions_summary_required": {
+          "name": "evidence_review_decisions_summary_required",
+          "value": "\"evidence_review_decisions\".\"public_summary\" is not null or \"evidence_review_decisions\".\"internal_note\" is not null"
+        },
+        "evidence_review_decisions_summary_nonempty": {
+          "name": "evidence_review_decisions_summary_nonempty",
+          "value": "\"evidence_review_decisions\".\"public_summary\" is null or length(trim(\"evidence_review_decisions\".\"public_summary\")) > 0"
+        },
+        "evidence_review_decisions_note_nonempty": {
+          "name": "evidence_review_decisions_note_nonempty",
+          "value": "\"evidence_review_decisions\".\"internal_note\" is null or length(trim(\"evidence_review_decisions\".\"internal_note\")) > 0"
+        },
+        "evidence_review_decisions_time_order": {
+          "name": "evidence_review_decisions_time_order",
+          "value": "\"evidence_review_decisions\".\"expected_evidence_updated_at\" <= \"evidence_review_decisions\".\"decided_at\" and \"evidence_review_decisions\".\"expected_claim_updated_at\" <= \"evidence_review_decisions\".\"decided_at\""
+        },
+        "evidence_review_decisions_disposition_shape": {
+          "name": "evidence_review_decisions_disposition_shape",
+          "value": "(\"evidence_review_decisions\".\"disposition\" = 'accepted' and \"evidence_review_decisions\".\"evidence_review_status\" = 'accepted') or (\"evidence_review_decisions\".\"disposition\" = 'rejected' and \"evidence_review_decisions\".\"evidence_review_status\" = 'rejected' and \"evidence_review_decisions\".\"finding\" = 'insufficient' and \"evidence_review_decisions\".\"claim_action\" = 'no_change') or (\"evidence_review_decisions\".\"disposition\" = 'held' and \"evidence_review_decisions\".\"evidence_review_status\" = 'pending' and \"evidence_review_decisions\".\"finding\" = 'insufficient' and \"evidence_review_decisions\".\"claim_action\" = 'no_change')"
+        },
+        "evidence_review_decisions_action_event_shape": {
+          "name": "evidence_review_decisions_action_event_shape",
+          "value": "(\"evidence_review_decisions\".\"claim_action\" = 'no_change' and \"evidence_review_decisions\".\"verification_event_id\" is null and \"evidence_review_decisions\".\"from_claim_status\" = \"evidence_review_decisions\".\"to_claim_status\") or (\"evidence_review_decisions\".\"claim_action\" <> 'no_change' and \"evidence_review_decisions\".\"disposition\" = 'accepted' and \"evidence_review_decisions\".\"verification_event_id\" is not null)"
+        },
+        "evidence_review_decisions_confirm_shape": {
+          "name": "evidence_review_decisions_confirm_shape",
+          "value": "\"evidence_review_decisions\".\"claim_action\" <> 'confirm' or (\"evidence_review_decisions\".\"finding\" = 'supports_claim' and \"evidence_review_decisions\".\"from_claim_status\" in ('candidate', 'confirmed', 'stale') and \"evidence_review_decisions\".\"to_claim_status\" = 'confirmed' and \"evidence_review_decisions\".\"next_review_at\" is not null and \"evidence_review_decisions\".\"next_review_at\" > \"evidence_review_decisions\".\"decided_at\")"
+        },
+        "evidence_review_decisions_stale_shape": {
+          "name": "evidence_review_decisions_stale_shape",
+          "value": "\"evidence_review_decisions\".\"claim_action\" <> 'mark_stale' or (\"evidence_review_decisions\".\"finding\" = 'contradicts_claim' and \"evidence_review_decisions\".\"from_claim_status\" = 'confirmed' and \"evidence_review_decisions\".\"to_claim_status\" = 'stale' and \"evidence_review_decisions\".\"next_review_at\" is not null and \"evidence_review_decisions\".\"next_review_at\" > \"evidence_review_decisions\".\"decided_at\")"
+        },
+        "evidence_review_decisions_end_shape": {
+          "name": "evidence_review_decisions_end_shape",
+          "value": "\"evidence_review_decisions\".\"claim_action\" <> 'end' or (\"evidence_review_decisions\".\"finding\" = 'contradicts_claim' and \"evidence_review_decisions\".\"from_claim_status\" in ('confirmed', 'stale') and \"evidence_review_decisions\".\"to_claim_status\" = 'ended' and \"evidence_review_decisions\".\"ended_reason\" is not null)"
+        },
+        "evidence_review_decisions_reject_shape": {
+          "name": "evidence_review_decisions_reject_shape",
+          "value": "\"evidence_review_decisions\".\"claim_action\" <> 'reject' or (\"evidence_review_decisions\".\"finding\" = 'contradicts_claim' and \"evidence_review_decisions\".\"from_claim_status\" = 'candidate' and \"evidence_review_decisions\".\"to_claim_status\" = 'rejected')"
+        },
+        "evidence_review_decisions_optional_action_fields": {
+          "name": "evidence_review_decisions_optional_action_fields",
+          "value": "(\"evidence_review_decisions\".\"claim_action\" in ('confirm', 'mark_stale') or \"evidence_review_decisions\".\"next_review_at\" is null) and (\"evidence_review_decisions\".\"claim_action\" = 'end' or \"evidence_review_decisions\".\"ended_reason\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.export_activation_records": {
+      "name": "export_activation_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_request_id": {
+          "name": "approval_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_status": {
+          "name": "activation_status",
+          "type": "export_activation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_digest": {
+          "name": "snapshot_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_version": {
+          "name": "dataset_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_snapshot_digest": {
+          "name": "previous_snapshot_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pointer_key": {
+          "name": "pointer_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_prefix": {
+          "name": "release_prefix",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_count": {
+          "name": "artifact_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "export_activation_records_request_unique": {
+          "name": "export_activation_records_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_activation_records_snapshot_unique": {
+          "name": "export_activation_records_snapshot_unique",
+          "columns": [
+            {
+              "expression": "snapshot_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_activation_records_dataset_unique": {
+          "name": "export_activation_records_dataset_unique",
+          "columns": [
+            {
+              "expression": "dataset_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_activation_records_published_idx": {
+          "name": "export_activation_records_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_activation_records_actor_idx": {
+          "name": "export_activation_records_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "export_activation_records_digest_shape": {
+          "name": "export_activation_records_digest_shape",
+          "value": "\"export_activation_records\".\"snapshot_digest\" ~ '^[a-f0-9]{64}$'"
+        },
+        "export_activation_records_previous_digest_shape": {
+          "name": "export_activation_records_previous_digest_shape",
+          "value": "\"export_activation_records\".\"previous_snapshot_digest\" is null or \"export_activation_records\".\"previous_snapshot_digest\" ~ '^[a-f0-9]{64}$'"
+        },
+        "export_activation_records_distinct_previous_digest": {
+          "name": "export_activation_records_distinct_previous_digest",
+          "value": "\"export_activation_records\".\"previous_snapshot_digest\" is null or \"export_activation_records\".\"previous_snapshot_digest\" <> \"export_activation_records\".\"snapshot_digest\""
+        },
+        "export_activation_records_artifact_count_range": {
+          "name": "export_activation_records_artifact_count_range",
+          "value": "\"export_activation_records\".\"artifact_count\" between 1 and 100"
+        },
+        "export_activation_records_time_order": {
+          "name": "export_activation_records_time_order",
+          "value": "\"export_activation_records\".\"generated_at\" <= \"export_activation_records\".\"published_at\""
+        },
+        "export_activation_records_actor_nonempty": {
+          "name": "export_activation_records_actor_nonempty",
+          "value": "length(trim(\"export_activation_records\".\"actor_id\")) > 0"
+        },
+        "export_activation_records_reason_nonempty": {
+          "name": "export_activation_records_reason_nonempty",
+          "value": "length(trim(\"export_activation_records\".\"reason_code\")) > 0"
+        },
+        "export_activation_records_fingerprint_nonempty": {
+          "name": "export_activation_records_fingerprint_nonempty",
+          "value": "length(\"export_activation_records\".\"request_fingerprint\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.export_release_decisions": {
+      "name": "export_release_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "export_release_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_status": {
+          "name": "release_status",
+          "type": "export_release_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_digest": {
+          "name": "snapshot_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_count": {
+          "name": "artifact_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_version": {
+          "name": "dataset_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_status": {
+          "name": "candidate_status",
+          "type": "export_release_candidate_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validation_issues": {
+          "name": "validation_issues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_summary": {
+          "name": "public_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "export_release_decisions_request_unique": {
+          "name": "export_release_decisions_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_release_decisions_approved_snapshot_unique": {
+          "name": "export_release_decisions_approved_snapshot_unique",
+          "columns": [
+            {
+              "expression": "snapshot_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"export_release_decisions\".\"release_status\" = 'approved'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_release_decisions_approved_dataset_unique": {
+          "name": "export_release_decisions_approved_dataset_unique",
+          "columns": [
+            {
+              "expression": "dataset_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"export_release_decisions\".\"release_status\" = 'approved'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_release_decisions_decided_idx": {
+          "name": "export_release_decisions_decided_idx",
+          "columns": [
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_release_decisions_actor_idx": {
+          "name": "export_release_decisions_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_release_decisions_status_idx": {
+          "name": "export_release_decisions_status_idx",
+          "columns": [
+            {
+              "expression": "release_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "export_release_decisions_digest_shape": {
+          "name": "export_release_decisions_digest_shape",
+          "value": "\"export_release_decisions\".\"snapshot_digest\" ~ '^[a-f0-9]{64}$'"
+        },
+        "export_release_decisions_artifact_count_range": {
+          "name": "export_release_decisions_artifact_count_range",
+          "value": "\"export_release_decisions\".\"artifact_count\" between 1 and 100"
+        },
+        "export_release_decisions_validation_issues_array": {
+          "name": "export_release_decisions_validation_issues_array",
+          "value": "jsonb_typeof(\"export_release_decisions\".\"validation_issues\") = 'array' and jsonb_array_length(\"export_release_decisions\".\"validation_issues\") between 0 and 500"
+        },
+        "export_release_decisions_candidate_shape": {
+          "name": "export_release_decisions_candidate_shape",
+          "value": "(\"export_release_decisions\".\"candidate_status\" = 'eligible' and jsonb_array_length(\"export_release_decisions\".\"validation_issues\") = 0) or (\"export_release_decisions\".\"candidate_status\" = 'blocked' and jsonb_array_length(\"export_release_decisions\".\"validation_issues\") > 0)"
+        },
+        "export_release_decisions_dataset_version_nonempty": {
+          "name": "export_release_decisions_dataset_version_nonempty",
+          "value": "length(trim(\"export_release_decisions\".\"dataset_version\")) > 0"
+        },
+        "export_release_decisions_schema_version_nonempty": {
+          "name": "export_release_decisions_schema_version_nonempty",
+          "value": "length(trim(\"export_release_decisions\".\"schema_version\")) > 0"
+        },
+        "export_release_decisions_actor_nonempty": {
+          "name": "export_release_decisions_actor_nonempty",
+          "value": "length(trim(\"export_release_decisions\".\"actor_id\")) > 0"
+        },
+        "export_release_decisions_reason_nonempty": {
+          "name": "export_release_decisions_reason_nonempty",
+          "value": "length(trim(\"export_release_decisions\".\"reason_code\")) > 0"
+        },
+        "export_release_decisions_fingerprint_nonempty": {
+          "name": "export_release_decisions_fingerprint_nonempty",
+          "value": "length(\"export_release_decisions\".\"request_fingerprint\") > 0"
+        },
+        "export_release_decisions_summary_required": {
+          "name": "export_release_decisions_summary_required",
+          "value": "\"export_release_decisions\".\"public_summary\" is not null or \"export_release_decisions\".\"internal_note\" is not null"
+        },
+        "export_release_decisions_time_order": {
+          "name": "export_release_decisions_time_order",
+          "value": "\"export_release_decisions\".\"generated_at\" <= \"export_release_decisions\".\"decided_at\""
+        },
+        "export_release_decisions_approve_shape": {
+          "name": "export_release_decisions_approve_shape",
+          "value": "\"export_release_decisions\".\"action\" <> 'approve' or (\"export_release_decisions\".\"release_status\" = 'approved' and \"export_release_decisions\".\"candidate_status\" = 'eligible')"
+        },
+        "export_release_decisions_reject_shape": {
+          "name": "export_release_decisions_reject_shape",
+          "value": "\"export_release_decisions\".\"action\" <> 'reject' or \"export_release_decisions\".\"release_status\" = 'rejected'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.import_batches": {
+      "name": "import_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_kind": {
+          "name": "import_kind",
+          "type": "import_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_schema_version": {
+          "name": "source_schema_version",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_checksum": {
+          "name": "input_checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_count": {
+          "name": "input_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_count": {
+          "name": "accepted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replayed_count": {
+          "name": "replayed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "out_of_scope_count": {
+          "name": "out_of_scope_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_signal_count": {
+          "name": "duplicate_signal_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "automatic_confirmed_count": {
+          "name": "automatic_confirmed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejection_summary": {
+          "name": "rejection_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "import_batches_request_id_unique": {
+          "name": "import_batches_request_id_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "import_batches_source_checksum_unique": {
+          "name": "import_batches_source_checksum_unique",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "importer_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "input_checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "import_batches_actor_completed_idx": {
+          "name": "import_batches_actor_completed_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "import_batches_source_completed_idx": {
+          "name": "import_batches_source_completed_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "import_batches_kind_completed_idx": {
+          "name": "import_batches_kind_completed_idx",
+          "columns": [
+            {
+              "expression": "import_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "import_batches_source_id_sources_id_fk": {
+          "name": "import_batches_source_id_sources_id_fk",
+          "tableFrom": "import_batches",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "import_batches_actor_id_nonempty": {
+          "name": "import_batches_actor_id_nonempty",
+          "value": "length(trim(\"import_batches\".\"actor_id\")) > 0"
+        },
+        "import_batches_source_schema_version_nonempty": {
+          "name": "import_batches_source_schema_version_nonempty",
+          "value": "length(trim(\"import_batches\".\"source_schema_version\")) > 0"
+        },
+        "import_batches_importer_version_nonempty": {
+          "name": "import_batches_importer_version_nonempty",
+          "value": "length(trim(\"import_batches\".\"importer_version\")) > 0"
+        },
+        "import_batches_input_checksum_sha256": {
+          "name": "import_batches_input_checksum_sha256",
+          "value": "\"import_batches\".\"input_checksum\" ~ '^[a-f0-9]{64}$'"
+        },
+        "import_batches_counts_nonnegative": {
+          "name": "import_batches_counts_nonnegative",
+          "value": "\"import_batches\".\"input_count\" >= 0 and \"import_batches\".\"accepted_count\" >= 0 and \"import_batches\".\"rejected_count\" >= 0 and \"import_batches\".\"replayed_count\" >= 0 and \"import_batches\".\"out_of_scope_count\" >= 0 and \"import_batches\".\"duplicate_signal_count\" >= 0 and \"import_batches\".\"automatic_confirmed_count\" >= 0"
+        },
+        "import_batches_input_count_shape": {
+          "name": "import_batches_input_count_shape",
+          "value": "\"import_batches\".\"input_count\" = \"import_batches\".\"accepted_count\" + \"import_batches\".\"rejected_count\" + \"import_batches\".\"replayed_count\""
+        },
+        "import_batches_out_of_scope_subset": {
+          "name": "import_batches_out_of_scope_subset",
+          "value": "\"import_batches\".\"out_of_scope_count\" <= \"import_batches\".\"rejected_count\""
+        },
+        "import_batches_no_automatic_confirmed": {
+          "name": "import_batches_no_automatic_confirmed",
+          "value": "\"import_batches\".\"automatic_confirmed_count\" = 0"
+        },
+        "import_batches_time_order": {
+          "name": "import_batches_time_order",
+          "value": "\"import_batches\".\"started_at\" <= \"import_batches\".\"completed_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.location_profile_correction_decisions": {
+      "name": "location_profile_correction_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_location_updated_at": {
+          "name": "expected_location_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_field_paths": {
+          "name": "changed_field_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_values": {
+          "name": "before_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after_values": {
+          "name": "after_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_ids": {
+          "name": "source_record_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance_assignments": {
+          "name": "provenance_assignments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_summary": {
+          "name": "public_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "location_profile_corrections_request_unique": {
+          "name": "location_profile_corrections_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_profile_corrections_location_idx": {
+          "name": "location_profile_corrections_location_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_profile_corrections_actor_idx": {
+          "name": "location_profile_corrections_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_profile_correction_decisions_location_id_locations_id_fk": {
+          "name": "location_profile_correction_decisions_location_id_locations_id_fk",
+          "tableFrom": "location_profile_correction_decisions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "location_profile_corrections_fields_array": {
+          "name": "location_profile_corrections_fields_array",
+          "value": "jsonb_typeof(\"location_profile_correction_decisions\".\"changed_field_paths\") = 'array' and jsonb_array_length(\"location_profile_correction_decisions\".\"changed_field_paths\") between 1 and 10"
+        },
+        "location_profile_corrections_changes_object": {
+          "name": "location_profile_corrections_changes_object",
+          "value": "jsonb_typeof(\"location_profile_correction_decisions\".\"changes\") = 'object'"
+        },
+        "location_profile_corrections_before_object": {
+          "name": "location_profile_corrections_before_object",
+          "value": "jsonb_typeof(\"location_profile_correction_decisions\".\"before_values\") = 'object'"
+        },
+        "location_profile_corrections_after_object": {
+          "name": "location_profile_corrections_after_object",
+          "value": "jsonb_typeof(\"location_profile_correction_decisions\".\"after_values\") = 'object'"
+        },
+        "location_profile_corrections_sources_array": {
+          "name": "location_profile_corrections_sources_array",
+          "value": "jsonb_typeof(\"location_profile_correction_decisions\".\"source_record_ids\") = 'array' and jsonb_array_length(\"location_profile_correction_decisions\".\"source_record_ids\") between 1 and 100"
+        },
+        "location_profile_corrections_assignments_array": {
+          "name": "location_profile_corrections_assignments_array",
+          "value": "jsonb_typeof(\"location_profile_correction_decisions\".\"provenance_assignments\") = 'array' and jsonb_array_length(\"location_profile_correction_decisions\".\"provenance_assignments\") between 1 and 10"
+        },
+        "location_profile_corrections_actor_nonempty": {
+          "name": "location_profile_corrections_actor_nonempty",
+          "value": "length(trim(\"location_profile_correction_decisions\".\"actor_id\")) > 0"
+        },
+        "location_profile_corrections_reason_nonempty": {
+          "name": "location_profile_corrections_reason_nonempty",
+          "value": "length(trim(\"location_profile_correction_decisions\".\"reason_code\")) > 0"
+        },
+        "location_profile_corrections_fingerprint_nonempty": {
+          "name": "location_profile_corrections_fingerprint_nonempty",
+          "value": "length(\"location_profile_correction_decisions\".\"request_fingerprint\") > 0"
+        },
+        "location_profile_corrections_summary_required": {
+          "name": "location_profile_corrections_summary_required",
+          "value": "\"location_profile_correction_decisions\".\"public_summary\" is not null or \"location_profile_correction_decisions\".\"internal_note\" is not null"
+        },
+        "location_profile_corrections_summary_nonempty": {
+          "name": "location_profile_corrections_summary_nonempty",
+          "value": "\"location_profile_correction_decisions\".\"public_summary\" is null or length(trim(\"location_profile_correction_decisions\".\"public_summary\")) > 0"
+        },
+        "location_profile_corrections_note_nonempty": {
+          "name": "location_profile_corrections_note_nonempty",
+          "value": "\"location_profile_correction_decisions\".\"internal_note\" is null or length(trim(\"location_profile_correction_decisions\".\"internal_note\")) > 0"
+        },
+        "location_profile_corrections_time_order": {
+          "name": "location_profile_corrections_time_order",
+          "value": "\"location_profile_correction_decisions\".\"expected_location_updated_at\" <= \"location_profile_correction_decisions\".\"decided_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line": {
+          "name": "address_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_status": {
+          "name": "location_status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "claim_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hidden'"
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amenities": {
+          "name": "amenities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_type": {
+          "name": "osm_type",
+          "type": "osm_element_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_id": {
+          "name": "osm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "locations_slug_unique": {
+          "name": "locations_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_osm_identity_unique": {
+          "name": "locations_osm_identity_unique",
+          "columns": [
+            {
+              "expression": "osm_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "osm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"locations\".\"osm_type\" is not null and \"locations\".\"osm_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_entity_idx": {
+          "name": "locations_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_country_locality_idx": {
+          "name": "locations_country_locality_idx",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locality",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_status_idx": {
+          "name": "locations_status_idx",
+          "columns": [
+            {
+              "expression": "location_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_visibility_idx": {
+          "name": "locations_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_entity_id_entities_id_fk": {
+          "name": "locations_entity_id_entities_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "locations_latitude_range": {
+          "name": "locations_latitude_range",
+          "value": "\"locations\".\"latitude\" between -90 and 90"
+        },
+        "locations_longitude_range": {
+          "name": "locations_longitude_range",
+          "value": "\"locations\".\"longitude\" between -180 and 180"
+        },
+        "locations_osm_identity_pair": {
+          "name": "locations_osm_identity_pair",
+          "value": "(\"locations\".\"osm_type\" is null and \"locations\".\"osm_id\" is null) or (\"locations\".\"osm_type\" is not null and \"locations\".\"osm_id\" is not null)"
+        },
+        "locations_social_links_array": {
+          "name": "locations_social_links_array",
+          "value": "\"locations\".\"social_links\" is null or jsonb_typeof(\"locations\".\"social_links\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legacy_place_ids": {
+      "name": "legacy_place_ids",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "legacy_source_system",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_path": {
+          "name": "legacy_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migration_status": {
+          "name": "migration_status",
+          "type": "legacy_migration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legacy_place_ids_source_identity_unique": {
+          "name": "legacy_place_ids_source_identity_unique",
+          "columns": [
+            {
+              "expression": "source_system",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_place_ids_legacy_path_unique": {
+          "name": "legacy_place_ids_legacy_path_unique",
+          "columns": [
+            {
+              "expression": "legacy_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"legacy_place_ids\".\"legacy_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_place_ids_status_idx": {
+          "name": "legacy_place_ids_status_idx",
+          "columns": [
+            {
+              "expression": "migration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_place_ids_entity_idx": {
+          "name": "legacy_place_ids_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_place_ids_location_idx": {
+          "name": "legacy_place_ids_location_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_place_ids_source_record_idx": {
+          "name": "legacy_place_ids_source_record_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_place_ids_entity_id_entities_id_fk": {
+          "name": "legacy_place_ids_entity_id_entities_id_fk",
+          "tableFrom": "legacy_place_ids",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "legacy_place_ids_location_id_locations_id_fk": {
+          "name": "legacy_place_ids_location_id_locations_id_fk",
+          "tableFrom": "legacy_place_ids",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "legacy_place_ids_source_record_id_source_records_id_fk": {
+          "name": "legacy_place_ids_source_record_id_source_records_id_fk",
+          "tableFrom": "legacy_place_ids",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "legacy_place_ids_legacy_id_nonempty": {
+          "name": "legacy_place_ids_legacy_id_nonempty",
+          "value": "length(trim(\"legacy_place_ids\".\"legacy_id\")) > 0"
+        },
+        "legacy_place_ids_state_shape": {
+          "name": "legacy_place_ids_state_shape",
+          "value": "(\"legacy_place_ids\".\"migration_status\" = 'pending' and \"legacy_place_ids\".\"resolved_at\" is null and \"legacy_place_ids\".\"canonical_path\" is null and num_nonnulls(\"legacy_place_ids\".\"entity_id\", \"legacy_place_ids\".\"location_id\") = 0) or (\"legacy_place_ids\".\"migration_status\" = 'mapped' and \"legacy_place_ids\".\"resolved_at\" is not null and \"legacy_place_ids\".\"canonical_path\" is not null and num_nonnulls(\"legacy_place_ids\".\"entity_id\", \"legacy_place_ids\".\"location_id\") = 1) or (\"legacy_place_ids\".\"migration_status\" in ('unresolved', 'retired') and \"legacy_place_ids\".\"resolved_at\" is not null and \"legacy_place_ids\".\"canonical_path\" is null and num_nonnulls(\"legacy_place_ids\".\"entity_id\", \"legacy_place_ids\".\"location_id\") = 0)"
+        },
+        "legacy_place_ids_source_target": {
+          "name": "legacy_place_ids_source_target",
+          "value": "\"legacy_place_ids\".\"migration_status\" <> 'mapped' or (\"legacy_place_ids\".\"source_system\" = 'cryptopaymap_v2' and \"legacy_place_ids\".\"location_id\" is not null and \"legacy_place_ids\".\"entity_id\" is null) or (\"legacy_place_ids\".\"source_system\" = 'crypto_acceptance_registry' and \"legacy_place_ids\".\"entity_id\" is not null and \"legacy_place_ids\".\"location_id\" is null)"
+        },
+        "legacy_place_ids_legacy_path_format": {
+          "name": "legacy_place_ids_legacy_path_format",
+          "value": "\"legacy_place_ids\".\"legacy_path\" is null or \"legacy_place_ids\".\"legacy_path\" ~ '^/[^?#]*$'"
+        },
+        "legacy_place_ids_canonical_path_format": {
+          "name": "legacy_place_ids_canonical_path_format",
+          "value": "\"legacy_place_ids\".\"canonical_path\" is null or \"legacy_place_ids\".\"canonical_path\" ~ '^/[^?#]+$'"
+        },
+        "legacy_place_ids_path_change": {
+          "name": "legacy_place_ids_path_change",
+          "value": "\"legacy_place_ids\".\"legacy_path\" is null or \"legacy_place_ids\".\"canonical_path\" is null or \"legacy_place_ids\".\"legacy_path\" <> \"legacy_place_ids\".\"canonical_path\""
+        },
+        "legacy_place_ids_resolution_note_required": {
+          "name": "legacy_place_ids_resolution_note_required",
+          "value": "\"legacy_place_ids\".\"migration_status\" not in ('unresolved', 'retired') or \"legacy_place_ids\".\"resolution_note\" is not null"
+        },
+        "legacy_place_ids_resolution_note_nonempty": {
+          "name": "legacy_place_ids_resolution_note_nonempty",
+          "value": "\"legacy_place_ids\".\"resolution_note\" is null or length(trim(\"legacy_place_ids\".\"resolution_note\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_assets": {
+      "name": "media_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "media_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "media_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "media_review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rights_status": {
+          "name": "rights_status",
+          "type": "media_rights_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "media_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_id": {
+          "name": "evidence_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_id": {
+          "name": "license_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rights_holder": {
+          "name": "rights_holder",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_reference": {
+          "name": "consent_reference",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_assets_entity_idx": {
+          "name": "media_assets_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_location_idx": {
+          "name": "media_assets_location_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_claim_idx": {
+          "name": "media_assets_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_evidence_idx": {
+          "name": "media_assets_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_submission_idx": {
+          "name": "media_assets_submission_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_source_record_idx": {
+          "name": "media_assets_source_record_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_license_idx": {
+          "name": "media_assets_license_idx",
+          "columns": [
+            {
+              "expression": "license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_review_visibility_idx": {
+          "name": "media_assets_review_visibility_idx",
+          "columns": [
+            {
+              "expression": "review_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_assets_purpose_order_idx": {
+          "name": "media_assets_purpose_order_idx",
+          "columns": [
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_assets_entity_id_entities_id_fk": {
+          "name": "media_assets_entity_id_entities_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "media_assets_location_id_locations_id_fk": {
+          "name": "media_assets_location_id_locations_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "media_assets_claim_id_acceptance_claims_id_fk": {
+          "name": "media_assets_claim_id_acceptance_claims_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "acceptance_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "media_assets_evidence_id_evidence_id_fk": {
+          "name": "media_assets_evidence_id_evidence_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "evidence",
+          "columnsFrom": [
+            "evidence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "media_assets_source_record_id_source_records_id_fk": {
+          "name": "media_assets_source_record_id_source_records_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "media_assets_license_id_licenses_id_fk": {
+          "name": "media_assets_license_id_licenses_id_fk",
+          "tableFrom": "media_assets",
+          "tableTo": "licenses",
+          "columnsFrom": [
+            "license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_assets_subject_exactly_one": {
+          "name": "media_assets_subject_exactly_one",
+          "value": "num_nonnulls(\"media_assets\".\"entity_id\", \"media_assets\".\"location_id\", \"media_assets\".\"claim_id\", \"media_assets\".\"evidence_id\", \"media_assets\".\"submission_id\", \"media_assets\".\"source_record_id\") = 1"
+        },
+        "media_assets_purpose_role": {
+          "name": "media_assets_purpose_role",
+          "value": "(\"media_assets\".\"purpose\" = 'evidence' and \"media_assets\".\"role\" = 'evidence_image') or (\"media_assets\".\"purpose\" = 'owner_verification' and \"media_assets\".\"role\" = 'owner_verification_proof') or (\"media_assets\".\"purpose\" = 'canonical_logo' and \"media_assets\".\"role\" = 'logo') or (\"media_assets\".\"purpose\" in ('public_gallery_candidate', 'public_gallery') and \"media_assets\".\"role\" in ('cover', 'gallery', 'exterior', 'interior', 'product', 'menu', 'payment_sign', 'checkout_terminal'))"
+        },
+        "media_assets_public_eligible": {
+          "name": "media_assets_public_eligible",
+          "value": "\"media_assets\".\"visibility\" <> 'public' or (\"media_assets\".\"review_status\" = 'accepted' and \"media_assets\".\"purpose\" in ('public_gallery', 'canonical_logo') and \"media_assets\".\"rights_status\" in ('submitted_with_permission', 'licensed', 'public_domain') and \"media_assets\".\"published_at\" is not null and \"media_assets\".\"alt_text\" is not null and \"media_assets\".\"deleted_at\" is null)"
+        },
+        "media_assets_licensed_reference": {
+          "name": "media_assets_licensed_reference",
+          "value": "\"media_assets\".\"rights_status\" <> 'licensed' or \"media_assets\".\"license_id\" is not null"
+        },
+        "media_assets_permission_reference": {
+          "name": "media_assets_permission_reference",
+          "value": "\"media_assets\".\"rights_status\" <> 'submitted_with_permission' or \"media_assets\".\"rights_holder\" is not null or \"media_assets\".\"consent_reference\" is not null"
+        },
+        "media_assets_display_order_nonnegative": {
+          "name": "media_assets_display_order_nonnegative",
+          "value": "\"media_assets\".\"display_order\" >= 0"
+        },
+        "media_assets_attribution_nonempty": {
+          "name": "media_assets_attribution_nonempty",
+          "value": "\"media_assets\".\"attribution\" is null or length(trim(\"media_assets\".\"attribution\")) > 0"
+        },
+        "media_assets_alt_text_nonempty": {
+          "name": "media_assets_alt_text_nonempty",
+          "value": "\"media_assets\".\"alt_text\" is null or length(trim(\"media_assets\".\"alt_text\")) > 0"
+        },
+        "media_assets_rights_holder_nonempty": {
+          "name": "media_assets_rights_holder_nonempty",
+          "value": "\"media_assets\".\"rights_holder\" is null or length(trim(\"media_assets\".\"rights_holder\")) > 0"
+        },
+        "media_assets_consent_reference_nonempty": {
+          "name": "media_assets_consent_reference_nonempty",
+          "value": "\"media_assets\".\"consent_reference\" is null or length(trim(\"media_assets\".\"consent_reference\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_files": {
+      "name": "media_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "media_variant",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_scope": {
+          "name": "storage_scope",
+          "type": "media_storage_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_files_storage_key_unique": {
+          "name": "media_files_storage_key_unique",
+          "columns": [
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_files_asset_variant_unique": {
+          "name": "media_files_asset_variant_unique",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_files_asset_idx": {
+          "name": "media_files_asset_idx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_files_content_hash_idx": {
+          "name": "media_files_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_files_media_asset_id_media_assets_id_fk": {
+          "name": "media_files_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_files",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_files_storage_key_nonempty": {
+          "name": "media_files_storage_key_nonempty",
+          "value": "length(trim(\"media_files\".\"storage_key\")) > 0"
+        },
+        "media_files_mime_type_nonempty": {
+          "name": "media_files_mime_type_nonempty",
+          "value": "length(trim(\"media_files\".\"mime_type\")) > 0"
+        },
+        "media_files_byte_size_positive": {
+          "name": "media_files_byte_size_positive",
+          "value": "\"media_files\".\"byte_size\" > 0"
+        },
+        "media_files_dimensions_pair": {
+          "name": "media_files_dimensions_pair",
+          "value": "(\"media_files\".\"width\" is null and \"media_files\".\"height\" is null) or (\"media_files\".\"width\" > 0 and \"media_files\".\"height\" > 0)"
+        },
+        "media_files_content_hash_sha256": {
+          "name": "media_files_content_hash_sha256",
+          "value": "\"media_files\".\"content_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "media_files_original_filename_nonempty": {
+          "name": "media_files_original_filename_nonempty",
+          "value": "\"media_files\".\"original_filename\" is null or length(trim(\"media_files\".\"original_filename\")) > 0"
+        },
+        "media_files_original_filename_scope": {
+          "name": "media_files_original_filename_scope",
+          "value": "\"media_files\".\"original_filename\" is null or \"media_files\".\"variant\" = 'original'"
+        },
+        "media_files_original_not_public": {
+          "name": "media_files_original_not_public",
+          "value": "\"media_files\".\"variant\" <> 'original' or \"media_files\".\"storage_scope\" <> 'public'"
+        },
+        "media_files_public_format": {
+          "name": "media_files_public_format",
+          "value": "\"media_files\".\"storage_scope\" <> 'public' or (\"media_files\".\"variant\" <> 'original' and \"media_files\".\"mime_type\" in ('image/jpeg', 'image/webp'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_review_decisions": {
+      "name": "media_review_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_asset_id": {
+          "name": "media_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "media_review_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_match": {
+          "name": "target_match",
+          "type": "media_review_target_match",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_review": {
+          "name": "privacy_review",
+          "type": "media_review_privacy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_media_updated_at": {
+          "name": "expected_media_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_review_status": {
+          "name": "expected_review_status",
+          "type": "media_review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_purpose": {
+          "name": "expected_purpose",
+          "type": "media_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_rights_status": {
+          "name": "expected_rights_status",
+          "type": "media_rights_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_visibility": {
+          "name": "expected_visibility",
+          "type": "media_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_subject_type": {
+          "name": "expected_subject_type",
+          "type": "media_review_subject_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_subject_id": {
+          "name": "expected_subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_files": {
+          "name": "expected_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_review_status": {
+          "name": "to_review_status",
+          "type": "media_review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_purpose": {
+          "name": "to_purpose",
+          "type": "media_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_rights_status": {
+          "name": "to_rights_status",
+          "type": "media_rights_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_visibility": {
+          "name": "to_visibility",
+          "type": "media_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_id": {
+          "name": "license_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rights_holder": {
+          "name": "rights_holder",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_reference": {
+          "name": "consent_reference",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_attribution_required": {
+          "name": "license_attribution_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_display_file_id": {
+          "name": "public_display_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_thumbnail_file_id": {
+          "name": "public_thumbnail_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_file_ids": {
+          "name": "public_file_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_summary": {
+          "name": "public_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_review_decisions_request_unique": {
+          "name": "media_review_decisions_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_review_decisions_asset_idx": {
+          "name": "media_review_decisions_asset_idx",
+          "columns": [
+            {
+              "expression": "media_asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_review_decisions_actor_idx": {
+          "name": "media_review_decisions_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_review_decisions_action_idx": {
+          "name": "media_review_decisions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_review_decisions_media_asset_id_media_assets_id_fk": {
+          "name": "media_review_decisions_media_asset_id_media_assets_id_fk",
+          "tableFrom": "media_review_decisions",
+          "tableTo": "media_assets",
+          "columnsFrom": [
+            "media_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "media_review_decisions_public_display_file_id_media_files_id_fk": {
+          "name": "media_review_decisions_public_display_file_id_media_files_id_fk",
+          "tableFrom": "media_review_decisions",
+          "tableTo": "media_files",
+          "columnsFrom": [
+            "public_display_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "media_review_decisions_public_thumbnail_file_id_media_files_id_fk": {
+          "name": "media_review_decisions_public_thumbnail_file_id_media_files_id_fk",
+          "tableFrom": "media_review_decisions",
+          "tableTo": "media_files",
+          "columnsFrom": [
+            "public_thumbnail_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_review_decisions_expected_files_array": {
+          "name": "media_review_decisions_expected_files_array",
+          "value": "jsonb_typeof(\"media_review_decisions\".\"expected_files\") = 'array' and jsonb_array_length(\"media_review_decisions\".\"expected_files\") between 0 and 3"
+        },
+        "media_review_decisions_public_files_array": {
+          "name": "media_review_decisions_public_files_array",
+          "value": "jsonb_typeof(\"media_review_decisions\".\"public_file_ids\") = 'array' and jsonb_array_length(\"media_review_decisions\".\"public_file_ids\") between 0 and 3"
+        },
+        "media_review_decisions_actor_nonempty": {
+          "name": "media_review_decisions_actor_nonempty",
+          "value": "length(trim(\"media_review_decisions\".\"actor_id\")) > 0"
+        },
+        "media_review_decisions_reason_nonempty": {
+          "name": "media_review_decisions_reason_nonempty",
+          "value": "length(trim(\"media_review_decisions\".\"reason_code\")) > 0"
+        },
+        "media_review_decisions_fingerprint_nonempty": {
+          "name": "media_review_decisions_fingerprint_nonempty",
+          "value": "length(\"media_review_decisions\".\"request_fingerprint\") > 0"
+        },
+        "media_review_decisions_summary_required": {
+          "name": "media_review_decisions_summary_required",
+          "value": "\"media_review_decisions\".\"public_summary\" is not null or \"media_review_decisions\".\"internal_note\" is not null"
+        },
+        "media_review_decisions_time_order": {
+          "name": "media_review_decisions_time_order",
+          "value": "\"media_review_decisions\".\"expected_media_updated_at\" <= \"media_review_decisions\".\"decided_at\""
+        },
+        "media_review_decisions_private_approval_shape": {
+          "name": "media_review_decisions_private_approval_shape",
+          "value": "\"media_review_decisions\".\"action\" <> 'approve_private' or (\"media_review_decisions\".\"expected_review_status\" = 'pending' and \"media_review_decisions\".\"expected_purpose\" in ('evidence', 'owner_verification') and \"media_review_decisions\".\"expected_visibility\" = 'private' and \"media_review_decisions\".\"target_match\" = 'confirmed' and \"media_review_decisions\".\"privacy_review\" <> 'blocked' and \"media_review_decisions\".\"to_review_status\" = 'accepted' and \"media_review_decisions\".\"to_purpose\" = \"media_review_decisions\".\"expected_purpose\" and \"media_review_decisions\".\"to_visibility\" = 'private' and jsonb_array_length(\"media_review_decisions\".\"public_file_ids\") = 0)"
+        },
+        "media_review_decisions_public_approval_shape": {
+          "name": "media_review_decisions_public_approval_shape",
+          "value": "\"media_review_decisions\".\"action\" <> 'approve_public' or (\"media_review_decisions\".\"expected_review_status\" = 'pending' and \"media_review_decisions\".\"expected_purpose\" in ('public_gallery_candidate', 'canonical_logo') and \"media_review_decisions\".\"expected_visibility\" = 'private' and \"media_review_decisions\".\"target_match\" = 'confirmed' and \"media_review_decisions\".\"privacy_review\" = 'cleared' and \"media_review_decisions\".\"to_review_status\" = 'accepted' and \"media_review_decisions\".\"to_purpose\" in ('public_gallery', 'canonical_logo') and \"media_review_decisions\".\"to_rights_status\" in ('submitted_with_permission', 'licensed', 'public_domain') and \"media_review_decisions\".\"to_visibility\" = 'public' and \"media_review_decisions\".\"alt_text\" is not null and \"media_review_decisions\".\"display_order\" is not null and \"media_review_decisions\".\"public_display_file_id\" is not null and \"media_review_decisions\".\"published_at\" = \"media_review_decisions\".\"decided_at\")"
+        },
+        "media_review_decisions_reject_shape": {
+          "name": "media_review_decisions_reject_shape",
+          "value": "\"media_review_decisions\".\"action\" <> 'reject' or (\"media_review_decisions\".\"expected_review_status\" = 'pending' and \"media_review_decisions\".\"to_review_status\" = 'rejected' and \"media_review_decisions\".\"to_visibility\" = 'private' and jsonb_array_length(\"media_review_decisions\".\"public_file_ids\") = 0)"
+        },
+        "media_review_decisions_restrict_shape": {
+          "name": "media_review_decisions_restrict_shape",
+          "value": "\"media_review_decisions\".\"action\" <> 'restrict' or (\"media_review_decisions\".\"expected_review_status\" = 'accepted' and \"media_review_decisions\".\"expected_visibility\" = 'public' and \"media_review_decisions\".\"to_review_status\" = 'accepted' and \"media_review_decisions\".\"to_visibility\" = 'restricted')"
+        },
+        "media_review_decisions_supersede_shape": {
+          "name": "media_review_decisions_supersede_shape",
+          "value": "\"media_review_decisions\".\"action\" <> 'supersede' or (\"media_review_decisions\".\"expected_review_status\" = 'accepted' and \"media_review_decisions\".\"expected_purpose\" in ('public_gallery', 'canonical_logo') and \"media_review_decisions\".\"expected_visibility\" in ('public', 'restricted') and \"media_review_decisions\".\"to_review_status\" = 'superseded' and \"media_review_decisions\".\"to_visibility\" = 'restricted')"
+        },
+        "media_review_decisions_license_shape": {
+          "name": "media_review_decisions_license_shape",
+          "value": "\"media_review_decisions\".\"to_rights_status\" <> 'licensed' or \"media_review_decisions\".\"license_id\" is not null"
+        },
+        "media_review_decisions_permission_shape": {
+          "name": "media_review_decisions_permission_shape",
+          "value": "\"media_review_decisions\".\"to_rights_status\" <> 'submitted_with_permission' or \"media_review_decisions\".\"rights_holder\" is not null or \"media_review_decisions\".\"consent_reference\" is not null"
+        },
+        "media_review_decisions_attribution_shape": {
+          "name": "media_review_decisions_attribution_shape",
+          "value": "\"media_review_decisions\".\"license_attribution_required\" is not true or \"media_review_decisions\".\"attribution\" is not null"
+        },
+        "media_review_decisions_display_order_nonnegative": {
+          "name": "media_review_decisions_display_order_nonnegative",
+          "value": "\"media_review_decisions\".\"display_order\" is null or \"media_review_decisions\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "network_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "networks_slug_unique": {
+          "name": "networks_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "networks_status_idx": {
+          "name": "networks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_registry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_slug_unique": {
+          "name": "payment_methods_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_status_idx": {
+          "name": "payment_methods_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_routes": {
+      "name": "payment_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "route_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_registry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_routes_slug_unique": {
+          "name": "payment_routes_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_routes_status_idx": {
+          "name": "payment_routes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconfirmation_expirations": {
+      "name": "reconfirmation_expirations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_claim_status": {
+          "name": "from_claim_status",
+          "type": "acceptance_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_claim_status": {
+          "name": "to_claim_status",
+          "type": "acceptance_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_visibility": {
+          "name": "claim_visibility",
+          "type": "claim_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_event_id": {
+          "name": "verification_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_claim_updated_at": {
+          "name": "expected_claim_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_next_review_at": {
+          "name": "expected_next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "admin_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_summary": {
+          "name": "public_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reconfirmation_expirations_request_unique": {
+          "name": "reconfirmation_expirations_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconfirmation_expirations_claim_idx": {
+          "name": "reconfirmation_expirations_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconfirmation_expirations_event_idx": {
+          "name": "reconfirmation_expirations_event_idx",
+          "columns": [
+            {
+              "expression": "verification_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconfirmation_expirations_actor_idx": {
+          "name": "reconfirmation_expirations_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconfirmation_expirations_claim_id_acceptance_claims_id_fk": {
+          "name": "reconfirmation_expirations_claim_id_acceptance_claims_id_fk",
+          "tableFrom": "reconfirmation_expirations",
+          "tableTo": "acceptance_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reconfirmation_expirations_verification_event_id_verification_events_id_fk": {
+          "name": "reconfirmation_expirations_verification_event_id_verification_events_id_fk",
+          "tableFrom": "reconfirmation_expirations",
+          "tableTo": "verification_events",
+          "columnsFrom": [
+            "verification_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reconfirmation_expirations_status_shape": {
+          "name": "reconfirmation_expirations_status_shape",
+          "value": "\"reconfirmation_expirations\".\"from_claim_status\" = 'confirmed' and \"reconfirmation_expirations\".\"to_claim_status\" = 'stale'"
+        },
+        "reconfirmation_expirations_actor_shape": {
+          "name": "reconfirmation_expirations_actor_shape",
+          "value": "\"reconfirmation_expirations\".\"actor_type\" = 'system' and length(trim(\"reconfirmation_expirations\".\"actor_id\")) > 0"
+        },
+        "reconfirmation_expirations_reason_shape": {
+          "name": "reconfirmation_expirations_reason_shape",
+          "value": "\"reconfirmation_expirations\".\"reason_code\" = 'review_window_expired'"
+        },
+        "reconfirmation_expirations_summary_nonempty": {
+          "name": "reconfirmation_expirations_summary_nonempty",
+          "value": "\"reconfirmation_expirations\".\"public_summary\" is null or length(trim(\"reconfirmation_expirations\".\"public_summary\")) > 0"
+        },
+        "reconfirmation_expirations_note_nonempty": {
+          "name": "reconfirmation_expirations_note_nonempty",
+          "value": "\"reconfirmation_expirations\".\"internal_note\" is null or length(trim(\"reconfirmation_expirations\".\"internal_note\")) > 0"
+        },
+        "reconfirmation_expirations_time_order": {
+          "name": "reconfirmation_expirations_time_order",
+          "value": "\"reconfirmation_expirations\".\"expected_claim_updated_at\" <= \"reconfirmation_expirations\".\"effective_at\" and \"reconfirmation_expirations\".\"expected_next_review_at\" <= \"reconfirmation_expirations\".\"effective_at\""
+        },
+        "reconfirmation_expirations_fingerprint_nonempty": {
+          "name": "reconfirmation_expirations_fingerprint_nonempty",
+          "value": "length(\"reconfirmation_expirations\".\"request_fingerprint\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.candidate_duplicate_groups": {
+      "name": "candidate_duplicate_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "duplicate_group_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_duplicate_groups_status_idx": {
+          "name": "candidate_duplicate_groups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "candidate_duplicate_groups_resolution_note_nonempty": {
+          "name": "candidate_duplicate_groups_resolution_note_nonempty",
+          "value": "\"candidate_duplicate_groups\".\"resolution_note\" is null or length(trim(\"candidate_duplicate_groups\".\"resolution_note\")) > 0"
+        },
+        "candidate_duplicate_groups_resolution_time": {
+          "name": "candidate_duplicate_groups_resolution_time",
+          "value": "(\"candidate_duplicate_groups\".\"status\" = 'open' and \"candidate_duplicate_groups\".\"resolved_at\" is null) or (\"candidate_duplicate_groups\".\"status\" in ('resolved', 'dismissed') and \"candidate_duplicate_groups\".\"resolved_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.candidate_source_records": {
+      "name": "candidate_source_records",
+      "schema": "",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "candidate_source_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_source_records_source_idx": {
+          "name": "candidate_source_records_source_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "candidate_source_records_candidate_id_source_candidates_id_fk": {
+          "name": "candidate_source_records_candidate_id_source_candidates_id_fk",
+          "tableFrom": "candidate_source_records",
+          "tableTo": "source_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "candidate_source_records_source_record_id_source_records_id_fk": {
+          "name": "candidate_source_records_source_record_id_source_records_id_fk",
+          "tableFrom": "candidate_source_records",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "candidate_source_records_pk": {
+          "name": "candidate_source_records_pk",
+          "columns": [
+            "candidate_id",
+            "source_record_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.licenses": {
+      "name": "licenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_required": {
+          "name": "attribution_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share_alike": {
+          "name": "share_alike",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "licenses_slug_unique": {
+          "name": "licenses_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "licenses_slug_nonempty": {
+          "name": "licenses_slug_nonempty",
+          "value": "length(trim(\"licenses\".\"slug\")) > 0"
+        },
+        "licenses_name_nonempty": {
+          "name": "licenses_name_nonempty",
+          "value": "length(trim(\"licenses\".\"name\")) > 0"
+        },
+        "licenses_url_nonempty": {
+          "name": "licenses_url_nonempty",
+          "value": "\"licenses\".\"url\" is null or length(trim(\"licenses\".\"url\")) > 0"
+        },
+        "licenses_notes_nonempty": {
+          "name": "licenses_notes_nonempty",
+          "value": "\"licenses\".\"notes\" is null or length(trim(\"licenses\".\"notes\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provenance_links": {
+      "name": "provenance_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "provenance_subject_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_id": {
+          "name": "license_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance_role": {
+          "name": "provenance_role",
+          "type": "provenance_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provenance_links_record_unique": {
+          "name": "provenance_links_record_unique",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provenance_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provenance_links\".\"field_path\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provenance_links_field_unique": {
+          "name": "provenance_links_field_unique",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provenance_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provenance_links\".\"field_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provenance_links_subject_idx": {
+          "name": "provenance_links_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provenance_links_source_record_idx": {
+          "name": "provenance_links_source_record_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provenance_links_license_idx": {
+          "name": "provenance_links_license_idx",
+          "columns": [
+            {
+              "expression": "license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provenance_links_source_record_id_source_records_id_fk": {
+          "name": "provenance_links_source_record_id_source_records_id_fk",
+          "tableFrom": "provenance_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "provenance_links_license_id_licenses_id_fk": {
+          "name": "provenance_links_license_id_licenses_id_fk",
+          "tableFrom": "provenance_links",
+          "tableTo": "licenses",
+          "columnsFrom": [
+            "license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provenance_links_field_path_nonempty": {
+          "name": "provenance_links_field_path_nonempty",
+          "value": "\"provenance_links\".\"field_path\" is null or length(trim(\"provenance_links\".\"field_path\")) > 0"
+        },
+        "provenance_links_effective_order": {
+          "name": "provenance_links_effective_order",
+          "value": "\"provenance_links\".\"effective_from\" is null or \"provenance_links\".\"effective_to\" is null or \"provenance_links\".\"effective_from\" <= \"provenance_links\".\"effective_to\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_candidates": {
+      "name": "source_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "candidate_type": {
+          "name": "candidate_type",
+          "type": "candidate_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_status": {
+          "name": "candidate_status",
+          "type": "candidate_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_group_id": {
+          "name": "duplicate_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_location_id": {
+          "name": "canonical_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_candidates_status_priority_idx": {
+          "name": "source_candidates_status_priority_idx",
+          "columns": [
+            {
+              "expression": "candidate_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_candidates_normalized_name_idx": {
+          "name": "source_candidates_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_candidates_duplicate_group_idx": {
+          "name": "source_candidates_duplicate_group_idx",
+          "columns": [
+            {
+              "expression": "duplicate_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_candidates_canonical_entity_idx": {
+          "name": "source_candidates_canonical_entity_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_candidates_canonical_location_idx": {
+          "name": "source_candidates_canonical_location_idx",
+          "columns": [
+            {
+              "expression": "canonical_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_candidates_import_batch_idx": {
+          "name": "source_candidates_import_batch_idx",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_candidates_duplicate_group_id_candidate_duplicate_groups_id_fk": {
+          "name": "source_candidates_duplicate_group_id_candidate_duplicate_groups_id_fk",
+          "tableFrom": "source_candidates",
+          "tableTo": "candidate_duplicate_groups",
+          "columnsFrom": [
+            "duplicate_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "source_candidates_canonical_entity_id_entities_id_fk": {
+          "name": "source_candidates_canonical_entity_id_entities_id_fk",
+          "tableFrom": "source_candidates",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "canonical_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "source_candidates_canonical_location_id_locations_id_fk": {
+          "name": "source_candidates_canonical_location_id_locations_id_fk",
+          "tableFrom": "source_candidates",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "canonical_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_candidates_normalized_name_nonempty": {
+          "name": "source_candidates_normalized_name_nonempty",
+          "value": "length(trim(\"source_candidates\".\"normalized_name\")) > 0"
+        },
+        "source_candidates_priority_range": {
+          "name": "source_candidates_priority_range",
+          "value": "\"source_candidates\".\"priority\" is null or \"source_candidates\".\"priority\" between 0 and 1000"
+        },
+        "source_candidates_seen_order": {
+          "name": "source_candidates_seen_order",
+          "value": "\"source_candidates\".\"first_seen_at\" <= \"source_candidates\".\"last_seen_at\""
+        },
+        "source_candidates_location_type": {
+          "name": "source_candidates_location_type",
+          "value": "\"source_candidates\".\"canonical_location_id\" is null or \"source_candidates\".\"candidate_type\" = 'physical_place'"
+        },
+        "source_candidates_linked_canonical": {
+          "name": "source_candidates_linked_canonical",
+          "value": "\"source_candidates\".\"candidate_status\" not in ('linked', 'promoted') or \"source_candidates\".\"canonical_entity_id\" is not null or \"source_candidates\".\"canonical_location_id\" is not null"
+        },
+        "source_candidates_duplicate_group": {
+          "name": "source_candidates_duplicate_group",
+          "value": "\"source_candidates\".\"candidate_status\" <> 'duplicate' or \"source_candidates\".\"duplicate_group_id\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_records": {
+      "name": "source_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_url": {
+          "name": "archive_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_id": {
+          "name": "license_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_records_external_identity_unique": {
+          "name": "source_records_external_identity_unique",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"source_records\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_records_source_fetched_idx": {
+          "name": "source_records_source_fetched_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_records_content_hash_idx": {
+          "name": "source_records_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_records_license_idx": {
+          "name": "source_records_license_idx",
+          "columns": [
+            {
+              "expression": "license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_sources_id_fk": {
+          "name": "source_records_source_id_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "source_records_license_id_licenses_id_fk": {
+          "name": "source_records_license_id_licenses_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "licenses",
+          "columnsFrom": [
+            "license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_records_identity_required": {
+          "name": "source_records_identity_required",
+          "value": "\"source_records\".\"external_id\" is not null or \"source_records\".\"source_url\" is not null or \"source_records\".\"content_hash\" is not null"
+        },
+        "source_records_external_id_nonempty": {
+          "name": "source_records_external_id_nonempty",
+          "value": "\"source_records\".\"external_id\" is null or length(trim(\"source_records\".\"external_id\")) > 0"
+        },
+        "source_records_source_url_nonempty": {
+          "name": "source_records_source_url_nonempty",
+          "value": "\"source_records\".\"source_url\" is null or length(trim(\"source_records\".\"source_url\")) > 0"
+        },
+        "source_records_archive_url_nonempty": {
+          "name": "source_records_archive_url_nonempty",
+          "value": "\"source_records\".\"archive_url\" is null or length(trim(\"source_records\".\"archive_url\")) > 0"
+        },
+        "source_records_content_hash_nonempty": {
+          "name": "source_records_content_hash_nonempty",
+          "value": "\"source_records\".\"content_hash\" is null or length(trim(\"source_records\".\"content_hash\")) > 0"
+        },
+        "source_records_archive_requires_source": {
+          "name": "source_records_archive_requires_source",
+          "value": "\"source_records\".\"archive_url\" is null or \"source_records\".\"source_url\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_license_id": {
+          "name": "default_license_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sources_type_active_idx": {
+          "name": "sources_type_active_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sources_default_license_idx": {
+          "name": "sources_default_license_idx",
+          "columns": [
+            {
+              "expression": "default_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sources_default_license_id_licenses_id_fk": {
+          "name": "sources_default_license_id_licenses_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "licenses",
+          "columnsFrom": [
+            "default_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sources_name_nonempty": {
+          "name": "sources_name_nonempty",
+          "value": "length(trim(\"sources\".\"name\")) > 0"
+        },
+        "sources_base_url_nonempty": {
+          "name": "sources_base_url_nonempty",
+          "value": "\"sources\".\"base_url\" is null or length(trim(\"sources\".\"base_url\")) > 0"
+        },
+        "sources_attribution_nonempty": {
+          "name": "sources_attribution_nonempty",
+          "value": "\"sources\".\"attribution_text\" is null or length(trim(\"sources\".\"attribution_text\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quarantine_upload_reservations": {
+      "name": "quarantine_upload_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intake_request_id": {
+          "name": "intake_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "quarantine_upload_reservation_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_by_submission_id": {
+          "name": "consumed_by_submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quarantine_upload_reservations_owner_expiry_idx": {
+          "name": "quarantine_upload_reservations_owner_expiry_idx",
+          "columns": [
+            {
+              "expression": "intake_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quarantine_upload_reservations_consumed_submission_idx": {
+          "name": "quarantine_upload_reservations_consumed_submission_idx",
+          "columns": [
+            {
+              "expression": "consumed_by_submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quarantine_upload_reservations_consumed_by_submission_id_submissions_id_fk": {
+          "name": "quarantine_upload_reservations_consumed_by_submission_id_submissions_id_fk",
+          "tableFrom": "quarantine_upload_reservations",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "consumed_by_submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "quarantine_upload_reservations_consumption_pair": {
+          "name": "quarantine_upload_reservations_consumption_pair",
+          "value": "(\"quarantine_upload_reservations\".\"consumed_by_submission_id\" is null and \"quarantine_upload_reservations\".\"consumed_at\" is null) or (\"quarantine_upload_reservations\".\"consumed_by_submission_id\" is not null and \"quarantine_upload_reservations\".\"consumed_at\" is not null)"
+        },
+        "quarantine_upload_reservations_time_order": {
+          "name": "quarantine_upload_reservations_time_order",
+          "value": "\"quarantine_upload_reservations\".\"created_at\" < \"quarantine_upload_reservations\".\"expires_at\" and (\"quarantine_upload_reservations\".\"consumed_at\" is null or \"quarantine_upload_reservations\".\"created_at\" <= \"quarantine_upload_reservations\".\"consumed_at\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.submission_contacts": {
+      "name": "submission_contacts",
+      "schema": "",
+      "columns": {
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encrypted_email": {
+          "name": "encrypted_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_allowed": {
+          "name": "contact_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_until": {
+          "name": "retention_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "submission_contacts_email_hash_idx": {
+          "name": "submission_contacts_email_hash_idx",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submission_contacts_retention_idx": {
+          "name": "submission_contacts_retention_idx",
+          "columns": [
+            {
+              "expression": "retention_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_contacts_submission_id_submissions_id_fk": {
+          "name": "submission_contacts_submission_id_submissions_id_fk",
+          "tableFrom": "submission_contacts",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "submission_contacts_encrypted_email_nonempty": {
+          "name": "submission_contacts_encrypted_email_nonempty",
+          "value": "length(\"submission_contacts\".\"encrypted_email\") > 0"
+        },
+        "submission_contacts_email_hash_sha256": {
+          "name": "submission_contacts_email_hash_sha256",
+          "value": "\"submission_contacts\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.submission_events": {
+      "name": "submission_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "submission_workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "submission_workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "submission_event_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "submission_events_submission_created_idx": {
+          "name": "submission_events_submission_created_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submission_events_actor_created_idx": {
+          "name": "submission_events_actor_created_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_events_submission_id_submissions_id_fk": {
+          "name": "submission_events_submission_id_submissions_id_fk",
+          "tableFrom": "submission_events",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "submission_events_action_nonempty": {
+          "name": "submission_events_action_nonempty",
+          "value": "length(trim(\"submission_events\".\"action\")) > 0"
+        },
+        "submission_events_actor_nonempty": {
+          "name": "submission_events_actor_nonempty",
+          "value": "length(trim(\"submission_events\".\"actor_id\")) > 0"
+        },
+        "submission_events_reason_nonempty": {
+          "name": "submission_events_reason_nonempty",
+          "value": "\"submission_events\".\"reason_code\" is null or length(trim(\"submission_events\".\"reason_code\")) > 0"
+        },
+        "submission_events_note_nonempty": {
+          "name": "submission_events_note_nonempty",
+          "value": "\"submission_events\".\"internal_note\" is null or length(trim(\"submission_events\".\"internal_note\")) > 0"
+        },
+        "submission_events_status_change": {
+          "name": "submission_events_status_change",
+          "value": "\"submission_events\".\"from_status\" is null or \"submission_events\".\"from_status\" <> \"submission_events\".\"to_status\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.submission_payloads": {
+      "name": "submission_payloads",
+      "schema": "",
+      "columns": {
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "original_payload": {
+          "name": "original_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_changes": {
+          "name": "proposed_changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submission_payloads_submission_id_submissions_id_fk": {
+          "name": "submission_payloads_submission_id_submissions_id_fk",
+          "tableFrom": "submission_payloads",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "submission_payloads_original_object": {
+          "name": "submission_payloads_original_object",
+          "value": "jsonb_typeof(\"submission_payloads\".\"original_payload\") = 'object'"
+        },
+        "submission_payloads_normalized_object": {
+          "name": "submission_payloads_normalized_object",
+          "value": "\"submission_payloads\".\"normalized_payload\" is null or jsonb_typeof(\"submission_payloads\".\"normalized_payload\") = 'object'"
+        },
+        "submission_payloads_proposed_object": {
+          "name": "submission_payloads_proposed_object",
+          "value": "\"submission_payloads\".\"proposed_changes\" is null or jsonb_typeof(\"submission_payloads\".\"proposed_changes\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.submission_public_reference_counters": {
+      "name": "submission_public_reference_counters",
+      "schema": "",
+      "columns": {
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "next_sequence": {
+          "name": "next_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "submission_public_reference_year_range": {
+          "name": "submission_public_reference_year_range",
+          "value": "\"submission_public_reference_counters\".\"year\" between 2000 and 9999"
+        },
+        "submission_public_reference_sequence_range": {
+          "name": "submission_public_reference_sequence_range",
+          "value": "\"submission_public_reference_counters\".\"next_sequence\" between 2 and 1000000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intake_request_id": {
+          "name": "intake_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(17)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "submission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "submission_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "submission_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_status": {
+          "name": "workflow_status",
+          "type": "submission_workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "submission_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status_token_hash": {
+          "name": "status_token_hash",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "submissions_intake_request_unique": {
+          "name": "submissions_intake_request_unique",
+          "columns": [
+            {
+              "expression": "intake_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_public_id_unique": {
+          "name": "submissions_public_id_unique",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_status_token_hash_unique": {
+          "name": "submissions_status_token_hash_unique",
+          "columns": [
+            {
+              "expression": "status_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_workflow_priority_idx": {
+          "name": "submissions_workflow_priority_idx",
+          "columns": [
+            {
+              "expression": "workflow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_type_submitted_idx": {
+          "name": "submissions_type_submitted_idx",
+          "columns": [
+            {
+              "expression": "submission_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_target_idx": {
+          "name": "submissions_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "submissions_request_fingerprint_sha256": {
+          "name": "submissions_request_fingerprint_sha256",
+          "value": "\"submissions\".\"request_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "submissions_public_id_shape": {
+          "name": "submissions_public_id_shape",
+          "value": "\"submissions\".\"public_id\" ~ '^CPM-S-[0-9]{4}-[0-9]{6}$'"
+        },
+        "submissions_status_token_hash_shape": {
+          "name": "submissions_status_token_hash_shape",
+          "value": "\"submissions\".\"status_token_hash\" ~ '^sha256:[a-f0-9]{64}$'"
+        },
+        "submissions_priority_range": {
+          "name": "submissions_priority_range",
+          "value": "\"submissions\".\"priority\" between 0 and 1000"
+        },
+        "submissions_target_pair": {
+          "name": "submissions_target_pair",
+          "value": "(\"submissions\".\"target_type\" is null and \"submissions\".\"target_id\" is null) or (\"submissions\".\"target_type\" is not null and \"submissions\".\"target_id\" is not null)"
+        },
+        "submissions_resolved_requires_resolution": {
+          "name": "submissions_resolved_requires_resolution",
+          "value": "\"submissions\".\"workflow_status\" <> 'resolved' or \"submissions\".\"resolution\" is not null"
+        },
+        "submissions_duplicate_resolution_shape": {
+          "name": "submissions_duplicate_resolution_shape",
+          "value": "\"submissions\".\"workflow_status\" <> 'duplicate' or \"submissions\".\"resolution\" is null or \"submissions\".\"resolution\" = 'duplicate'"
+        },
+        "submissions_withdrawn_resolution_shape": {
+          "name": "submissions_withdrawn_resolution_shape",
+          "value": "\"submissions\".\"workflow_status\" <> 'withdrawn' or \"submissions\".\"resolution\" is null or \"submissions\".\"resolution\" = 'withdrawn'"
+        },
+        "submissions_update_order": {
+          "name": "submissions_update_order",
+          "value": "\"submissions\".\"submitted_at\" <= \"submissions\".\"updated_at\""
+        },
+        "submissions_resolved_time_order": {
+          "name": "submissions_resolved_time_order",
+          "value": "\"submissions\".\"resolved_at\" is null or (\"submissions\".\"submitted_at\" <= \"submissions\".\"resolved_at\" and \"submissions\".\"resolved_at\" <= \"submissions\".\"updated_at\")"
+        },
+        "submissions_withdrawn_time_order": {
+          "name": "submissions_withdrawn_time_order",
+          "value": "\"submissions\".\"withdrawn_at\" is null or (\"submissions\".\"submitted_at\" <= \"submissions\".\"withdrawn_at\" and \"submissions\".\"withdrawn_at\" <= \"submissions\".\"updated_at\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_event_evidence": {
+      "name": "verification_event_evidence",
+      "schema": "",
+      "columns": {
+        "verification_event_id": {
+          "name": "verification_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_id": {
+          "name": "evidence_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "verification_evidence_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_event_evidence_evidence_idx": {
+          "name": "verification_event_evidence_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_event_evidence_verification_event_id_verification_events_id_fk": {
+          "name": "verification_event_evidence_verification_event_id_verification_events_id_fk",
+          "tableFrom": "verification_event_evidence",
+          "tableTo": "verification_events",
+          "columnsFrom": [
+            "verification_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "verification_event_evidence_evidence_id_evidence_id_fk": {
+          "name": "verification_event_evidence_evidence_id_evidence_id_fk",
+          "tableFrom": "verification_event_evidence",
+          "tableTo": "evidence",
+          "columnsFrom": [
+            "evidence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "verification_event_evidence_pk": {
+          "name": "verification_event_evidence_pk",
+          "columns": [
+            "verification_event_id",
+            "evidence_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_events": {
+      "name": "verification_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "verification_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "acceptance_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "acceptance_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_visibility": {
+          "name": "from_visibility",
+          "type": "claim_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_visibility": {
+          "name": "to_visibility",
+          "type": "claim_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_summary": {
+          "name": "public_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "verification_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operator'"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_events_claim_effective_idx": {
+          "name": "verification_events_claim_effective_idx",
+          "columns": [
+            {
+              "expression": "claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_events_type_idx": {
+          "name": "verification_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_events_reason_idx": {
+          "name": "verification_events_reason_idx",
+          "columns": [
+            {
+              "expression": "reason_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_events_claim_id_acceptance_claims_id_fk": {
+          "name": "verification_events_claim_id_acceptance_claims_id_fk",
+          "tableFrom": "verification_events",
+          "tableTo": "acceptance_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_events_reason_nonempty": {
+          "name": "verification_events_reason_nonempty",
+          "value": "length(trim(\"verification_events\".\"reason_code\")) > 0"
+        },
+        "verification_events_public_summary_nonempty": {
+          "name": "verification_events_public_summary_nonempty",
+          "value": "\"verification_events\".\"public_summary\" is null or length(trim(\"verification_events\".\"public_summary\")) > 0"
+        },
+        "verification_events_internal_note_nonempty": {
+          "name": "verification_events_internal_note_nonempty",
+          "value": "\"verification_events\".\"internal_note\" is null or length(trim(\"verification_events\".\"internal_note\")) > 0"
+        },
+        "verification_events_operator_actor": {
+          "name": "verification_events_operator_actor",
+          "value": "\"verification_events\".\"actor_type\" <> 'operator' or \"verification_events\".\"actor_id\" is not null"
+        },
+        "verification_events_transition_present": {
+          "name": "verification_events_transition_present",
+          "value": "\"verification_events\".\"to_status\" is not null or \"verification_events\".\"to_visibility\" is not null or \"verification_events\".\"event_type\" = 'corrected'"
+        },
+        "verification_events_status_event_shape": {
+          "name": "verification_events_status_event_shape",
+          "value": "\"verification_events\".\"event_type\" not in ('confirmed', 'reconfirmed', 'marked_stale', 'ended', 'rejected', 'restored') or (\"verification_events\".\"from_visibility\" is null and \"verification_events\".\"to_visibility\" is null)"
+        },
+        "verification_events_visibility_event_shape": {
+          "name": "verification_events_visibility_event_shape",
+          "value": "\"verification_events\".\"event_type\" not in ('hidden', 'unhidden') or (\"verification_events\".\"from_status\" is null and \"verification_events\".\"to_status\" is null)"
+        },
+        "verification_events_corrected_shape": {
+          "name": "verification_events_corrected_shape",
+          "value": "\"verification_events\".\"event_type\" <> 'corrected' or (\"verification_events\".\"from_status\" is null and \"verification_events\".\"to_status\" is null and \"verification_events\".\"from_visibility\" is null and \"verification_events\".\"to_visibility\" is null and (\"verification_events\".\"public_summary\" is not null or \"verification_events\".\"internal_note\" is not null))"
+        },
+        "verification_events_confirmed_transition": {
+          "name": "verification_events_confirmed_transition",
+          "value": "\"verification_events\".\"event_type\" <> 'confirmed' or (\"verification_events\".\"to_status\" = 'confirmed' and (\"verification_events\".\"from_status\" is null or \"verification_events\".\"from_status\" = 'candidate'))"
+        },
+        "verification_events_reconfirmed_transition": {
+          "name": "verification_events_reconfirmed_transition",
+          "value": "\"verification_events\".\"event_type\" <> 'reconfirmed' or (\"verification_events\".\"from_status\" = 'confirmed' and \"verification_events\".\"to_status\" = 'confirmed')"
+        },
+        "verification_events_stale_transition": {
+          "name": "verification_events_stale_transition",
+          "value": "\"verification_events\".\"event_type\" <> 'marked_stale' or (\"verification_events\".\"from_status\" = 'confirmed' and \"verification_events\".\"to_status\" = 'stale')"
+        },
+        "verification_events_ended_transition": {
+          "name": "verification_events_ended_transition",
+          "value": "\"verification_events\".\"event_type\" <> 'ended' or (\"verification_events\".\"from_status\" in ('confirmed', 'stale') and \"verification_events\".\"to_status\" = 'ended')"
+        },
+        "verification_events_rejected_transition": {
+          "name": "verification_events_rejected_transition",
+          "value": "\"verification_events\".\"event_type\" <> 'rejected' or (\"verification_events\".\"from_status\" = 'candidate' and \"verification_events\".\"to_status\" = 'rejected')"
+        },
+        "verification_events_restored_transition": {
+          "name": "verification_events_restored_transition",
+          "value": "\"verification_events\".\"event_type\" <> 'restored' or (\"verification_events\".\"from_status\" = 'stale' and \"verification_events\".\"to_status\" = 'confirmed')"
+        },
+        "verification_events_hidden_transition": {
+          "name": "verification_events_hidden_transition",
+          "value": "\"verification_events\".\"event_type\" <> 'hidden' or (\"verification_events\".\"to_visibility\" in ('hidden', 'temporarily_hidden') and (\"verification_events\".\"from_visibility\" is null or \"verification_events\".\"from_visibility\" = 'public'))"
+        },
+        "verification_events_unhidden_transition": {
+          "name": "verification_events_unhidden_transition",
+          "value": "\"verification_events\".\"event_type\" <> 'unhidden' or (\"verification_events\".\"from_visibility\" in ('hidden', 'temporarily_hidden') and \"verification_events\".\"to_visibility\" = 'public')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.acceptance_claim_status": {
+      "name": "acceptance_claim_status",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "confirmed",
+        "stale",
+        "ended",
+        "rejected"
+      ]
+    },
+    "public.claim_visibility": {
+      "name": "claim_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "hidden",
+        "temporarily_hidden"
+      ]
+    },
+    "public.route_type": {
+      "name": "route_type",
+      "schema": "public",
+      "values": [
+        "direct_wallet",
+        "processor_checkout"
+      ]
+    },
+    "public.submission_resolution": {
+      "name": "submission_resolution",
+      "schema": "public",
+      "values": [
+        "approved",
+        "partially_approved",
+        "accepted_as_candidate",
+        "not_approved",
+        "duplicate",
+        "no_change",
+        "withdrawn"
+      ]
+    },
+    "public.submission_workflow_status": {
+      "name": "submission_workflow_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "triage",
+        "in_review",
+        "needs_information",
+        "on_hold",
+        "resolved",
+        "duplicate",
+        "rejected_spam",
+        "withdrawn"
+      ]
+    },
+    "public.acceptance_scope": {
+      "name": "acceptance_scope",
+      "schema": "public",
+      "values": [
+        "all_checkout",
+        "selected_products",
+        "new_purchase_only",
+        "renewal_only",
+        "region_limited",
+        "temporary"
+      ]
+    },
+    "public.claim_region_inclusion": {
+      "name": "claim_region_inclusion",
+      "schema": "public",
+      "values": [
+        "include",
+        "exclude"
+      ]
+    },
+    "public.claim_scope": {
+      "name": "claim_scope",
+      "schema": "public",
+      "values": [
+        "location_specific",
+        "brand_region",
+        "brand_global",
+        "online_service",
+        "platform_capability"
+      ]
+    },
+    "public.merchant_receives": {
+      "name": "merchant_receives",
+      "schema": "public",
+      "values": [
+        "crypto",
+        "fiat",
+        "crypto_or_fiat",
+        "not_publicly_confirmed"
+      ]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "deprecated"
+      ]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "native",
+        "token",
+        "other"
+      ]
+    },
+    "public.candidate_duplicate_decision_action": {
+      "name": "candidate_duplicate_decision_action",
+      "schema": "public",
+      "values": [
+        "confirm_duplicate",
+        "dismiss_signal"
+      ]
+    },
+    "public.candidate_duplicate_decision_reason": {
+      "name": "candidate_duplicate_decision_reason",
+      "schema": "public",
+      "values": [
+        "same_osm_identity",
+        "same_physical_location",
+        "same_official_domain",
+        "same_online_service",
+        "manual_match",
+        "different_location",
+        "different_business",
+        "different_service",
+        "insufficient_evidence",
+        "stale_signal",
+        "other"
+      ]
+    },
+    "public.candidate_duplicate_signal_reason": {
+      "name": "candidate_duplicate_signal_reason",
+      "schema": "public",
+      "values": [
+        "shared_osm_identity",
+        "same_name_and_coordinates",
+        "shared_official_domain",
+        "same_normalized_name"
+      ]
+    },
+    "public.candidate_duplicate_signal_strength": {
+      "name": "candidate_duplicate_signal_strength",
+      "schema": "public",
+      "values": [
+        "strong",
+        "review"
+      ]
+    },
+    "public.entity_status": {
+      "name": "entity_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "ended",
+        "unknown"
+      ]
+    },
+    "public.entity_type": {
+      "name": "entity_type",
+      "schema": "public",
+      "values": [
+        "merchant",
+        "online_service",
+        "payment_processor",
+        "payment_program",
+        "platform"
+      ]
+    },
+    "public.evidence_class": {
+      "name": "evidence_class",
+      "schema": "public",
+      "values": [
+        "a",
+        "b",
+        "c"
+      ]
+    },
+    "public.evidence_kind": {
+      "name": "evidence_kind",
+      "schema": "public",
+      "values": [
+        "live_checkout",
+        "official_payment_page",
+        "verified_representative",
+        "payment_proof",
+        "official_social",
+        "processor_case_study",
+        "dated_osm_observation",
+        "independent_user_report",
+        "directory_listing",
+        "undated_osm_tag",
+        "article",
+        "search_snippet",
+        "platform_capability",
+        "other"
+      ]
+    },
+    "public.evidence_origin_role": {
+      "name": "evidence_origin_role",
+      "schema": "public",
+      "values": [
+        "merchant_side",
+        "processor_side",
+        "usage_side",
+        "on_ground",
+        "osm_side",
+        "directory",
+        "other"
+      ]
+    },
+    "public.evidence_polarity": {
+      "name": "evidence_polarity",
+      "schema": "public",
+      "values": [
+        "supporting",
+        "contradicting",
+        "neutral"
+      ]
+    },
+    "public.evidence_review_status": {
+      "name": "evidence_review_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.evidence_source_type": {
+      "name": "evidence_source_type",
+      "schema": "public",
+      "values": [
+        "official_page",
+        "official_social",
+        "processor",
+        "openstreetmap",
+        "directory",
+        "article",
+        "search",
+        "user_submission",
+        "business_representative",
+        "live_observation",
+        "payment_proof",
+        "other"
+      ]
+    },
+    "public.evidence_visibility": {
+      "name": "evidence_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "restricted"
+      ]
+    },
+    "public.evidence_review_claim_action": {
+      "name": "evidence_review_claim_action",
+      "schema": "public",
+      "values": [
+        "no_change",
+        "confirm",
+        "mark_stale",
+        "end",
+        "reject"
+      ]
+    },
+    "public.evidence_review_disposition": {
+      "name": "evidence_review_disposition",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected",
+        "held"
+      ]
+    },
+    "public.evidence_review_finding": {
+      "name": "evidence_review_finding",
+      "schema": "public",
+      "values": [
+        "supports_claim",
+        "contradicts_claim",
+        "insufficient"
+      ]
+    },
+    "public.export_activation_status": {
+      "name": "export_activation_status",
+      "schema": "public",
+      "values": [
+        "active"
+      ]
+    },
+    "public.export_release_action": {
+      "name": "export_release_action",
+      "schema": "public",
+      "values": [
+        "approve",
+        "reject"
+      ]
+    },
+    "public.export_release_candidate_status": {
+      "name": "export_release_candidate_status",
+      "schema": "public",
+      "values": [
+        "eligible",
+        "blocked"
+      ]
+    },
+    "public.export_release_status": {
+      "name": "export_release_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.admin_actor_type": {
+      "name": "admin_actor_type",
+      "schema": "public",
+      "values": [
+        "human",
+        "system"
+      ]
+    },
+    "public.import_kind": {
+      "name": "import_kind",
+      "schema": "public",
+      "values": [
+        "physical_place",
+        "online_service"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "temporarily_closed",
+        "closed",
+        "unknown"
+      ]
+    },
+    "public.osm_element_type": {
+      "name": "osm_element_type",
+      "schema": "public",
+      "values": [
+        "node",
+        "way",
+        "relation"
+      ]
+    },
+    "public.legacy_migration_status": {
+      "name": "legacy_migration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "mapped",
+        "unresolved",
+        "retired"
+      ]
+    },
+    "public.legacy_source_system": {
+      "name": "legacy_source_system",
+      "schema": "public",
+      "values": [
+        "cryptopaymap_v2",
+        "crypto_acceptance_registry"
+      ]
+    },
+    "public.media_purpose": {
+      "name": "media_purpose",
+      "schema": "public",
+      "values": [
+        "evidence",
+        "owner_verification",
+        "public_gallery_candidate",
+        "public_gallery",
+        "canonical_logo"
+      ]
+    },
+    "public.media_review_status": {
+      "name": "media_review_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.media_rights_status": {
+      "name": "media_rights_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "submitted_with_permission",
+        "licensed",
+        "public_domain",
+        "restricted"
+      ]
+    },
+    "public.media_role": {
+      "name": "media_role",
+      "schema": "public",
+      "values": [
+        "cover",
+        "gallery",
+        "exterior",
+        "interior",
+        "product",
+        "menu",
+        "payment_sign",
+        "checkout_terminal",
+        "logo",
+        "evidence_image",
+        "owner_verification_proof"
+      ]
+    },
+    "public.media_storage_scope": {
+      "name": "media_storage_scope",
+      "schema": "public",
+      "values": [
+        "quarantine",
+        "private",
+        "public"
+      ]
+    },
+    "public.media_variant": {
+      "name": "media_variant",
+      "schema": "public",
+      "values": [
+        "original",
+        "display",
+        "thumbnail"
+      ]
+    },
+    "public.media_visibility": {
+      "name": "media_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public",
+        "restricted"
+      ]
+    },
+    "public.media_review_action": {
+      "name": "media_review_action",
+      "schema": "public",
+      "values": [
+        "approve_private",
+        "approve_public",
+        "reject",
+        "restrict",
+        "supersede"
+      ]
+    },
+    "public.media_review_privacy": {
+      "name": "media_review_privacy",
+      "schema": "public",
+      "values": [
+        "cleared",
+        "private_only",
+        "blocked"
+      ]
+    },
+    "public.media_review_subject_type": {
+      "name": "media_review_subject_type",
+      "schema": "public",
+      "values": [
+        "entity",
+        "location",
+        "claim",
+        "evidence",
+        "submission",
+        "source_record"
+      ]
+    },
+    "public.media_review_target_match": {
+      "name": "media_review_target_match",
+      "schema": "public",
+      "values": [
+        "confirmed",
+        "uncertain",
+        "wrong_target"
+      ]
+    },
+    "public.network_status": {
+      "name": "network_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "deprecated"
+      ]
+    },
+    "public.payment_registry_status": {
+      "name": "payment_registry_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "deprecated"
+      ]
+    },
+    "public.candidate_source_relationship": {
+      "name": "candidate_source_relationship",
+      "schema": "public",
+      "values": [
+        "origin",
+        "supporting",
+        "contradiction",
+        "update",
+        "duplicate_signal"
+      ]
+    },
+    "public.candidate_status": {
+      "name": "candidate_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "triaged",
+        "linked",
+        "promoted",
+        "duplicate",
+        "rejected",
+        "archived"
+      ]
+    },
+    "public.candidate_type": {
+      "name": "candidate_type",
+      "schema": "public",
+      "values": [
+        "physical_place",
+        "online_service",
+        "payment_processor",
+        "payment_program",
+        "platform"
+      ]
+    },
+    "public.duplicate_group_status": {
+      "name": "duplicate_group_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "resolved",
+        "dismissed"
+      ]
+    },
+    "public.provenance_role": {
+      "name": "provenance_role",
+      "schema": "public",
+      "values": [
+        "origin",
+        "verification",
+        "correction",
+        "attribution"
+      ]
+    },
+    "public.provenance_subject_type": {
+      "name": "provenance_subject_type",
+      "schema": "public",
+      "values": [
+        "entity",
+        "location",
+        "acceptance_claim",
+        "claim_asset",
+        "evidence",
+        "verification_event",
+        "media"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "osm",
+        "official_site",
+        "official_social",
+        "processor",
+        "directory",
+        "user_submission",
+        "legacy_import",
+        "business_representative",
+        "live_observation",
+        "payment_proof",
+        "other"
+      ]
+    },
+    "public.quarantine_upload_reservation_purpose": {
+      "name": "quarantine_upload_reservation_purpose",
+      "schema": "public",
+      "values": [
+        "evidence_image",
+        "owner_verification_proof",
+        "public_gallery_candidate"
+      ]
+    },
+    "public.submission_event_actor_type": {
+      "name": "submission_event_actor_type",
+      "schema": "public",
+      "values": [
+        "submitter",
+        "reviewer",
+        "system"
+      ]
+    },
+    "public.submission_relationship": {
+      "name": "submission_relationship",
+      "schema": "public",
+      "values": [
+        "customer",
+        "employee",
+        "owner_or_authorized_representative",
+        "payment_provider",
+        "independent_researcher",
+        "other"
+      ]
+    },
+    "public.submission_target_type": {
+      "name": "submission_target_type",
+      "schema": "public",
+      "values": [
+        "entity",
+        "location",
+        "claim",
+        "new_record"
+      ]
+    },
+    "public.submission_type": {
+      "name": "submission_type",
+      "schema": "public",
+      "values": [
+        "suggest",
+        "payment_report",
+        "problem_report",
+        "claim",
+        "photos"
+      ]
+    },
+    "public.verification_actor_type": {
+      "name": "verification_actor_type",
+      "schema": "public",
+      "values": [
+        "operator",
+        "system",
+        "import"
+      ]
+    },
+    "public.verification_event_type": {
+      "name": "verification_event_type",
+      "schema": "public",
+      "values": [
+        "confirmed",
+        "reconfirmed",
+        "marked_stale",
+        "ended",
+        "rejected",
+        "restored",
+        "corrected",
+        "hidden",
+        "unhidden"
+      ]
+    },
+    "public.verification_evidence_relationship": {
+      "name": "verification_evidence_relationship",
+      "schema": "public",
+      "values": [
+        "basis",
+        "contradiction",
+        "context",
+        "superseded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1783607991085,
       "tag": "0023_solid_scourge",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1784042220148,
+      "tag": "0024_kind_rawhide_kid",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/check-photo-media-submission-contract.ts
+++ b/scripts/check-photo-media-submission-contract.ts
@@ -4,6 +4,7 @@ import {
   photosSubmissionIntakeSchema,
   submissionMediaItemSchema,
 } from '../src/submissions/photo-media-contract';
+import './check-photo-private-intake';
 
 const intake = {
   schemaVersion: 'submission-common-v1',

--- a/scripts/check-photo-private-intake.ts
+++ b/scripts/check-photo-private-intake.ts
@@ -1,0 +1,11 @@
+import { quarantineUploadReservations } from '../src/db/schema';
+import { createPhotoPrivateIntakeService } from '../src/submissions/photo-intake-service';
+
+if (quarantineUploadReservations.id.name !== 'id') {
+  throw new Error('Quarantine reservation schema is not exported.');
+}
+if (typeof createPhotoPrivateIntakeService !== 'function') {
+  throw new Error('Photo private intake service is not executable.');
+}
+
+console.log('Photo private intake schema and service checks passed.');

--- a/src/db/schema/submissions.ts
+++ b/src/db/schema/submissions.ts
@@ -49,6 +49,16 @@ export const submissionEventActorTypeEnum = pgEnum(
   submissionEventActorTypeValues,
 );
 
+export const quarantineUploadReservationPurposeValues = [
+  'evidence_image',
+  'owner_verification_proof',
+  'public_gallery_candidate',
+] as const;
+export const quarantineUploadReservationPurposeEnum = pgEnum(
+  'quarantine_upload_reservation_purpose',
+  quarantineUploadReservationPurposeValues,
+);
+
 export const submissionPublicReferenceCounters = pgTable(
   'submission_public_reference_counters',
   {
@@ -218,6 +228,38 @@ export const submissionEvents = pgTable(
   ],
 );
 
+export const quarantineUploadReservations = pgTable(
+  'quarantine_upload_reservations',
+  {
+    id: uuid('id').primaryKey(),
+    intakeRequestId: uuid('intake_request_id').notNull(),
+    purpose: quarantineUploadReservationPurposeEnum('purpose').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    consumedBySubmissionId: uuid('consumed_by_submission_id').references(() => submissions.id, {
+      onDelete: 'restrict',
+    }),
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('quarantine_upload_reservations_owner_expiry_idx').on(
+      table.intakeRequestId,
+      table.expiresAt,
+    ),
+    index('quarantine_upload_reservations_consumed_submission_idx').on(
+      table.consumedBySubmissionId,
+    ),
+    check(
+      'quarantine_upload_reservations_consumption_pair',
+      sql`(${table.consumedBySubmissionId} is null and ${table.consumedAt} is null) or (${table.consumedBySubmissionId} is not null and ${table.consumedAt} is not null)`,
+    ),
+    check(
+      'quarantine_upload_reservations_time_order',
+      sql`${table.createdAt} < ${table.expiresAt} and (${table.consumedAt} is null or ${table.createdAt} <= ${table.consumedAt})`,
+    ),
+  ],
+);
+
 export type Submission = typeof submissions.$inferSelect;
 export type NewSubmission = typeof submissions.$inferInsert;
 export type SubmissionPayload = typeof submissionPayloads.$inferSelect;
@@ -226,3 +268,5 @@ export type SubmissionContact = typeof submissionContacts.$inferSelect;
 export type NewSubmissionContact = typeof submissionContacts.$inferInsert;
 export type SubmissionEvent = typeof submissionEvents.$inferSelect;
 export type NewSubmissionEvent = typeof submissionEvents.$inferInsert;
+export type QuarantineUploadReservation = typeof quarantineUploadReservations.$inferSelect;
+export type NewQuarantineUploadReservation = typeof quarantineUploadReservations.$inferInsert;

--- a/src/submissions/drizzle-persistence.ts
+++ b/src/submissions/drizzle-persistence.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import type { CryptoPayMapDatabase } from '../db/client';
 import {
   submissionContacts,
@@ -6,6 +6,7 @@ import {
   submissionPayloads,
   submissionPublicReferenceCounters,
   submissions,
+  quarantineUploadReservations,
 } from '../db/schema';
 import { formatSubmissionPublicId } from './contract';
 import { parseSubmissionHoldEventPayload } from './hold-contract';
@@ -220,6 +221,29 @@ export function createDrizzleSubmissionPersistenceBackend(
           createdAt: command.submittedAt,
         }),
       );
+
+      if (command.quarantineUploadIds !== undefined) {
+        const reservationIds = command.quarantineUploadIds;
+        statements.push(
+          database.execute(sql`
+            with consumed as (
+              update ${quarantineUploadReservations}
+              set
+                ${quarantineUploadReservations.consumedBySubmissionId} = ${command.id},
+                ${quarantineUploadReservations.consumedAt} = ${command.submittedAt}
+              where ${inArray(quarantineUploadReservations.id, reservationIds)}
+                and ${quarantineUploadReservations.intakeRequestId} = ${command.intakeRequestId}
+                and ${quarantineUploadReservations.purpose} = 'public_gallery_candidate'
+                and ${quarantineUploadReservations.expiresAt} > ${command.submittedAt}
+                and ${quarantineUploadReservations.consumedBySubmissionId} is null
+                and ${quarantineUploadReservations.consumedAt} is null
+              returning ${quarantineUploadReservations.id}
+            )
+            select 1 / case when count(*) = ${reservationIds.length} then 1 else 0 end
+            from consumed
+          `),
+        );
+      }
 
       try {
         await database.batch(statements as unknown as DatabaseBatchInput);

--- a/src/submissions/in-memory-persistence.ts
+++ b/src/submissions/in-memory-persistence.ts
@@ -16,8 +16,22 @@ interface StoredSubmission extends SubmissionPersistenceReplayRecord {
   contact: CreateSubmissionPersistenceCommand['contact'];
 }
 
+interface StoredQuarantineReservation {
+  id: string;
+  intakeRequestId: string;
+  purpose: 'evidence_image' | 'owner_verification_proof' | 'public_gallery_candidate';
+  expiresAt: Date;
+  consumedBySubmissionId: string | null;
+  consumedAt: Date | null;
+}
+
 export function createInMemorySubmissionPersistenceBackend(): SubmissionPersistenceBackend & {
   snapshot(): StoredSubmission[];
+  seedQuarantineReservation(
+    reservation: Omit<StoredQuarantineReservation, 'consumedBySubmissionId' | 'consumedAt'> &
+      Partial<Pick<StoredQuarantineReservation, 'consumedBySubmissionId' | 'consumedAt'>>,
+  ): void;
+  reservationSnapshot(): StoredQuarantineReservation[];
 } {
   const counters = new Map<number, number>();
   const submissionsById = new Map<string, StoredSubmission>();
@@ -25,6 +39,7 @@ export function createInMemorySubmissionPersistenceBackend(): SubmissionPersiste
   const submissionIdByPublicId = new Map<string, string>();
   const publicIds = new Set<string>();
   const statusTokenHashes = new Set<string>();
+  const quarantineReservations = new Map<string, StoredQuarantineReservation>();
 
   return {
     async allocatePublicReference(year) {
@@ -83,6 +98,25 @@ export function createInMemorySubmissionPersistenceBackend(): SubmissionPersiste
         );
       }
 
+      const reservationIds = command.quarantineUploadIds ?? [];
+      const reservations = reservationIds.map((id) => quarantineReservations.get(id));
+      if (
+        reservations.some(
+          (reservation) =>
+            reservation === undefined ||
+            reservation.intakeRequestId !== command.intakeRequestId ||
+            reservation.purpose !== 'public_gallery_candidate' ||
+            reservation.expiresAt.getTime() <= command.submittedAt.getTime() ||
+            reservation.consumedBySubmissionId !== null ||
+            reservation.consumedAt !== null,
+        )
+      ) {
+        throw new SubmissionPersistenceError(
+          'conflict',
+          'Submission persistence conflicted with current private state.',
+        );
+      }
+
       const stored: StoredSubmission = {
         submissionId: command.id,
         publicId: command.publicId,
@@ -104,6 +138,11 @@ export function createInMemorySubmissionPersistenceBackend(): SubmissionPersiste
       submissionIdByPublicId.set(command.publicId, command.id);
       publicIds.add(command.publicId);
       statusTokenHashes.add(command.statusTokenHash);
+      for (const reservation of reservations) {
+        if (reservation === undefined) continue;
+        reservation.consumedBySubmissionId = command.id;
+        reservation.consumedAt = command.submittedAt;
+      }
 
       return {
         submissionId: command.id,
@@ -153,6 +192,23 @@ export function createInMemorySubmissionPersistenceBackend(): SubmissionPersiste
         normalizedPayload:
           stored.normalizedPayload === null ? null : structuredClone(stored.normalizedPayload),
         contact: stored.contact === null ? null : { ...stored.contact },
+      }));
+    },
+
+    seedQuarantineReservation(reservation) {
+      quarantineReservations.set(reservation.id, {
+        ...reservation,
+        expiresAt: new Date(reservation.expiresAt),
+        consumedBySubmissionId: reservation.consumedBySubmissionId ?? null,
+        consumedAt: reservation.consumedAt ? new Date(reservation.consumedAt) : null,
+      });
+    },
+
+    reservationSnapshot() {
+      return [...quarantineReservations.values()].map((reservation) => ({
+        ...reservation,
+        expiresAt: new Date(reservation.expiresAt),
+        consumedAt: reservation.consumedAt ? new Date(reservation.consumedAt) : null,
       }));
     },
   };

--- a/src/submissions/intake-service.ts
+++ b/src/submissions/intake-service.ts
@@ -50,6 +50,7 @@ export interface SubmissionPrivateIntakeService {
 export interface ParsedSubmissionPrivateIntake {
   intake: CommonSubmissionIntake;
   normalizedPayload: Record<string, unknown> | null;
+  quarantineUploadIds?: string[];
 }
 
 export interface SubmissionIntakeParser {
@@ -133,6 +134,7 @@ export function createSubmissionPrivateIntakeService(
       let parsedRequestId: string;
       let intake: CommonSubmissionIntake;
       let normalizedPayload: Record<string, unknown> | null;
+      let quarantineUploadIds: string[] | undefined;
       try {
         parsedRequestId = requestIdSchema.parse(requestId);
         const parsed = intakeParser.parse(rawInput);
@@ -141,6 +143,7 @@ export function createSubmissionPrivateIntakeService(
           parsed.normalizedPayload === null
             ? null
             : submissionOriginalPayloadSchema.parse(parsed.normalizedPayload);
+        quarantineUploadIds = parsed.quarantineUploadIds;
       } catch (error) {
         throw new SubmissionIntakeError(
           'invalid_request',
@@ -199,6 +202,7 @@ export function createSubmissionPrivateIntakeService(
           contact,
           actorId,
           actorType: 'submitter',
+          ...(quarantineUploadIds === undefined ? {} : { quarantineUploadIds }),
         });
 
         return {

--- a/src/submissions/persistence.ts
+++ b/src/submissions/persistence.ts
@@ -43,6 +43,7 @@ export interface CreateSubmissionPersistenceCommand {
   contact: SubmissionContactPersistenceInput | null;
   actorId: string;
   actorType: SubmissionEventActorType;
+  quarantineUploadIds?: string[];
 }
 
 export interface CreateSubmissionPersistenceReceipt {

--- a/src/submissions/photo-intake-service.ts
+++ b/src/submissions/photo-intake-service.ts
@@ -1,0 +1,37 @@
+import { commonSubmissionIntakeSchema } from './contract';
+import {
+  createSubmissionPrivateIntakeService,
+  type SubmissionPrivateIntakeDependencies,
+  type SubmissionPrivateIntakeService,
+} from './intake-service';
+import {
+  normalizeParsedPhotosSubmissionIntake,
+  photosSubmissionIntakeSchema,
+} from './photo-media-contract';
+
+export type PhotoPrivateIntakeDependencies = Omit<
+  SubmissionPrivateIntakeDependencies,
+  'intakeParser'
+>;
+
+export function createPhotoPrivateIntakeService(
+  dependencies: PhotoPrivateIntakeDependencies,
+): SubmissionPrivateIntakeService {
+  return createSubmissionPrivateIntakeService({
+    ...dependencies,
+    intakeParser: {
+      parse(rawInput) {
+        const photoIntake = photosSubmissionIntakeSchema.parse(rawInput);
+        const originalIntake = commonSubmissionIntakeSchema.parse(rawInput);
+        const normalized = normalizeParsedPhotosSubmissionIntake(photoIntake);
+        return {
+          intake: originalIntake,
+          normalizedPayload: structuredClone(normalized) as unknown as Record<string, unknown>,
+          quarantineUploadIds: photoIntake.originalPayload.media.map(
+            (item) => item.quarantineUploadId,
+          ),
+        };
+      },
+    },
+  });
+}

--- a/tests/photo-private-intake.test.ts
+++ b/tests/photo-private-intake.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type { SubmissionContactProtector } from '../src/submissions/contact-protection';
+import { createInMemorySubmissionPersistenceBackend } from '../src/submissions/in-memory-persistence';
+import { createPhotoPrivateIntakeService } from '../src/submissions/photo-intake-service';
+import { createHmacSubmissionStatusSecretProvider } from '../src/submissions/status-secret-provider';
+
+const requestId = '20000000-0000-4000-8000-000000000001';
+const uploadId = '30000000-0000-4000-8000-000000000001';
+const receivedAt = new Date('2026-07-15T12:00:00.000Z');
+
+function rawIntake(note: string | null = null) {
+  return {
+    schemaVersion: 'submission-common-v1',
+    submissionType: 'photos',
+    targetType: 'location',
+    targetId: '40000000-0000-4000-8000-000000000001',
+    relationship: 'customer',
+    contact: { email: 'private@example.test', contactAllowed: true },
+    evidenceLinks: [],
+    originalPayload: {
+      schemaVersion: 'photo-media-v1',
+      media: [
+        {
+          quarantineUploadId: uploadId,
+          purpose: 'public_gallery_candidate',
+          role: 'gallery',
+          declaredMimeType: 'image/jpeg',
+          declaredByteSize: 125_000,
+          capturedAt: '2026-07-10',
+          description: 'Storefront entrance.',
+          suggestedAltText: 'Entrance of the listed shop.',
+          photographerPresent: true,
+          rights: {
+            rightsStatus: 'submitted_with_permission',
+            rightsHolderPresent: true,
+            permissionReferencePresent: false,
+            licenseName: null,
+            licenseUrl: null,
+            publicDisplayPermission: true,
+          },
+        },
+      ],
+      submitterNote: note,
+    },
+    acknowledgements: { privacyNoticeAccepted: true, submissionTermsAccepted: true },
+  };
+}
+
+const contactProtector: SubmissionContactProtector = {
+  async protectEmail() {
+    return {
+      encryptedEmail: 'encrypted-contact-envelope',
+      emailHash: 'a'.repeat(64),
+      retentionUntil: new Date('2026-10-15T12:00:00.000Z'),
+    };
+  },
+};
+
+function fixture() {
+  const persistence = createInMemorySubmissionPersistenceBackend();
+  persistence.seedQuarantineReservation({
+    id: uploadId,
+    intakeRequestId: requestId,
+    purpose: 'public_gallery_candidate',
+    expiresAt: new Date('2026-07-15T13:00:00.000Z'),
+  });
+  let sequence = 0;
+  return {
+    persistence,
+    intake: createPhotoPrivateIntakeService({
+      persistence,
+      statusSecrets: createHmacSubmissionStatusSecretProvider(new Uint8Array(32).fill(9)),
+      contactProtector,
+      generateSubmissionId: () =>
+        `10000000-0000-4000-8000-${(++sequence).toString().padStart(12, '0')}`,
+    }),
+  };
+}
+
+describe('P5-05B private Photos intake', () => {
+  it('atomically persists private payloads and consumes its reservation', async () => {
+    const { intake, persistence } = fixture();
+    const result = await intake.submit(requestId, rawIntake(), receivedAt);
+
+    expect(result.state).toBe('committed');
+    expect(persistence.snapshot()).toHaveLength(1);
+    expect(persistence.reservationSnapshot()[0]).toMatchObject({
+      consumedBySubmissionId: persistence.snapshot()[0]?.submissionId,
+      consumedAt: receivedAt,
+    });
+    const privateState = JSON.stringify(persistence.snapshot());
+    expect(privateState).toContain('encrypted-contact-envelope');
+    expect(privateState).not.toContain('private@example.test');
+    expect(privateState).not.toContain(result.statusSecret);
+    expect(privateState).not.toContain('storageKey');
+  });
+
+  it('replays identically and rejects changed content without mutation', async () => {
+    const { intake, persistence } = fixture();
+    const first = await intake.submit(requestId, rawIntake(), receivedAt);
+    await expect(intake.submit(requestId, rawIntake(), receivedAt)).resolves.toEqual({
+      ...first,
+      state: 'replayed',
+    });
+    await expect(intake.submit(requestId, rawIntake('Changed.'), receivedAt)).rejects.toMatchObject(
+      { code: 'idempotency_conflict' },
+    );
+    expect(persistence.snapshot()).toHaveLength(1);
+  });
+
+  it.each([
+    ['expired', { expiresAt: receivedAt }],
+    ['wrong owner', { intakeRequestId: '20000000-0000-4000-8000-000000000099' }],
+    ['wrong purpose', { purpose: 'evidence_image' as const }],
+    [
+      'already consumed',
+      {
+        consumedBySubmissionId: '10000000-0000-4000-8000-000000000099',
+        consumedAt: new Date('2026-07-15T11:00:00.000Z'),
+      },
+    ],
+  ])('rolls back all private records for a %s reservation', async (_label, override) => {
+    const { intake, persistence } = fixture();
+    persistence.seedQuarantineReservation({
+      id: uploadId,
+      intakeRequestId: requestId,
+      purpose: 'public_gallery_candidate',
+      expiresAt: new Date('2026-07-15T13:00:00.000Z'),
+      ...override,
+    });
+    await expect(intake.submit(requestId, rawIntake(), receivedAt)).rejects.toMatchObject({
+      code: 'conflict',
+    });
+    expect(persistence.snapshot()).toHaveLength(0);
+  });
+
+  it('permits only one request identity to consume the same reservation', async () => {
+    const { intake, persistence } = fixture();
+    const competing = createPhotoPrivateIntakeService({
+      persistence,
+      statusSecrets: createHmacSubmissionStatusSecretProvider(new Uint8Array(32).fill(9)),
+      contactProtector,
+    });
+    const outcomes = await Promise.allSettled([
+      intake.submit(requestId, rawIntake(), receivedAt),
+      competing.submit('20000000-0000-4000-8000-000000000002', rawIntake(), receivedAt),
+    ]);
+    expect(outcomes.filter((outcome) => outcome.status === 'fulfilled')).toHaveLength(1);
+    expect(persistence.snapshot()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Implementation item

P5-05B — Idempotent private Photos intake and quarantine reservation linkage

## Purpose

Persist valid P5-05A Photos submissions privately and atomically bind every opaque quarantine upload reservation without creating Media or public object access.

## Existing reservation model investigation

The P5-05B baseline contained no quarantine upload reservation table, service, migration, type, or durable ownership/expiry state. Existing Media Asset/File tables model reviewed Media and are not upload reservations. This PR therefore adds the minimum private reservation model; it contains no storage key, URL, filename, credential, or R2 access.

## Changes

- Photos-specific parser integrated with the shared private Submission intake boundary
- durable Submission envelope, private original payload, review-safe normalized projection, protected contact, status-token hash, and private receipt event
- minimum reservation ownership, purpose, expiry, and consumption model
- executable schema check and focused replay, rollback, concurrency, and leakage tests
- P5-05B completion and next-item tracking

## Database and migration changes

Migration 0024 adds `quarantine_upload_reservation_purpose` and `quarantine_upload_reservations`, with ownership/expiry indexes, atomic consumption linkage, time-order checks, and a Submission foreign key.

## Transaction boundary

Submission, payload, normalized projection, optional protected contact, `submission_received` event, status-token hash, and all reservation consumes execute in one Drizzle batch transaction. A conditional update plus affected-row guard rolls back unless every reservation exists, belongs to the request UUID, is unexpired, is unconsumed, and has `public_gallery_candidate` purpose.

## Replay behavior

Identical request UUID and content deterministically replay the original public reference, timestamp, and request-bound status secret without another Submission or consume.

## Changed-content conflict behavior

Reusing a request UUID with changed canonical content returns a generalized idempotency conflict and leaves the committed Submission unchanged.

## Concurrency behavior

Conditional row updates lock matching reservations and re-evaluate the unconsumed predicate; only one competing request can consume a reservation. The complete-count guard rejects partial acquisition.

## Rollback behavior

Missing, expired, wrong-owner, wrong-purpose, previously consumed, or concurrently lost reservations abort the complete transaction. No orphan Submission, payload, contact, event, or partial consume remains.

## Privacy boundary

Contact plaintext uses the shared encryption/hash boundary. Status-secret plaintext is never stored. Responses/errors do not disclose reservation ownership, storage keys, URLs, filenames, EXIF/GPS, wallet/receipt/customer data, raw payloads, or encryption material.

## Explicit non-effects

No R2 signing/access, binary upload or validation, decoding, EXIF processing, derivative generation, Media Asset/File creation, rights/privacy/quality approval, gallery ordering, canonical mutation, public export, publication, or production deployment.

## Tests

`WRANGLER_LOG_PATH=/tmp/cryptopaymap-wrangler.log npm run quality` passed: format, lint, Astro check, schema checks, migration drift, 216 test files / 1,064 tests, build, accessibility, and staging checks.

Final head `43f96f0c3600ee0bc8706c2b9069ab95a8c3d923` passed:

- Foundation validation
- Migration drift
- Staging review validation
- Capture representative review screenshots

## Next bounded item

P5-05C, after P5-05B merge. Its exact bounded scope is established before implementation; this PR does not start it.