### PR TITLE
P5-05E: process private photos and create Media handoff

### DIFF
--- a/docs/P5_05E_PHOTO_PRIVATE_PROCESSING_AND_MEDIA_HANDOFF.md
+++ b/docs/P5_05E_PHOTO_PRIVATE_PROCESSING_AND_MEDIA_HANDOFF.md
@@ -1,0 +1,171 @@
+# P5-05E controlled private photo processing and Media handoff
+
+**Implementation item:** P5-05E  
+**Status:** Completed through #220  
+**Started:** 2026-07-15  
+**Completed:** 2026-07-15
+
+## Purpose
+
+Consume the exact private byte set validated by P5-05D, re-verify its integrity immediately before processing, require bounded metadata-stripped and orientation-normalized private derivatives, and atomically hand the result to the existing protected Media review system. This slice creates no public Media state and performs no review approval.
+
+## Input boundary
+
+The processing request contains:
+
+- one opaque processing request UUID;
+- one existing private Photos Submission UUID;
+- one bounded processor version identifier;
+- the complete P5-05D validation receipt;
+- the exact validated private objects held only by the trusted processing caller.
+
+The request does not contain a public object URL, signed download URL, storage credential, original filename, contact value, status secret, wallet data, receipt data, or public approval instruction.
+
+## Exact context requirements
+
+Before processor execution, the service requires:
+
+- the Submission to exist and retain type `photos`;
+- an active processing-compatible Submission workflow state;
+- exact Entity or Location target agreement;
+- the normalized Photos projection to remain valid;
+- every normalized item, validation receipt item, validated byte object, and reservation row to form one exact set;
+- every reservation to have been consumed by the same Photos Submission;
+- validation to have occurred no later than reservation expiry and consumption;
+- declared MIME, byte size, dimensions, private object key, and SHA-256 to agree across all layers;
+- the exact source bytes to reproduce the P5-05D SHA-256 immediately before processing.
+
+A mismatch fails closed before any processor call or Media insertion.
+
+## Controlled processor contract
+
+The injected private processor receives one validated private object and its intended public-gallery role. It must return exactly:
+
+- one `display` derivative;
+- one `thumbnail` derivative.
+
+Each derivative must declare and satisfy:
+
+- JPEG or WebP still-image format;
+- metadata removed;
+- orientation normalized;
+- exact byte buffer, MIME type, width, and height;
+- display maximum of 2,048 pixels on either axis and 5,000,000 bytes;
+- thumbnail maximum of 512 pixels on either axis and 1,000,000 bytes;
+- no pixel-count enlargement beyond the validated source;
+- structurally valid, non-animated JPEG or WebP content;
+- a newly computed SHA-256 matching the stored private derivative metadata.
+
+P5-05E establishes the processor contract and validation boundary. It does not add a production image-codec package or claim that repository tests execute a production R2 processing deployment.
+
+## Private derivative storage
+
+Private review derivatives use the existing canonical Media storage-key convention:
+
+```text
+media/private/{mediaAssetId}/{mediaFileId}-{contentHash}.{jpg|webp}
+```
+
+The provider-neutral R2-compatible adapter:
+
+- checks for an existing object before write;
+- replays only when byte size, MIME type, content hash, source hash, asset identity, variant, and private scope metadata agree exactly;
+- rejects a key containing different content or metadata;
+- verifies object metadata after write;
+- exposes cleanup for newly staged objects when the database handoff fails.
+
+No private derivative is copied to public storage in this slice.
+
+## Atomic Media handoff
+
+For each accepted processing item, the handoff creates:
+
+- one deterministic private `Media Asset`;
+- purpose `public_gallery_candidate`;
+- the submitted review role;
+- `reviewStatus = pending`;
+- `rightsStatus = unknown`;
+- `visibility = private`;
+- an exact Entity or Location subject;
+- one original `Media File` that references the private quarantine object;
+- one private display `Media File`;
+- one private thumbnail `Media File`;
+- one private Submission event containing bounded processing provenance and review context.
+
+The database operation uses one Submission-scoped advisory lock and one atomic batch. It guards:
+
+- exact Submission type, workflow state, and update version;
+- absence of any previous Media handoff for the Submission;
+- absence of the deterministic event UUID.
+
+A Photos Submission can therefore create its Media handoff only once. A different processing request UUID cannot create a second Media set.
+
+## Replay and rollback
+
+Identical retries:
+
+- derive the same event, asset, and file UUIDs;
+- return the stored receipt before reloading mutable Submission state;
+- do not run the processor again;
+- do not rewrite derivatives or insert duplicate Media rows.
+
+Changed content under the same processing request UUID returns an idempotency conflict.
+
+If processing, derivative validation, storage, or database persistence fails:
+
+- no Media rows are partially committed;
+- newly created derivative objects are deleted on a best-effort cleanup path;
+- exact pre-existing replayed derivative objects are not deleted;
+- no public or canonical state changes.
+
+## Privacy boundary
+
+The private audit event may contain review-safe role, description, suggested alt text, rights declaration shape, and processor/content-hash provenance. It does not contain:
+
+- object bytes;
+- quarantine or derivative storage keys in the returned receipt;
+- signed URLs or credentials;
+- original filenames;
+- EXIF or GPS payloads;
+- contact plaintext;
+- status secrets;
+- public Media approval.
+
+The leakage-safe receipt contains only opaque reservation, Media Asset/File identities, hashes, processing state, Submission identity, and timestamp.
+
+## Explicit non-effects
+
+P5-05E does not add:
+
+- a production image codec or worker deployment;
+- production R2 bucket binding;
+- a public Photos route or browser form;
+- asynchronous queue or retry infrastructure;
+- face, plate, QR, wallet, or privacy-content decisions;
+- duplicate or abuse-hash policy decisions;
+- rights, privacy, quality, cover, or gallery-order approval;
+- public storage copying;
+- Media decision execution;
+- canonical mutation;
+- export or publication;
+- production deployment.
+
+## Completion evidence
+
+Pull request #220 adds the processing contract, exact source re-hash, bounded derivative validation, deterministic replay identities, R2-compatible and in-memory private derivative stores, Drizzle atomic Media handoff, one-handoff-per-Submission guard, executable schema check, and focused integrity, replay, conflict, storage, rollback, and leakage tests.
+
+Implementation head `c2079faba752b66471d5bcee35cfb1fb4173b837` passed:
+
+- format and lint;
+- Astro and TypeScript;
+- executable runtime and submission schema checks;
+- migration history and drift;
+- 221 test files and 1,095 tests;
+- build, accessibility, Phase 1, and staging artifact checks;
+- Foundation validation, Migration drift, Staging review validation, and representative screenshot capture.
+
+No migration was required. P5-05E reuses the existing `media_assets`, `media_files`, `submission_events`, Submission payload, and quarantine reservation structures.
+
+## Next bounded item
+
+P5-05F will define duplicate content-hash behavior and private upload lifecycle cleanup. It must distinguish harmless exact reuse from cross-target or previously rejected material, keep duplicate signals review-only, and apply bounded retention and cleanup rules to abandoned, rejected, superseded, or completed private objects without deleting active review material.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-05E — Controlled private photo processing and protected Media handoff
+P5-05F — Photo duplicate signals and private upload lifecycle cleanup
 
 ## Current repository state
 
@@ -32,7 +32,8 @@ P5-05E — Controlled private photo processing and protected Media handoff
 - P5-05B idempotent private Photos intake and quarantine reservation linkage completed in #217.
 - P5-05C photo quarantine upload authorization and durable reservation issuance completed in #218.
 - P5-05D private object existence and byte-level validation completed in #219.
-- P5-05E is next; its bounded scope is controlled private processing and protected Media handoff without public approval or publication.
+- P5-05E controlled private processing and protected Media handoff completed in #220.
+- P5-05F is next; its bounded scope is review-only duplicate content-hash signals plus retention and cleanup of abandoned, rejected, superseded, or completed private uploads.
 
 ## P5-05A completion result
 
@@ -92,6 +93,23 @@ P5-05D provides:
 - injectable decoding and R2-compatible storage boundaries;
 - no production R2 binding, EXIF removal, derivative generation, Media creation, canonical mutation, export, or publication.
 
+## P5-05E completion result
+
+P5-05E provides:
+
+- exact Photos Submission, target, normalized item, validated byte, and consumed reservation matching;
+- immediate SHA-256 re-verification before processing;
+- an injectable controlled processor contract requiring metadata removal and orientation normalization;
+- bounded, structurally revalidated JPEG or WebP display and thumbnail derivatives;
+- canonical private derivative keys and idempotent R2-compatible writes;
+- deterministic Media Asset/File and private handoff-event identities;
+- one private pending `public_gallery_candidate` Media Asset per submitted item;
+- quarantine original plus private display and thumbnail Media Files;
+- Submission-scoped atomic persistence and one-handoff-per-Submission protection;
+- replay that remains stable after later Submission workflow updates;
+- cleanup of newly staged derivatives after failed database handoff;
+- no production codec or R2 binding, Media approval, public storage copy, canonical mutation, export, or publication.
+
 ## Current references
 
 - `docs/IMPLEMENTATION_PLAN.md`
@@ -113,6 +131,7 @@ P5-05D provides:
 - `docs/P5_05B_PHOTO_PRIVATE_INTAKE.md`
 - `docs/P5_05C_PHOTO_UPLOAD_AUTHORIZATION.md`
 - `docs/P5_05D_PHOTO_OBJECT_VALIDATION.md`
+- `docs/P5_05E_PHOTO_PRIVATE_PROCESSING_AND_MEDIA_HANDOFF.md`
 
 ## Phase 5 sequence
 
@@ -120,19 +139,19 @@ P5-05D provides:
 2. P5-02 — Suggest Place and Online Service — Completed through #156–#192
 3. P5-03 — Payment and problem reports — Completed through #194–#202
 4. P5-04 — Business and service claims — Completed through #203–#215
-5. P5-05 — Photo and Media submission intake — In progress at P5-05E; P5-05D completed #219
+5. P5-05 — Photo and Media submission intake — In progress at P5-05F; P5-05E completed #220
 6. P5-06 — Review workflow extensions — Planned
 7. P5-07 — Canonical application transactions and retention — Planned
 8. P5-08 — MVP-B integration audit — Planned
 
 ## Next
 
-Define and implement P5-05E controlled private processing and protected Media handoff. It must re-verify the P5-05D content hash or consume the exact validated byte set before metadata stripping, orientation normalization, resizing, derivative creation, or any private Media record is produced.
+Define and implement P5-05F duplicate content-hash signals and private upload lifecycle cleanup. Exact or near-existing hashes must remain review signals rather than automatic misuse conclusions, and cleanup must distinguish active review material from expired authorization, abandoned upload, rejected Media, superseded derivative, and completed retention states.
 
 ## Blocked
 
-No repository blocker is known. Production R2 binding, asynchronous processing infrastructure, public route wiring, protected Media reviewer execution, public Media approval, export activation, and production review remain separate later slices.
+No repository blocker is known. Production codec and R2 binding, asynchronous processing infrastructure, public Photos route and browser wiring, privacy-content analysis, protected Media reviewer execution, public Media approval, export activation, and production review remain separate later slices.
 
 ## Verification rule
 
-Repository reality is determined by current `main`, merged pull requests, actual CI results, and fixed-review receipts. Structural validation is not a display-safe derivative, a Submission never publishes Media automatically, and opaque quarantine references never expose persistent storage credentials or public object URLs.
+Repository reality is determined by current `main`, merged pull requests, actual CI results, and fixed-review receipts. A private derivative and pending Media handoff are not public approval, duplicate hashes are review signals rather than proof of misuse, and opaque private storage references never become public object URLs through Submission intake.

--- a/scripts/check-photo-object-validation.ts
+++ b/scripts/check-photo-object-validation.ts
@@ -6,6 +6,7 @@ import {
   photoObjectValidationRequestSchema,
 } from '../src/submissions/photo-object-validation';
 import { createR2PhotoQuarantineObjectStore } from '../src/submissions/r2-photo-quarantine-object-store';
+import './check-photo-private-processing';
 
 const parsed = photoObjectValidationRequestSchema.parse({
   schemaVersion: 'photo-object-validation-v1',

--- a/scripts/check-photo-private-processing.ts
+++ b/scripts/check-photo-private-processing.ts
@@ -35,8 +35,7 @@ const request = photoPrivateProcessingRequestSchema.parse({
     objects: [
       {
         quarantineUploadId: '50000000-0000-4000-8000-000000000001',
-        privateObjectKey:
-          'quarantine/photos/v1/50000000-0000-4000-8000-000000000001',
+        privateObjectKey: 'quarantine/photos/v1/50000000-0000-4000-8000-000000000001',
         body: Uint8Array.from([1, 2, 3, 4]),
         mimeType: 'image/png',
         byteSize: 4,

--- a/scripts/check-photo-private-processing.ts
+++ b/scripts/check-photo-private-processing.ts
@@ -1,0 +1,125 @@
+import { createDrizzlePhotoMediaHandoffPersistence } from '../src/submissions/drizzle-photo-private-processing';
+import { createInMemoryPrivatePhotoDerivativeStore } from '../src/submissions/in-memory-private-photo-derivatives';
+import {
+  createPhotoPrivateProcessingService,
+  photoMediaHandoffEventPayloadSchema,
+  photoPrivateProcessingReceiptSchema,
+  photoPrivateProcessingRequestSchema,
+  photoProcessedDerivativeSchema,
+} from '../src/submissions/photo-private-processing';
+import { createR2PrivatePhotoDerivativeStore } from '../src/submissions/r2-private-photo-derivatives';
+
+const request = photoPrivateProcessingRequestSchema.parse({
+  schemaVersion: 'photo-private-processing-v1',
+  processingRequestId: '10000000-0000-4000-8000-000000000001',
+  submissionId: '20000000-0000-4000-8000-000000000001',
+  processorVersion: 'check-codec/1.0.0',
+  validation: {
+    receipt: {
+      schemaVersion: 'photo-object-validation-receipt-v1',
+      intakeRequestId: '30000000-0000-4000-8000-000000000001',
+      targetType: 'location',
+      targetId: '40000000-0000-4000-8000-000000000001',
+      validatedAt: '2026-07-15T00:00:00.000Z',
+      media: [
+        {
+          quarantineUploadId: '50000000-0000-4000-8000-000000000001',
+          mimeType: 'image/png',
+          byteSize: 4,
+          width: 1,
+          height: 1,
+          contentHash: 'a'.repeat(64),
+        },
+      ],
+    },
+    objects: [
+      {
+        quarantineUploadId: '50000000-0000-4000-8000-000000000001',
+        privateObjectKey:
+          'quarantine/photos/v1/50000000-0000-4000-8000-000000000001',
+        body: Uint8Array.from([1, 2, 3, 4]),
+        mimeType: 'image/png',
+        byteSize: 4,
+        width: 1,
+        height: 1,
+        contentHash: 'a'.repeat(64),
+      },
+    ],
+  },
+});
+
+photoProcessedDerivativeSchema.parse({
+  variant: 'display',
+  body: Uint8Array.from([1]),
+  mimeType: 'image/webp',
+  width: 1,
+  height: 1,
+  metadataStripped: true,
+  orientationNormalized: true,
+});
+
+const event = photoMediaHandoffEventPayloadSchema.parse({
+  schemaVersion: 'photo-media-handoff-event-v1',
+  processingRequestId: request.processingRequestId,
+  requestFingerprint: 'b'.repeat(64),
+  submissionId: request.submissionId,
+  processorVersion: request.processorVersion,
+  processedAt: '2026-07-15T00:01:00.000Z',
+  targetType: 'location',
+  targetId: request.validation.receipt.targetId,
+  media: [
+    {
+      quarantineUploadId: request.validation.receipt.media[0]?.quarantineUploadId,
+      mediaAssetId: '60000000-0000-4000-8000-000000000001',
+      originalFileId: '70000000-0000-4000-8000-000000000001',
+      displayFileId: '70000000-0000-4000-8000-000000000002',
+      thumbnailFileId: '70000000-0000-4000-8000-000000000003',
+      originalContentHash: 'a'.repeat(64),
+      displayContentHash: 'c'.repeat(64),
+      thumbnailContentHash: 'd'.repeat(64),
+      reviewContext: {
+        role: 'cover',
+        capturedAt: null,
+        description: null,
+        suggestedAltText: null,
+        photographerPresent: true,
+        rightsStatus: 'submitted_with_permission',
+        rightsHolderPresent: true,
+        permissionReferencePresent: false,
+        licenseName: null,
+        licenseUrl: null,
+        publicDisplayPermission: true,
+      },
+    },
+  ],
+});
+
+photoPrivateProcessingReceiptSchema.parse({
+  schemaVersion: 'photo-private-processing-receipt-v1',
+  state: 'committed',
+  processingRequestId: event.processingRequestId,
+  submissionId: event.submissionId,
+  processedAt: event.processedAt,
+  media: event.media.map((item) => ({
+    quarantineUploadId: item.quarantineUploadId,
+    mediaAssetId: item.mediaAssetId,
+    originalContentHash: item.originalContentHash,
+    displayFileId: item.displayFileId,
+    displayContentHash: item.displayContentHash,
+    thumbnailFileId: item.thumbnailFileId,
+    thumbnailContentHash: item.thumbnailContentHash,
+  })),
+});
+
+for (const implementation of [
+  createPhotoPrivateProcessingService,
+  createDrizzlePhotoMediaHandoffPersistence,
+  createInMemoryPrivatePhotoDerivativeStore,
+  createR2PrivatePhotoDerivativeStore,
+]) {
+  if (typeof implementation !== 'function') {
+    throw new Error('P5-05E photo private processing implementation is not executable.');
+  }
+}
+
+console.log('Photo private processing and Media handoff schemas passed.');

--- a/src/submissions/drizzle-photo-private-processing.ts
+++ b/src/submissions/drizzle-photo-private-processing.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, sql } from 'drizzle-orm';
+import { asc, eq, sql } from 'drizzle-orm';
 import type { CryptoPayMapDatabase } from '../db/client';
 import {
   mediaAssets,
@@ -52,7 +52,12 @@ export function createDrizzlePhotoMediaHandoffPersistence(
         row.targetId === null ||
         row.normalizedPayload === null ||
         !processableStatuses.has(
-          row.workflowStatus as 'received' | 'triage' | 'in_review' | 'needs_information' | 'on_hold',
+          row.workflowStatus as
+            | 'received'
+            | 'triage'
+            | 'in_review'
+            | 'needs_information'
+            | 'on_hold',
         )
       ) {
         return null;
@@ -129,6 +134,12 @@ export function createDrizzlePhotoMediaHandoffPersistence(
               and ${submissions.submissionType} = 'photos'
               and ${submissions.updatedAt} = ${command.expectedSubmissionUpdatedAt}
               and ${submissions.workflowStatus} = ${command.expectedWorkflowStatus}
+          )
+          and not exists (
+            select 1
+            from ${submissionEvents}
+            where ${submissionEvents.submissionId} = ${command.submissionId}
+              and ${submissionEvents.action} = 'photo_media_handoff_created'
           )
           and not exists (
             select 1 from ${submissionEvents}

--- a/src/submissions/drizzle-photo-private-processing.ts
+++ b/src/submissions/drizzle-photo-private-processing.ts
@@ -1,0 +1,189 @@
+import { and, asc, eq, sql } from 'drizzle-orm';
+import type { CryptoPayMapDatabase } from '../db/client';
+import {
+  mediaAssets,
+  mediaFiles,
+  quarantineUploadReservations,
+  submissionEvents,
+  submissionPayloads,
+  submissions,
+} from '../db/schema';
+import {
+  photoMediaHandoffEventPayloadSchema,
+  type PhotoMediaHandoffPersistence,
+  type PhotoProcessingSubmissionContext,
+} from './photo-private-processing';
+
+type DatabaseBatchInput = Parameters<CryptoPayMapDatabase['batch']>[0];
+
+const processableStatuses = new Set([
+  'received',
+  'triage',
+  'in_review',
+  'needs_information',
+  'on_hold',
+] as const);
+
+export function createDrizzlePhotoMediaHandoffPersistence(
+  database: CryptoPayMapDatabase,
+): PhotoMediaHandoffPersistence {
+  return {
+    async loadSubmissionContext(submissionId) {
+      const rows = await database
+        .select({
+          id: submissions.id,
+          intakeRequestId: submissions.intakeRequestId,
+          submissionType: submissions.submissionType,
+          targetType: submissions.targetType,
+          targetId: submissions.targetId,
+          workflowStatus: submissions.workflowStatus,
+          updatedAt: submissions.updatedAt,
+          normalizedPayload: submissionPayloads.normalizedPayload,
+        })
+        .from(submissions)
+        .innerJoin(submissionPayloads, eq(submissionPayloads.submissionId, submissions.id))
+        .where(eq(submissions.id, submissionId))
+        .limit(1);
+      const row = rows[0];
+      if (
+        row === undefined ||
+        row.submissionType !== 'photos' ||
+        (row.targetType !== 'entity' && row.targetType !== 'location') ||
+        row.targetId === null ||
+        row.normalizedPayload === null ||
+        !processableStatuses.has(
+          row.workflowStatus as 'received' | 'triage' | 'in_review' | 'needs_information' | 'on_hold',
+        )
+      ) {
+        return null;
+      }
+
+      const reservations = await database
+        .select({
+          id: quarantineUploadReservations.id,
+          intakeRequestId: quarantineUploadReservations.intakeRequestId,
+          purpose: quarantineUploadReservations.purpose,
+          expiresAt: quarantineUploadReservations.expiresAt,
+          consumedBySubmissionId: quarantineUploadReservations.consumedBySubmissionId,
+          consumedAt: quarantineUploadReservations.consumedAt,
+        })
+        .from(quarantineUploadReservations)
+        .where(eq(quarantineUploadReservations.intakeRequestId, row.intakeRequestId))
+        .orderBy(asc(quarantineUploadReservations.id));
+
+      const context: PhotoProcessingSubmissionContext = {
+        id: row.id,
+        intakeRequestId: row.intakeRequestId,
+        submissionType: 'photos',
+        targetType: row.targetType,
+        targetId: row.targetId,
+        workflowStatus: row.workflowStatus as PhotoProcessingSubmissionContext['workflowStatus'],
+        updatedAt: row.updatedAt.toISOString(),
+        normalizedPayload: structuredClone(row.normalizedPayload),
+        reservations: reservations.map((reservation) => ({
+          id: reservation.id,
+          intakeRequestId: reservation.intakeRequestId,
+          purpose: reservation.purpose,
+          expiresAt: reservation.expiresAt.toISOString(),
+          consumedBySubmissionId: reservation.consumedBySubmissionId,
+          consumedAt: reservation.consumedAt?.toISOString() ?? null,
+        })),
+      };
+      return context;
+    },
+
+    async readHandoffEvent(eventId) {
+      const rows = await database
+        .select({
+          action: submissionEvents.action,
+          internalNote: submissionEvents.internalNote,
+        })
+        .from(submissionEvents)
+        .where(eq(submissionEvents.id, eventId))
+        .limit(1);
+      const row = rows[0];
+      if (
+        row === undefined ||
+        row.action !== 'photo_media_handoff_created' ||
+        row.internalNote === null
+      ) {
+        return null;
+      }
+      try {
+        return photoMediaHandoffEventPayloadSchema.parse(JSON.parse(row.internalNote));
+      } catch {
+        throw new Error('Stored photo Media handoff event is malformed.');
+      }
+    },
+
+    async commitHandoff(command) {
+      const lock = database.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${command.submissionId}, 0))`,
+      );
+      const guard = database.select({
+        guard: sql<number>`1 / case when
+          exists (
+            select 1
+            from ${submissions}
+            where ${submissions.id} = ${command.submissionId}
+              and ${submissions.submissionType} = 'photos'
+              and ${submissions.updatedAt} = ${command.expectedSubmissionUpdatedAt}
+              and ${submissions.workflowStatus} = ${command.expectedWorkflowStatus}
+          )
+          and not exists (
+            select 1 from ${submissionEvents}
+            where ${submissionEvents.id} = ${command.eventId}
+          )
+          then 1 else 0 end`,
+      });
+      const insertAssets = database.insert(mediaAssets).values(
+        command.assets.map((asset) => ({
+          id: asset.id,
+          purpose: asset.purpose,
+          role: asset.role,
+          reviewStatus: asset.reviewStatus,
+          rightsStatus: asset.rightsStatus,
+          visibility: asset.visibility,
+          entityId: asset.entityId,
+          locationId: asset.locationId,
+          claimId: null,
+          evidenceId: null,
+          submissionId: null,
+          sourceRecordId: null,
+          licenseId: null,
+          attribution: null,
+          altText: null,
+          rightsHolder: null,
+          consentReference: null,
+          displayOrder: asset.displayOrder,
+          capturedAt: asset.capturedAt,
+          publishedAt: null,
+          createdAt: asset.createdAt,
+          updatedAt: asset.updatedAt,
+          deletedAt: null,
+        })),
+      );
+      const insertFiles = database.insert(mediaFiles).values(command.files);
+      const insertEvent = database.insert(submissionEvents).values({
+        id: command.eventId,
+        submissionId: command.submissionId,
+        fromStatus: null,
+        toStatus: command.expectedWorkflowStatus,
+        action: 'photo_media_handoff_created',
+        reasonCode: 'photo_processing_completed',
+        actorId: 'system:photo-private-processing',
+        actorType: 'system',
+        internalNote: JSON.stringify(command.eventPayload),
+        createdAt: new Date(command.eventPayload.processedAt),
+      });
+
+      await database.batch([
+        lock,
+        guard,
+        insertAssets,
+        insertFiles,
+        insertEvent,
+      ] as unknown as DatabaseBatchInput);
+    },
+  };
+}

--- a/src/submissions/in-memory-private-photo-derivatives.ts
+++ b/src/submissions/in-memory-private-photo-derivatives.ts
@@ -1,0 +1,73 @@
+import type {
+  PrivatePhotoDerivativeStore,
+  PrivatePhotoDerivativeWriteCommand,
+} from './photo-private-processing';
+import { PrivatePhotoDerivativeStoreError } from './r2-private-photo-derivatives';
+
+interface StoredDerivative {
+  key: string;
+  body: Uint8Array;
+  mimeType: 'image/jpeg' | 'image/webp';
+  contentHash: string;
+  mediaAssetId: string;
+  variant: 'display' | 'thumbnail';
+  sourceContentHash: string;
+}
+
+function clone(command: PrivatePhotoDerivativeWriteCommand): StoredDerivative {
+  return {
+    ...command,
+    body: Uint8Array.from(command.body),
+  };
+}
+
+function matches(existing: StoredDerivative, command: PrivatePhotoDerivativeWriteCommand): boolean {
+  return (
+    existing.key === command.key &&
+    existing.mimeType === command.mimeType &&
+    existing.contentHash === command.contentHash &&
+    existing.mediaAssetId === command.mediaAssetId &&
+    existing.variant === command.variant &&
+    existing.sourceContentHash === command.sourceContentHash &&
+    existing.body.byteLength === command.body.byteLength &&
+    existing.body.every((byte, index) => byte === command.body[index])
+  );
+}
+
+export function createInMemoryPrivatePhotoDerivativeStore(): PrivatePhotoDerivativeStore & {
+  snapshot(): StoredDerivative[];
+  seed(command: PrivatePhotoDerivativeWriteCommand): void;
+} {
+  const objects = new Map<string, StoredDerivative>();
+
+  return {
+    async writePrivateDerivative(command) {
+      const existing = objects.get(command.key);
+      if (existing !== undefined) {
+        if (!matches(existing, command)) {
+          throw new PrivatePhotoDerivativeStoreError(
+            'object_conflict',
+            'A private photo derivative key already contains different content.',
+          );
+        }
+        return { state: 'replayed' as const };
+      }
+      objects.set(command.key, clone(command));
+      return { state: 'created' as const };
+    },
+
+    async deletePrivateDerivative(key) {
+      objects.delete(key);
+    },
+
+    snapshot() {
+      return [...objects.values()]
+        .sort((left, right) => left.key.localeCompare(right.key))
+        .map((object) => ({ ...object, body: Uint8Array.from(object.body) }));
+    },
+
+    seed(command) {
+      objects.set(command.key, clone(command));
+    },
+  };
+}

--- a/src/submissions/photo-private-processing.ts
+++ b/src/submissions/photo-private-processing.ts
@@ -9,10 +9,10 @@ import {
   photosReviewProjectionSchema,
   publicGalleryMediaRoleSchema,
   submissionMediaMimeTypeSchema,
+  type PhotosReviewProjection,
 } from './photo-media-contract';
 import {
   photoObjectValidationReceiptSchema,
-  type PhotoObjectValidationResult,
   type ValidatedPhotoObject,
 } from './photo-object-validation';
 import { photoQuarantineObjectKey } from './photo-upload-authorization';
@@ -360,57 +360,44 @@ function assertReplay(
   return receiptFromEvent(existing, 'replayed');
 }
 
-async function requestFingerprint(
-  request: PhotoPrivateProcessingRequest,
-  context: PhotoProcessingSubmissionContext,
-): Promise<string> {
-  const normalized = photosReviewProjectionSchema.parse(context.normalizedPayload);
+async function requestFingerprint(request: PhotoPrivateProcessingRequest): Promise<string> {
   return sha256Text(
     JSON.stringify({
       schemaVersion: request.schemaVersion,
       processingRequestId: request.processingRequestId,
       submissionId: request.submissionId,
       processorVersion: request.processorVersion,
-      submissionUpdatedAt: context.updatedAt,
-      intakeRequestId: request.validation.receipt.intakeRequestId,
-      targetType: request.validation.receipt.targetType,
-      targetId: request.validation.receipt.targetId,
-      validatedAt: request.validation.receipt.validatedAt,
-      media: normalized.media.map((item) => {
-        const validated = request.validation.receipt.media.find(
-          (candidate) => candidate.quarantineUploadId === item.quarantineUploadId,
-        );
-        return {
-          quarantineUploadId: item.quarantineUploadId,
-          role: item.role,
-          declaredMimeType: item.declaredMimeType,
-          declaredByteSize: item.declaredByteSize,
-          capturedAt: item.capturedAt,
-          description: item.description,
-          suggestedAltText: item.suggestedAltText,
-          photographerPresent: item.photographerPresent,
-          rightsStatus: item.rightsStatus,
-          rightsHolderPresent: item.rightsHolderPresent,
-          permissionReferencePresent: item.permissionReferencePresent,
-          licenseName: item.licenseName,
-          licenseUrl: item.licenseUrl,
-          publicDisplayPermission: item.publicDisplayPermission,
-          validatedMimeType: validated?.mimeType,
-          validatedByteSize: validated?.byteSize,
-          width: validated?.width,
-          height: validated?.height,
-          contentHash: validated?.contentHash,
-        };
-      }),
+      receipt: request.validation.receipt,
+      objects: request.validation.objects.map((object) => ({
+        quarantineUploadId: object.quarantineUploadId,
+        privateObjectKey: object.privateObjectKey,
+        mimeType: object.mimeType,
+        byteSize: object.byteSize,
+        width: object.width,
+        height: object.height,
+        contentHash: object.contentHash,
+      })),
     }),
   );
+}
+
+function parseNormalizedPayload(value: unknown): PhotosReviewProjection {
+  const parsed = photosReviewProjectionSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new PhotoPrivateProcessingError(
+      'submission_unavailable',
+      'The Photos Submission is unavailable for private processing.',
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
 }
 
 async function assertValidationMatches(
   request: PhotoPrivateProcessingRequest,
   context: PhotoProcessingSubmissionContext,
-): Promise<Map<string, ValidatedPhotoObject>> {
-  const normalized = photosReviewProjectionSchema.parse(context.normalizedPayload);
+): Promise<{ normalized: PhotosReviewProjection; objects: Map<string, ValidatedPhotoObject> }> {
+  const normalized = parseNormalizedPayload(context.normalizedPayload);
   const receipt = request.validation.receipt;
   const objects = request.validation.objects;
 
@@ -504,7 +491,7 @@ async function assertValidationMatches(
     }
   }
 
-  return objectById;
+  return { normalized, objects: objectById };
 }
 
 function mapInspectionError(error: unknown): PhotoPrivateProcessingError {
@@ -526,7 +513,15 @@ async function validateDerivative(
   derivative: PhotoProcessedDerivative,
   source: ValidatedPhotoObject,
 ): Promise<PhotoProcessedDerivative & { contentHash: string }> {
-  const parsed = photoProcessedDerivativeSchema.parse(derivative);
+  const result = photoProcessedDerivativeSchema.safeParse(derivative);
+  if (!result.success) {
+    throw new PhotoPrivateProcessingError(
+      'derivative_invalid',
+      'The private photo processor returned an invalid derivative contract.',
+      { cause: result.error },
+    );
+  }
+  const parsed = result.data;
   const maximumBytes = parsed.variant === 'display' ? MAX_DISPLAY_BYTES : MAX_THUMBNAIL_BYTES;
   const maximumDimension =
     parsed.variant === 'display' ? MAX_DISPLAY_DIMENSION : MAX_THUMBNAIL_DIMENSION;
@@ -563,10 +558,7 @@ async function validateDerivative(
   return { ...parsed, contentHash: await sha256(parsed.body) };
 }
 
-async function cleanupCreated(
-  store: PrivatePhotoDerivativeStore,
-  keys: string[],
-): Promise<void> {
+async function cleanupCreated(store: PrivatePhotoDerivativeStore, keys: string[]): Promise<void> {
   await Promise.allSettled(keys.map((key) => store.deletePrivateDerivative(key)));
 }
 
@@ -574,7 +566,10 @@ export function createPhotoPrivateProcessingService(
   dependencies: PhotoPrivateProcessingServiceDependencies,
 ) {
   return {
-    async process(rawInput: unknown, processedAt = new Date()): Promise<PhotoPrivateProcessingReceipt> {
+    async process(
+      rawInput: unknown,
+      processedAt = new Date(),
+    ): Promise<PhotoPrivateProcessingReceipt> {
       validateDate(processedAt);
       let request: PhotoPrivateProcessingRequest;
       try {
@@ -587,7 +582,23 @@ export function createPhotoPrivateProcessingService(
         );
       }
 
-      const eventId = await deterministicUuid('photo-media-handoff-event-v1', request.processingRequestId);
+      const eventId = await deterministicUuid(
+        'photo-media-handoff-event-v1',
+        request.processingRequestId,
+      );
+      const fingerprint = await requestFingerprint(request);
+      let existing: PhotoMediaHandoffEventPayload | null;
+      try {
+        existing = await dependencies.persistence.readHandoffEvent(eventId);
+      } catch (error) {
+        throw new PhotoPrivateProcessingError(
+          'persistence_conflict',
+          'The private photo processing replay state could not be loaded.',
+          { cause: error },
+        );
+      }
+      if (existing !== null) return assertReplay(existing, request, fingerprint);
+
       let context: PhotoProcessingSubmissionContext | null;
       try {
         context = await dependencies.persistence.loadSubmissionContext(request.submissionId);
@@ -605,12 +616,9 @@ export function createPhotoPrivateProcessingService(
         );
       }
 
-      const fingerprint = await requestFingerprint(request, context);
-      const existing = await dependencies.persistence.readHandoffEvent(eventId);
-      if (existing !== null) return assertReplay(existing, request, fingerprint);
-
-      const objectById = await assertValidationMatches(request, context);
-      const normalized = photosReviewProjectionSchema.parse(context.normalizedPayload);
+      const validated = await assertValidationMatches(request, context);
+      const normalized = validated.normalized;
+      const objectById = validated.objects;
       const createdKeys: string[] = [];
       const assets: PhotoMediaAssetInsert[] = [];
       const files: PhotoMediaFileInsert[] = [];
@@ -639,15 +647,27 @@ export function createPhotoPrivateProcessingService(
               { cause: error },
             );
           }
-          const parsedOutput = z.array(photoProcessedDerivativeSchema).length(2).parse(processorOutput);
-          const variants = new Map(parsedOutput.map((candidate) => [candidate.variant, candidate]));
+          const outputResult = z.array(photoProcessedDerivativeSchema).length(2).safeParse(processorOutput);
+          if (!outputResult.success) {
+            throw new PhotoPrivateProcessingError(
+              'derivative_invalid',
+              'The private photo processor must return exactly two valid derivatives.',
+              { cause: outputResult.error },
+            );
+          }
+          const variants = new Map(
+            outputResult.data.map((candidate) => [candidate.variant, candidate]),
+          );
           if (variants.size !== 2 || !variants.has('display') || !variants.has('thumbnail')) {
             throw new PhotoPrivateProcessingError(
               'derivative_invalid',
               'The private photo processor must return one display and one thumbnail derivative.',
             );
           }
-          const display = await validateDerivative(variants.get('display') as PhotoProcessedDerivative, source);
+          const display = await validateDerivative(
+            variants.get('display') as PhotoProcessedDerivative,
+            source,
+          );
           const thumbnail = await validateDerivative(
             variants.get('thumbnail') as PhotoProcessedDerivative,
             source,
@@ -663,9 +683,18 @@ export function createPhotoPrivateProcessingService(
             'photo-media-asset-v1',
             `${context.id}:${item.quarantineUploadId}`,
           );
-          const originalFileId = await deterministicUuid('photo-media-file-original-v1', mediaAssetId);
-          const displayFileId = await deterministicUuid('photo-media-file-display-v1', mediaAssetId);
-          const thumbnailFileId = await deterministicUuid('photo-media-file-thumbnail-v1', mediaAssetId);
+          const originalFileId = await deterministicUuid(
+            'photo-media-file-original-v1',
+            mediaAssetId,
+          );
+          const displayFileId = await deterministicUuid(
+            'photo-media-file-display-v1',
+            mediaAssetId,
+          );
+          const thumbnailFileId = await deterministicUuid(
+            'photo-media-file-thumbnail-v1',
+            mediaAssetId,
+          );
           const displayKey = privateMediaDerivativeKey(mediaAssetId, {
             id: displayFileId,
             contentHash: display.contentHash,

--- a/src/submissions/photo-private-processing.ts
+++ b/src/submissions/photo-private-processing.ts
@@ -1,0 +1,834 @@
+import { z } from 'zod';
+import { privateMediaDerivativeKey } from '../admin/media-review/storage-plan';
+import {
+  inspectPhotoImage,
+  PhotoImageInspectionError,
+  type DecodedPhotoImage,
+} from './photo-image-inspection';
+import {
+  photosReviewProjectionSchema,
+  publicGalleryMediaRoleSchema,
+  submissionMediaMimeTypeSchema,
+} from './photo-media-contract';
+import {
+  photoObjectValidationReceiptSchema,
+  type PhotoObjectValidationResult,
+  type ValidatedPhotoObject,
+} from './photo-object-validation';
+import { photoQuarantineObjectKey } from './photo-upload-authorization';
+
+const MAX_ITEMS = 8;
+const MAX_DISPLAY_BYTES = 5_000_000;
+const MAX_THUMBNAIL_BYTES = 1_000_000;
+const MAX_DISPLAY_DIMENSION = 2_048;
+const MAX_THUMBNAIL_DIMENSION = 512;
+
+const processingWorkflowStatusSchema = z.enum([
+  'received',
+  'triage',
+  'in_review',
+  'needs_information',
+  'on_hold',
+]);
+
+const processorVersionSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(120)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:/-]*$/);
+
+const validatedPhotoObjectSchema = z
+  .object({
+    quarantineUploadId: z.uuid(),
+    privateObjectKey: z.string().min(1).max(512),
+    body: z.instanceof(Uint8Array),
+    mimeType: submissionMediaMimeTypeSchema,
+    byteSize: z.number().int().min(1).max(5_000_000),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
+    contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+  })
+  .strict();
+
+export const photoPrivateProcessingRequestSchema = z
+  .object({
+    schemaVersion: z.literal('photo-private-processing-v1'),
+    processingRequestId: z.uuid(),
+    submissionId: z.uuid(),
+    processorVersion: processorVersionSchema,
+    validation: z
+      .object({
+        receipt: photoObjectValidationReceiptSchema,
+        objects: z.array(validatedPhotoObjectSchema).min(1).max(MAX_ITEMS),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const photoProcessedDerivativeSchema = z
+  .object({
+    variant: z.enum(['display', 'thumbnail']),
+    body: z.instanceof(Uint8Array),
+    mimeType: z.enum(['image/jpeg', 'image/webp']),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
+    metadataStripped: z.literal(true),
+    orientationNormalized: z.literal(true),
+  })
+  .strict();
+
+const handoffReviewContextSchema = z
+  .object({
+    role: publicGalleryMediaRoleSchema,
+    capturedAt: z.string().nullable(),
+    description: z.string().nullable(),
+    suggestedAltText: z.string().nullable(),
+    photographerPresent: z.boolean(),
+    rightsStatus: z.enum(['submitted_with_permission', 'licensed', 'public_domain']),
+    rightsHolderPresent: z.boolean(),
+    permissionReferencePresent: z.boolean(),
+    licenseName: z.string().nullable(),
+    licenseUrl: z.string().nullable(),
+    publicDisplayPermission: z.literal(true),
+  })
+  .strict();
+
+export const photoMediaHandoffEventPayloadSchema = z
+  .object({
+    schemaVersion: z.literal('photo-media-handoff-event-v1'),
+    processingRequestId: z.uuid(),
+    requestFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    submissionId: z.uuid(),
+    processorVersion: processorVersionSchema,
+    processedAt: z.iso.datetime({ offset: true }),
+    targetType: z.enum(['entity', 'location']),
+    targetId: z.uuid(),
+    media: z
+      .array(
+        z
+          .object({
+            quarantineUploadId: z.uuid(),
+            mediaAssetId: z.uuid(),
+            originalFileId: z.uuid(),
+            displayFileId: z.uuid(),
+            thumbnailFileId: z.uuid(),
+            originalContentHash: z.string().regex(/^[a-f0-9]{64}$/),
+            displayContentHash: z.string().regex(/^[a-f0-9]{64}$/),
+            thumbnailContentHash: z.string().regex(/^[a-f0-9]{64}$/),
+            reviewContext: handoffReviewContextSchema,
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(MAX_ITEMS),
+  })
+  .strict();
+
+export const photoPrivateProcessingReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('photo-private-processing-receipt-v1'),
+    state: z.enum(['committed', 'replayed']),
+    processingRequestId: z.uuid(),
+    submissionId: z.uuid(),
+    processedAt: z.iso.datetime({ offset: true }),
+    media: z
+      .array(
+        z
+          .object({
+            quarantineUploadId: z.uuid(),
+            mediaAssetId: z.uuid(),
+            originalContentHash: z.string().regex(/^[a-f0-9]{64}$/),
+            displayFileId: z.uuid(),
+            displayContentHash: z.string().regex(/^[a-f0-9]{64}$/),
+            thumbnailFileId: z.uuid(),
+            thumbnailContentHash: z.string().regex(/^[a-f0-9]{64}$/),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(MAX_ITEMS),
+  })
+  .strict();
+
+export type PhotoPrivateProcessingRequest = z.infer<typeof photoPrivateProcessingRequestSchema>;
+export type PhotoProcessedDerivative = z.infer<typeof photoProcessedDerivativeSchema>;
+export type PhotoMediaHandoffEventPayload = z.infer<typeof photoMediaHandoffEventPayloadSchema>;
+export type PhotoPrivateProcessingReceipt = z.infer<typeof photoPrivateProcessingReceiptSchema>;
+
+export interface PhotoProcessingReservationSnapshot {
+  id: string;
+  intakeRequestId: string;
+  purpose: 'evidence_image' | 'owner_verification_proof' | 'public_gallery_candidate';
+  expiresAt: string;
+  consumedBySubmissionId: string | null;
+  consumedAt: string | null;
+}
+
+export interface PhotoProcessingSubmissionContext {
+  id: string;
+  intakeRequestId: string;
+  submissionType: 'photos';
+  targetType: 'entity' | 'location';
+  targetId: string;
+  workflowStatus: z.infer<typeof processingWorkflowStatusSchema>;
+  updatedAt: string;
+  normalizedPayload: unknown;
+  reservations: PhotoProcessingReservationSnapshot[];
+}
+
+export interface PhotoPrivateProcessorCommand {
+  source: ValidatedPhotoObject;
+  role: z.infer<typeof publicGalleryMediaRoleSchema>;
+  processorVersion: string;
+}
+
+export interface PhotoPrivateProcessor {
+  process(command: PhotoPrivateProcessorCommand): Promise<PhotoProcessedDerivative[]>;
+}
+
+export interface PrivatePhotoDerivativeWriteCommand {
+  key: string;
+  body: Uint8Array;
+  mimeType: 'image/jpeg' | 'image/webp';
+  contentHash: string;
+  mediaAssetId: string;
+  variant: 'display' | 'thumbnail';
+  sourceContentHash: string;
+}
+
+export interface PrivatePhotoDerivativeStore {
+  writePrivateDerivative(
+    command: PrivatePhotoDerivativeWriteCommand,
+  ): Promise<{ state: 'created' | 'replayed' }>;
+  deletePrivateDerivative(key: string): Promise<void>;
+}
+
+export interface PhotoMediaAssetInsert {
+  id: string;
+  purpose: 'public_gallery_candidate';
+  role: z.infer<typeof publicGalleryMediaRoleSchema>;
+  reviewStatus: 'pending';
+  rightsStatus: 'unknown';
+  visibility: 'private';
+  entityId: string | null;
+  locationId: string | null;
+  displayOrder: number;
+  capturedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface PhotoMediaFileInsert {
+  id: string;
+  mediaAssetId: string;
+  variant: 'original' | 'display' | 'thumbnail';
+  storageScope: 'quarantine' | 'private';
+  storageKey: string;
+  originalFilename: null;
+  mimeType: string;
+  byteSize: number;
+  width: number;
+  height: number;
+  contentHash: string;
+  createdAt: Date;
+}
+
+export interface PhotoMediaHandoffCommitCommand {
+  eventId: string;
+  eventPayload: PhotoMediaHandoffEventPayload;
+  submissionId: string;
+  expectedSubmissionUpdatedAt: Date;
+  expectedWorkflowStatus: z.infer<typeof processingWorkflowStatusSchema>;
+  assets: PhotoMediaAssetInsert[];
+  files: PhotoMediaFileInsert[];
+}
+
+export interface PhotoMediaHandoffPersistence {
+  loadSubmissionContext(submissionId: string): Promise<PhotoProcessingSubmissionContext | null>;
+  readHandoffEvent(eventId: string): Promise<PhotoMediaHandoffEventPayload | null>;
+  commitHandoff(command: PhotoMediaHandoffCommitCommand): Promise<void>;
+}
+
+export class PhotoPrivateProcessingError extends Error {
+  constructor(
+    readonly code:
+      | 'invalid_request'
+      | 'idempotency_conflict'
+      | 'submission_unavailable'
+      | 'validation_conflict'
+      | 'processing_failed'
+      | 'derivative_invalid'
+      | 'storage_conflict'
+      | 'persistence_conflict',
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'PhotoPrivateProcessingError';
+  }
+}
+
+export interface PhotoPrivateProcessingServiceDependencies {
+  persistence: PhotoMediaHandoffPersistence;
+  processor: PhotoPrivateProcessor;
+  derivatives: PrivatePhotoDerivativeStore;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function sha256(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', Uint8Array.from(bytes));
+  return bytesToHex(new Uint8Array(digest));
+}
+
+async function sha256Text(value: string): Promise<string> {
+  return sha256(new TextEncoder().encode(value));
+}
+
+function uuidFromDigest(digest: Uint8Array): string {
+  const bytes = Uint8Array.from(digest.slice(0, 16));
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x80;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = bytesToHex(bytes);
+  return z
+    .uuid()
+    .parse(
+      `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`,
+    );
+}
+
+async function deterministicUuid(namespace: string, value: string): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(`cryptopaymap:${namespace}:${value}`),
+    ),
+  );
+  return uuidFromDigest(digest);
+}
+
+function validateDate(value: Date): void {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new PhotoPrivateProcessingError(
+      'invalid_request',
+      'Photo processing timestamp is invalid.',
+    );
+  }
+}
+
+function receiptFromEvent(
+  payload: PhotoMediaHandoffEventPayload,
+  state: 'committed' | 'replayed',
+): PhotoPrivateProcessingReceipt {
+  return photoPrivateProcessingReceiptSchema.parse({
+    schemaVersion: 'photo-private-processing-receipt-v1',
+    state,
+    processingRequestId: payload.processingRequestId,
+    submissionId: payload.submissionId,
+    processedAt: payload.processedAt,
+    media: payload.media.map((item) => ({
+      quarantineUploadId: item.quarantineUploadId,
+      mediaAssetId: item.mediaAssetId,
+      originalContentHash: item.originalContentHash,
+      displayFileId: item.displayFileId,
+      displayContentHash: item.displayContentHash,
+      thumbnailFileId: item.thumbnailFileId,
+      thumbnailContentHash: item.thumbnailContentHash,
+    })),
+  });
+}
+
+function assertReplay(
+  existing: PhotoMediaHandoffEventPayload,
+  request: PhotoPrivateProcessingRequest,
+  fingerprint: string,
+): PhotoPrivateProcessingReceipt {
+  if (
+    existing.processingRequestId !== request.processingRequestId ||
+    existing.submissionId !== request.submissionId ||
+    existing.processorVersion !== request.processorVersion ||
+    existing.requestFingerprint !== fingerprint
+  ) {
+    throw new PhotoPrivateProcessingError(
+      'idempotency_conflict',
+      'The photo processing request identity was reused with different content.',
+    );
+  }
+  return receiptFromEvent(existing, 'replayed');
+}
+
+async function requestFingerprint(
+  request: PhotoPrivateProcessingRequest,
+  context: PhotoProcessingSubmissionContext,
+): Promise<string> {
+  const normalized = photosReviewProjectionSchema.parse(context.normalizedPayload);
+  return sha256Text(
+    JSON.stringify({
+      schemaVersion: request.schemaVersion,
+      processingRequestId: request.processingRequestId,
+      submissionId: request.submissionId,
+      processorVersion: request.processorVersion,
+      submissionUpdatedAt: context.updatedAt,
+      intakeRequestId: request.validation.receipt.intakeRequestId,
+      targetType: request.validation.receipt.targetType,
+      targetId: request.validation.receipt.targetId,
+      validatedAt: request.validation.receipt.validatedAt,
+      media: normalized.media.map((item) => {
+        const validated = request.validation.receipt.media.find(
+          (candidate) => candidate.quarantineUploadId === item.quarantineUploadId,
+        );
+        return {
+          quarantineUploadId: item.quarantineUploadId,
+          role: item.role,
+          declaredMimeType: item.declaredMimeType,
+          declaredByteSize: item.declaredByteSize,
+          capturedAt: item.capturedAt,
+          description: item.description,
+          suggestedAltText: item.suggestedAltText,
+          photographerPresent: item.photographerPresent,
+          rightsStatus: item.rightsStatus,
+          rightsHolderPresent: item.rightsHolderPresent,
+          permissionReferencePresent: item.permissionReferencePresent,
+          licenseName: item.licenseName,
+          licenseUrl: item.licenseUrl,
+          publicDisplayPermission: item.publicDisplayPermission,
+          validatedMimeType: validated?.mimeType,
+          validatedByteSize: validated?.byteSize,
+          width: validated?.width,
+          height: validated?.height,
+          contentHash: validated?.contentHash,
+        };
+      }),
+    }),
+  );
+}
+
+async function assertValidationMatches(
+  request: PhotoPrivateProcessingRequest,
+  context: PhotoProcessingSubmissionContext,
+): Promise<Map<string, ValidatedPhotoObject>> {
+  const normalized = photosReviewProjectionSchema.parse(context.normalizedPayload);
+  const receipt = request.validation.receipt;
+  const objects = request.validation.objects;
+
+  if (
+    context.id !== request.submissionId ||
+    context.submissionType !== 'photos' ||
+    context.intakeRequestId !== receipt.intakeRequestId ||
+    context.targetType !== receipt.targetType ||
+    context.targetId !== receipt.targetId ||
+    !processingWorkflowStatusSchema.safeParse(context.workflowStatus).success
+  ) {
+    throw new PhotoPrivateProcessingError(
+      'submission_unavailable',
+      'The Photos Submission is unavailable for private processing.',
+    );
+  }
+
+  if (
+    normalized.targetType !== context.targetType ||
+    normalized.targetId !== context.targetId ||
+    normalized.media.length !== receipt.media.length ||
+    normalized.media.length !== objects.length ||
+    normalized.media.length !== context.reservations.length
+  ) {
+    throw new PhotoPrivateProcessingError(
+      'validation_conflict',
+      'The validated photo set does not match its private Submission context.',
+    );
+  }
+
+  const validationTime = Date.parse(receipt.validatedAt);
+  if (!Number.isFinite(validationTime)) {
+    throw new PhotoPrivateProcessingError(
+      'validation_conflict',
+      'The photo validation receipt is invalid.',
+    );
+  }
+
+  const receiptById = new Map(receipt.media.map((item) => [item.quarantineUploadId, item]));
+  const objectById = new Map(objects.map((item) => [item.quarantineUploadId, item]));
+  const reservationById = new Map(context.reservations.map((item) => [item.id, item]));
+  if (
+    receiptById.size !== receipt.media.length ||
+    objectById.size !== objects.length ||
+    reservationById.size !== context.reservations.length
+  ) {
+    throw new PhotoPrivateProcessingError(
+      'validation_conflict',
+      'The validated photo set contains duplicate private references.',
+    );
+  }
+
+  for (const item of normalized.media) {
+    const validated = receiptById.get(item.quarantineUploadId);
+    const object = objectById.get(item.quarantineUploadId);
+    const reservation = reservationById.get(item.quarantineUploadId);
+    if (validated === undefined || object === undefined || reservation === undefined) {
+      throw new PhotoPrivateProcessingError(
+        'validation_conflict',
+        'The validated photo set is incomplete.',
+      );
+    }
+    if (
+      item.purpose !== 'public_gallery_candidate' ||
+      validated.mimeType !== item.declaredMimeType ||
+      validated.byteSize !== item.declaredByteSize ||
+      object.mimeType !== validated.mimeType ||
+      object.byteSize !== validated.byteSize ||
+      object.width !== validated.width ||
+      object.height !== validated.height ||
+      object.contentHash !== validated.contentHash ||
+      object.privateObjectKey !== photoQuarantineObjectKey(item.quarantineUploadId) ||
+      object.body.byteLength !== object.byteSize ||
+      reservation.intakeRequestId !== context.intakeRequestId ||
+      reservation.purpose !== 'public_gallery_candidate' ||
+      reservation.consumedBySubmissionId !== context.id ||
+      reservation.consumedAt === null ||
+      validationTime > Date.parse(reservation.expiresAt) ||
+      validationTime > Date.parse(reservation.consumedAt)
+    ) {
+      throw new PhotoPrivateProcessingError(
+        'validation_conflict',
+        'The validated photo does not match its consumed private reservation.',
+      );
+    }
+    if ((await sha256(object.body)) !== object.contentHash) {
+      throw new PhotoPrivateProcessingError(
+        'validation_conflict',
+        'The validated photo bytes changed before processing.',
+      );
+    }
+  }
+
+  return objectById;
+}
+
+function mapInspectionError(error: unknown): PhotoPrivateProcessingError {
+  if (error instanceof PhotoImageInspectionError) {
+    return new PhotoPrivateProcessingError(
+      'derivative_invalid',
+      'The private photo processor returned an invalid derivative.',
+      { cause: error },
+    );
+  }
+  return new PhotoPrivateProcessingError(
+    'derivative_invalid',
+    'The private photo derivative could not be inspected.',
+    { cause: error },
+  );
+}
+
+async function validateDerivative(
+  derivative: PhotoProcessedDerivative,
+  source: ValidatedPhotoObject,
+): Promise<PhotoProcessedDerivative & { contentHash: string }> {
+  const parsed = photoProcessedDerivativeSchema.parse(derivative);
+  const maximumBytes = parsed.variant === 'display' ? MAX_DISPLAY_BYTES : MAX_THUMBNAIL_BYTES;
+  const maximumDimension =
+    parsed.variant === 'display' ? MAX_DISPLAY_DIMENSION : MAX_THUMBNAIL_DIMENSION;
+  if (
+    parsed.body.byteLength === 0 ||
+    parsed.body.byteLength > maximumBytes ||
+    parsed.width > maximumDimension ||
+    parsed.height > maximumDimension ||
+    parsed.width * parsed.height > source.width * source.height
+  ) {
+    throw new PhotoPrivateProcessingError(
+      'derivative_invalid',
+      'The private photo derivative exceeds its processing boundary.',
+    );
+  }
+
+  let inspected: DecodedPhotoImage;
+  try {
+    inspected = inspectPhotoImage(parsed.body);
+  } catch (error) {
+    throw mapInspectionError(error);
+  }
+  if (
+    inspected.animated ||
+    inspected.mimeType !== parsed.mimeType ||
+    inspected.width !== parsed.width ||
+    inspected.height !== parsed.height
+  ) {
+    throw new PhotoPrivateProcessingError(
+      'derivative_invalid',
+      'The private photo derivative does not match its declared result.',
+    );
+  }
+  return { ...parsed, contentHash: await sha256(parsed.body) };
+}
+
+async function cleanupCreated(
+  store: PrivatePhotoDerivativeStore,
+  keys: string[],
+): Promise<void> {
+  await Promise.allSettled(keys.map((key) => store.deletePrivateDerivative(key)));
+}
+
+export function createPhotoPrivateProcessingService(
+  dependencies: PhotoPrivateProcessingServiceDependencies,
+) {
+  return {
+    async process(rawInput: unknown, processedAt = new Date()): Promise<PhotoPrivateProcessingReceipt> {
+      validateDate(processedAt);
+      let request: PhotoPrivateProcessingRequest;
+      try {
+        request = photoPrivateProcessingRequestSchema.parse(rawInput);
+      } catch (error) {
+        throw new PhotoPrivateProcessingError(
+          'invalid_request',
+          'Private photo processing request failed validation.',
+          { cause: error },
+        );
+      }
+
+      const eventId = await deterministicUuid('photo-media-handoff-event-v1', request.processingRequestId);
+      let context: PhotoProcessingSubmissionContext | null;
+      try {
+        context = await dependencies.persistence.loadSubmissionContext(request.submissionId);
+      } catch (error) {
+        throw new PhotoPrivateProcessingError(
+          'persistence_conflict',
+          'The private photo processing context could not be loaded.',
+          { cause: error },
+        );
+      }
+      if (context === null) {
+        throw new PhotoPrivateProcessingError(
+          'submission_unavailable',
+          'The Photos Submission is unavailable for private processing.',
+        );
+      }
+
+      const fingerprint = await requestFingerprint(request, context);
+      const existing = await dependencies.persistence.readHandoffEvent(eventId);
+      if (existing !== null) return assertReplay(existing, request, fingerprint);
+
+      const objectById = await assertValidationMatches(request, context);
+      const normalized = photosReviewProjectionSchema.parse(context.normalizedPayload);
+      const createdKeys: string[] = [];
+      const assets: PhotoMediaAssetInsert[] = [];
+      const files: PhotoMediaFileInsert[] = [];
+      const eventMedia: PhotoMediaHandoffEventPayload['media'] = [];
+
+      try {
+        for (const [index, item] of normalized.media.entries()) {
+          const source = objectById.get(item.quarantineUploadId);
+          if (source === undefined) {
+            throw new PhotoPrivateProcessingError(
+              'validation_conflict',
+              'The validated photo set is incomplete.',
+            );
+          }
+          let processorOutput: PhotoProcessedDerivative[];
+          try {
+            processorOutput = await dependencies.processor.process({
+              source,
+              role: item.role,
+              processorVersion: request.processorVersion,
+            });
+          } catch (error) {
+            throw new PhotoPrivateProcessingError(
+              'processing_failed',
+              'The private photo processor failed.',
+              { cause: error },
+            );
+          }
+          const parsedOutput = z.array(photoProcessedDerivativeSchema).length(2).parse(processorOutput);
+          const variants = new Map(parsedOutput.map((candidate) => [candidate.variant, candidate]));
+          if (variants.size !== 2 || !variants.has('display') || !variants.has('thumbnail')) {
+            throw new PhotoPrivateProcessingError(
+              'derivative_invalid',
+              'The private photo processor must return one display and one thumbnail derivative.',
+            );
+          }
+          const display = await validateDerivative(variants.get('display') as PhotoProcessedDerivative, source);
+          const thumbnail = await validateDerivative(
+            variants.get('thumbnail') as PhotoProcessedDerivative,
+            source,
+          );
+          if (display.width * display.height < thumbnail.width * thumbnail.height) {
+            throw new PhotoPrivateProcessingError(
+              'derivative_invalid',
+              'The display derivative cannot be smaller than the thumbnail derivative.',
+            );
+          }
+
+          const mediaAssetId = await deterministicUuid(
+            'photo-media-asset-v1',
+            `${context.id}:${item.quarantineUploadId}`,
+          );
+          const originalFileId = await deterministicUuid('photo-media-file-original-v1', mediaAssetId);
+          const displayFileId = await deterministicUuid('photo-media-file-display-v1', mediaAssetId);
+          const thumbnailFileId = await deterministicUuid('photo-media-file-thumbnail-v1', mediaAssetId);
+          const displayKey = privateMediaDerivativeKey(mediaAssetId, {
+            id: displayFileId,
+            contentHash: display.contentHash,
+            mimeType: display.mimeType,
+          });
+          const thumbnailKey = privateMediaDerivativeKey(mediaAssetId, {
+            id: thumbnailFileId,
+            contentHash: thumbnail.contentHash,
+            mimeType: thumbnail.mimeType,
+          });
+
+          for (const command of [
+            {
+              key: displayKey,
+              body: display.body,
+              mimeType: display.mimeType,
+              contentHash: display.contentHash,
+              mediaAssetId,
+              variant: 'display' as const,
+              sourceContentHash: source.contentHash,
+            },
+            {
+              key: thumbnailKey,
+              body: thumbnail.body,
+              mimeType: thumbnail.mimeType,
+              contentHash: thumbnail.contentHash,
+              mediaAssetId,
+              variant: 'thumbnail' as const,
+              sourceContentHash: source.contentHash,
+            },
+          ]) {
+            const written = await dependencies.derivatives.writePrivateDerivative(command);
+            if (written.state === 'created') createdKeys.push(command.key);
+          }
+
+          const capturedAt =
+            item.capturedAt === null ? null : new Date(`${item.capturedAt}T00:00:00.000Z`);
+          assets.push({
+            id: mediaAssetId,
+            purpose: 'public_gallery_candidate',
+            role: item.role,
+            reviewStatus: 'pending',
+            rightsStatus: 'unknown',
+            visibility: 'private',
+            entityId: context.targetType === 'entity' ? context.targetId : null,
+            locationId: context.targetType === 'location' ? context.targetId : null,
+            displayOrder: index,
+            capturedAt,
+            createdAt: processedAt,
+            updatedAt: processedAt,
+          });
+          files.push(
+            {
+              id: originalFileId,
+              mediaAssetId,
+              variant: 'original',
+              storageScope: 'quarantine',
+              storageKey: source.privateObjectKey,
+              originalFilename: null,
+              mimeType: source.mimeType,
+              byteSize: source.byteSize,
+              width: source.width,
+              height: source.height,
+              contentHash: source.contentHash,
+              createdAt: processedAt,
+            },
+            {
+              id: displayFileId,
+              mediaAssetId,
+              variant: 'display',
+              storageScope: 'private',
+              storageKey: displayKey,
+              originalFilename: null,
+              mimeType: display.mimeType,
+              byteSize: display.body.byteLength,
+              width: display.width,
+              height: display.height,
+              contentHash: display.contentHash,
+              createdAt: processedAt,
+            },
+            {
+              id: thumbnailFileId,
+              mediaAssetId,
+              variant: 'thumbnail',
+              storageScope: 'private',
+              storageKey: thumbnailKey,
+              originalFilename: null,
+              mimeType: thumbnail.mimeType,
+              byteSize: thumbnail.body.byteLength,
+              width: thumbnail.width,
+              height: thumbnail.height,
+              contentHash: thumbnail.contentHash,
+              createdAt: processedAt,
+            },
+          );
+          eventMedia.push({
+            quarantineUploadId: item.quarantineUploadId,
+            mediaAssetId,
+            originalFileId,
+            displayFileId,
+            thumbnailFileId,
+            originalContentHash: source.contentHash,
+            displayContentHash: display.contentHash,
+            thumbnailContentHash: thumbnail.contentHash,
+            reviewContext: {
+              role: item.role,
+              capturedAt: item.capturedAt,
+              description: item.description,
+              suggestedAltText: item.suggestedAltText,
+              photographerPresent: item.photographerPresent,
+              rightsStatus: item.rightsStatus,
+              rightsHolderPresent: item.rightsHolderPresent,
+              permissionReferencePresent: item.permissionReferencePresent,
+              licenseName: item.licenseName,
+              licenseUrl: item.licenseUrl,
+              publicDisplayPermission: item.publicDisplayPermission,
+            },
+          });
+        }
+      } catch (error) {
+        await cleanupCreated(dependencies.derivatives, createdKeys);
+        if (error instanceof PhotoPrivateProcessingError) throw error;
+        throw new PhotoPrivateProcessingError(
+          'storage_conflict',
+          'Private photo derivatives could not be staged.',
+          { cause: error },
+        );
+      }
+
+      const eventPayload = photoMediaHandoffEventPayloadSchema.parse({
+        schemaVersion: 'photo-media-handoff-event-v1',
+        processingRequestId: request.processingRequestId,
+        requestFingerprint: fingerprint,
+        submissionId: context.id,
+        processorVersion: request.processorVersion,
+        processedAt: processedAt.toISOString(),
+        targetType: context.targetType,
+        targetId: context.targetId,
+        media: eventMedia,
+      });
+
+      try {
+        await dependencies.persistence.commitHandoff({
+          eventId,
+          eventPayload,
+          submissionId: context.id,
+          expectedSubmissionUpdatedAt: new Date(context.updatedAt),
+          expectedWorkflowStatus: context.workflowStatus,
+          assets,
+          files,
+        });
+      } catch (error) {
+        const raced = await dependencies.persistence.readHandoffEvent(eventId);
+        if (raced !== null) return assertReplay(raced, request, fingerprint);
+        await cleanupCreated(dependencies.derivatives, createdKeys);
+        throw new PhotoPrivateProcessingError(
+          'persistence_conflict',
+          'Private photo Media handoff could not be committed.',
+          { cause: error },
+        );
+      }
+
+      return receiptFromEvent(eventPayload, 'committed');
+    },
+  };
+}

--- a/src/submissions/photo-private-processing.ts
+++ b/src/submissions/photo-private-processing.ts
@@ -647,7 +647,10 @@ export function createPhotoPrivateProcessingService(
               { cause: error },
             );
           }
-          const outputResult = z.array(photoProcessedDerivativeSchema).length(2).safeParse(processorOutput);
+          const outputResult = z
+            .array(photoProcessedDerivativeSchema)
+            .length(2)
+            .safeParse(processorOutput);
           if (!outputResult.success) {
             throw new PhotoPrivateProcessingError(
               'derivative_invalid',

--- a/src/submissions/r2-private-photo-derivatives.ts
+++ b/src/submissions/r2-private-photo-derivatives.ts
@@ -1,0 +1,97 @@
+import type { R2BucketLike, R2ObjectLike } from '../admin/media-review/r2-storage';
+import type {
+  PrivatePhotoDerivativeStore,
+  PrivatePhotoDerivativeWriteCommand,
+} from './photo-private-processing';
+
+export class PrivatePhotoDerivativeStoreError extends Error {
+  constructor(
+    readonly code: 'object_conflict' | 'write_failed',
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'PrivatePhotoDerivativeStoreError';
+  }
+}
+
+function matches(object: R2ObjectLike, command: PrivatePhotoDerivativeWriteCommand): boolean {
+  return (
+    object.key === command.key &&
+    object.size === command.body.byteLength &&
+    object.httpMetadata?.contentType === command.mimeType &&
+    object.customMetadata?.contentHash === command.contentHash &&
+    object.customMetadata?.sourceContentHash === command.sourceContentHash &&
+    object.customMetadata?.mediaAssetId === command.mediaAssetId &&
+    object.customMetadata?.variant === command.variant &&
+    object.customMetadata?.scope === 'private-review-derivative'
+  );
+}
+
+export function createR2PrivatePhotoDerivativeStore(
+  privateBucket: R2BucketLike,
+): PrivatePhotoDerivativeStore {
+  return {
+    async writePrivateDerivative(command) {
+      let existing: R2ObjectLike | null;
+      try {
+        existing = await privateBucket.head(command.key);
+      } catch (error) {
+        throw new PrivatePhotoDerivativeStoreError(
+          'write_failed',
+          'Private photo derivative state could not be inspected.',
+          { cause: error },
+        );
+      }
+      if (existing !== null) {
+        if (!matches(existing, command)) {
+          throw new PrivatePhotoDerivativeStoreError(
+            'object_conflict',
+            'A private photo derivative key already contains different content.',
+          );
+        }
+        return { state: 'replayed' as const };
+      }
+
+      try {
+        await privateBucket.put(command.key, command.body, {
+          httpMetadata: { contentType: command.mimeType },
+          customMetadata: {
+            contentHash: command.contentHash,
+            sourceContentHash: command.sourceContentHash,
+            mediaAssetId: command.mediaAssetId,
+            variant: command.variant,
+            scope: 'private-review-derivative',
+          },
+        });
+        const written = await privateBucket.head(command.key);
+        if (written === null || !matches(written, command)) {
+          throw new PrivatePhotoDerivativeStoreError(
+            'write_failed',
+            'Private photo derivative verification failed after storage.',
+          );
+        }
+      } catch (error) {
+        if (error instanceof PrivatePhotoDerivativeStoreError) throw error;
+        throw new PrivatePhotoDerivativeStoreError(
+          'write_failed',
+          'Private photo derivative could not be stored.',
+          { cause: error },
+        );
+      }
+      return { state: 'created' as const };
+    },
+
+    async deletePrivateDerivative(key) {
+      try {
+        await privateBucket.delete(key);
+      } catch (error) {
+        throw new PrivatePhotoDerivativeStoreError(
+          'write_failed',
+          'Private photo derivative cleanup failed.',
+          { cause: error },
+        );
+      }
+    },
+  };
+}

--- a/tests/photo-private-derivative-storage.test.ts
+++ b/tests/photo-private-derivative-storage.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  R2BucketLike,
+  R2ObjectBodyLike,
+  R2ObjectLike,
+} from '../src/admin/media-review/r2-storage';
+import { createR2PrivatePhotoDerivativeStore } from '../src/submissions/r2-private-photo-derivatives';
+
+class MemoryBucket implements R2BucketLike {
+  readonly objects = new Map<
+    string,
+    {
+      body: Uint8Array;
+      httpMetadata: { contentType: string };
+      customMetadata: Record<string, string>;
+    }
+  >();
+
+  async head(key: string): Promise<R2ObjectLike | null> {
+    const object = this.objects.get(key);
+    if (object === undefined) return null;
+    return {
+      key,
+      size: object.body.byteLength,
+      httpMetadata: { ...object.httpMetadata },
+      customMetadata: { ...object.customMetadata },
+    };
+  }
+
+  async get(key: string): Promise<R2ObjectBodyLike | null> {
+    const object = this.objects.get(key);
+    if (object === undefined) return null;
+    return {
+      key,
+      size: object.body.byteLength,
+      body: Uint8Array.from(object.body),
+      httpMetadata: { ...object.httpMetadata },
+      customMetadata: { ...object.customMetadata },
+    };
+  }
+
+  async put(
+    key: string,
+    value: unknown,
+    options: {
+      httpMetadata: { contentType: string };
+      customMetadata: Record<string, string>;
+    },
+  ) {
+    if (!(value instanceof Uint8Array)) throw new Error('expected bytes');
+    this.objects.set(key, {
+      body: Uint8Array.from(value),
+      httpMetadata: { ...options.httpMetadata },
+      customMetadata: { ...options.customMetadata },
+    });
+  }
+
+  async delete(key: string) {
+    this.objects.delete(key);
+  }
+}
+
+const command = {
+  key: `media/private/10000000-0000-4000-8000-000000000001/${'a'.repeat(64)}.webp`,
+  body: Uint8Array.from([1, 2, 3]),
+  mimeType: 'image/webp' as const,
+  contentHash: 'a'.repeat(64),
+  mediaAssetId: '10000000-0000-4000-8000-000000000001',
+  variant: 'display' as const,
+  sourceContentHash: 'b'.repeat(64),
+};
+
+describe('P5-05E R2-compatible private derivative storage', () => {
+  it('creates, verifies, replays, and deletes exact private derivatives', async () => {
+    const bucket = new MemoryBucket();
+    const store = createR2PrivatePhotoDerivativeStore(bucket);
+
+    await expect(store.writePrivateDerivative(command)).resolves.toEqual({ state: 'created' });
+    await expect(store.writePrivateDerivative(command)).resolves.toEqual({ state: 'replayed' });
+    expect(await bucket.head(command.key)).toEqual(
+      expect.objectContaining({
+        size: 3,
+        httpMetadata: { contentType: 'image/webp' },
+        customMetadata: expect.objectContaining({
+          contentHash: command.contentHash,
+          sourceContentHash: command.sourceContentHash,
+          mediaAssetId: command.mediaAssetId,
+          variant: 'display',
+          scope: 'private-review-derivative',
+        }),
+      }),
+    );
+
+    await store.deletePrivateDerivative(command.key);
+    await expect(bucket.head(command.key)).resolves.toBeNull();
+  });
+
+  it('rejects a pre-existing key with different content or metadata', async () => {
+    const bucket = new MemoryBucket();
+    const store = createR2PrivatePhotoDerivativeStore(bucket);
+    await store.writePrivateDerivative(command);
+
+    await expect(
+      store.writePrivateDerivative({
+        ...command,
+        body: Uint8Array.from([9, 9, 9]),
+        contentHash: 'c'.repeat(64),
+      }),
+    ).rejects.toMatchObject({ code: 'object_conflict' });
+  });
+});

--- a/tests/photo-private-processing.test.ts
+++ b/tests/photo-private-processing.test.ts
@@ -1,0 +1,525 @@
+import { describe, expect, it } from 'vitest';
+import { createInMemoryPrivatePhotoDerivativeStore } from '../src/submissions/in-memory-private-photo-derivatives';
+import {
+  createPhotoPrivateProcessingService,
+  PhotoPrivateProcessingError,
+  type PhotoMediaHandoffCommitCommand,
+  type PhotoMediaHandoffEventPayload,
+  type PhotoMediaHandoffPersistence,
+  type PhotoPrivateProcessingRequest,
+  type PhotoPrivateProcessor,
+  type PhotoProcessingSubmissionContext,
+} from '../src/submissions/photo-private-processing';
+import { photoQuarantineObjectKey } from '../src/submissions/photo-upload-authorization';
+
+const submissionId = '10000000-0000-4000-8000-000000000001';
+const intakeRequestId = '20000000-0000-4000-8000-000000000001';
+const processingRequestId = '30000000-0000-4000-8000-000000000001';
+const targetId = '40000000-0000-4000-8000-000000000001';
+const reservationId = '50000000-0000-4000-8000-000000000001';
+const validatedAt = '2026-07-15T00:00:00.000Z';
+const consumedAt = '2026-07-15T00:05:00.000Z';
+const processedAt = new Date('2026-07-15T00:06:00.000Z');
+
+function uint32Be(value: number): number[] {
+  return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff];
+}
+
+function uint32Le(value: number): number[] {
+  return [value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff];
+}
+
+function ascii(value: string): number[] {
+  return [...value].map((character) => character.charCodeAt(0));
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc & 1) === 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: number[]): number[] {
+  const typeBytes = ascii(type);
+  return [
+    ...uint32Be(data.length),
+    ...typeBytes,
+    ...data,
+    ...uint32Be(crc32(Uint8Array.from([...typeBytes, ...data]))),
+  ];
+}
+
+function png(width: number, height: number): Uint8Array {
+  return Uint8Array.from([
+    0x89,
+    0x50,
+    0x4e,
+    0x47,
+    0x0d,
+    0x0a,
+    0x1a,
+    0x0a,
+    ...pngChunk('IHDR', [...uint32Be(width), ...uint32Be(height), 8, 2, 0, 0, 0]),
+    ...pngChunk('IDAT', [0]),
+    ...pngChunk('IEND', []),
+  ]);
+}
+
+function webp(width: number, height: number, animated = false): Uint8Array {
+  const payload = [
+    animated ? 0x02 : 0x00,
+    0,
+    0,
+    0,
+    ...uint32Le(width - 1).slice(0, 3),
+    ...uint32Le(height - 1).slice(0, 3),
+  ];
+  const body = [...ascii('VP8X'), ...uint32Le(payload.length), ...payload];
+  return Uint8Array.from([
+    ...ascii('RIFF'),
+    ...uint32Le(4 + body.length),
+    ...ascii('WEBP'),
+    ...body,
+  ]);
+}
+
+async function hash(bytes: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', Uint8Array.from(bytes)),
+  );
+  return [...digest].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+class MemoryPersistence implements PhotoMediaHandoffPersistence {
+  readonly events = new Map<string, PhotoMediaHandoffEventPayload>();
+  readonly commits: PhotoMediaHandoffCommitCommand[] = [];
+  failCommit = false;
+
+  constructor(readonly context: PhotoProcessingSubmissionContext | null) {}
+
+  async loadSubmissionContext() {
+    return this.context === null ? null : structuredClone(this.context);
+  }
+
+  async readHandoffEvent(eventId: string) {
+    const event = this.events.get(eventId);
+    return event === undefined ? null : structuredClone(event);
+  }
+
+  async commitHandoff(command: PhotoMediaHandoffCommitCommand) {
+    if (this.failCommit) throw new Error('commit failed');
+    if (this.events.has(command.eventId)) throw new Error('duplicate event');
+    if (
+      this.context === null ||
+      command.submissionId !== this.context.id ||
+      command.expectedSubmissionUpdatedAt.toISOString() !== this.context.updatedAt ||
+      command.expectedWorkflowStatus !== this.context.workflowStatus
+    ) {
+      throw new Error('stale submission');
+    }
+    this.commits.push(structuredClone(command));
+    this.events.set(command.eventId, structuredClone(command.eventPayload));
+  }
+}
+
+function processor(overrides: Partial<PhotoPrivateProcessor> = {}): PhotoPrivateProcessor & {
+  calls: number;
+} {
+  const result: PhotoPrivateProcessor & { calls: number } = {
+    calls: 0,
+    async process() {
+      result.calls += 1;
+      return [
+        {
+          variant: 'display',
+          body: webp(800, 600),
+          mimeType: 'image/webp',
+          width: 800,
+          height: 600,
+          metadataStripped: true,
+          orientationNormalized: true,
+        },
+        {
+          variant: 'thumbnail',
+          body: webp(160, 120),
+          mimeType: 'image/webp',
+          width: 160,
+          height: 120,
+          metadataStripped: true,
+          orientationNormalized: true,
+        },
+      ];
+    },
+    ...overrides,
+  };
+  return result;
+}
+
+async function fixture() {
+  const body = png(1_000, 800);
+  const contentHash = await hash(body);
+  const context: PhotoProcessingSubmissionContext = {
+    id: submissionId,
+    intakeRequestId,
+    submissionType: 'photos',
+    targetType: 'location',
+    targetId,
+    workflowStatus: 'received',
+    updatedAt: consumedAt,
+    normalizedPayload: {
+      targetType: 'location',
+      targetId,
+      relationship: 'customer',
+      media: [
+        {
+          quarantineUploadId: reservationId,
+          purpose: 'public_gallery_candidate',
+          role: 'cover',
+          declaredMimeType: 'image/png',
+          declaredByteSize: body.byteLength,
+          capturedAt: '2026-07-14',
+          description: 'Storefront exterior.',
+          suggestedAltText: 'Exterior of the storefront.',
+          photographerPresent: true,
+          rightsStatus: 'submitted_with_permission',
+          rightsHolderPresent: true,
+          permissionReferencePresent: false,
+          licenseName: null,
+          licenseUrl: null,
+          publicDisplayPermission: true,
+        },
+      ],
+      submitterNote: null,
+    },
+    reservations: [
+      {
+        id: reservationId,
+        intakeRequestId,
+        purpose: 'public_gallery_candidate',
+        expiresAt: '2026-07-15T00:10:00.000Z',
+        consumedBySubmissionId: submissionId,
+        consumedAt,
+      },
+    ],
+  };
+  const request: PhotoPrivateProcessingRequest = {
+    schemaVersion: 'photo-private-processing-v1',
+    processingRequestId,
+    submissionId,
+    processorVersion: 'test-codec/1.0.0',
+    validation: {
+      receipt: {
+        schemaVersion: 'photo-object-validation-receipt-v1',
+        intakeRequestId,
+        targetType: 'location',
+        targetId,
+        validatedAt,
+        media: [
+          {
+            quarantineUploadId: reservationId,
+            mimeType: 'image/png',
+            byteSize: body.byteLength,
+            width: 1_000,
+            height: 800,
+            contentHash,
+          },
+        ],
+      },
+      objects: [
+        {
+          quarantineUploadId: reservationId,
+          privateObjectKey: photoQuarantineObjectKey(reservationId),
+          body,
+          mimeType: 'image/png',
+          byteSize: body.byteLength,
+          width: 1_000,
+          height: 800,
+          contentHash,
+        },
+      ],
+    },
+  };
+  return { body, contentHash, context, request };
+}
+
+function leakText(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+describe('P5-05E private photo processing and Media handoff', () => {
+  it('creates private pending Media with quarantine original and two safe derivatives', async () => {
+    const { context, request, contentHash } = await fixture();
+    const persistence = new MemoryPersistence(context);
+    const derivatives = createInMemoryPrivatePhotoDerivativeStore();
+    const privateProcessor = processor();
+    const service = createPhotoPrivateProcessingService({
+      persistence,
+      derivatives,
+      processor: privateProcessor,
+    });
+
+    const receipt = await service.process(request, processedAt);
+
+    expect(receipt.state).toBe('committed');
+    expect(privateProcessor.calls).toBe(1);
+    expect(persistence.commits).toHaveLength(1);
+    expect(persistence.commits[0]?.assets).toEqual([
+      expect.objectContaining({
+        purpose: 'public_gallery_candidate',
+        role: 'cover',
+        reviewStatus: 'pending',
+        rightsStatus: 'unknown',
+        visibility: 'private',
+        entityId: null,
+        locationId: targetId,
+      }),
+    ]);
+    expect(persistence.commits[0]?.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          variant: 'original',
+          storageScope: 'quarantine',
+          storageKey: photoQuarantineObjectKey(reservationId),
+          contentHash,
+        }),
+        expect.objectContaining({ variant: 'display', storageScope: 'private' }),
+        expect.objectContaining({ variant: 'thumbnail', storageScope: 'private' }),
+      ]),
+    );
+    expect(derivatives.snapshot()).toHaveLength(2);
+    expect(leakText(receipt)).not.toContain('storageKey');
+    expect(leakText(receipt)).not.toContain('privateObjectKey');
+    expect(leakText(receipt)).not.toContain('body');
+  });
+
+  it('replays the same request without reprocessing or rewriting derivatives', async () => {
+    const { context, request } = await fixture();
+    const persistence = new MemoryPersistence(context);
+    const derivatives = createInMemoryPrivatePhotoDerivativeStore();
+    const privateProcessor = processor();
+    const service = createPhotoPrivateProcessingService({
+      persistence,
+      derivatives,
+      processor: privateProcessor,
+    });
+
+    const committed = await service.process(request, processedAt);
+    const replayed = await service.process(request, new Date('2026-07-15T01:00:00.000Z'));
+
+    expect(committed.state).toBe('committed');
+    expect(replayed).toEqual({ ...committed, state: 'replayed' });
+    expect(privateProcessor.calls).toBe(1);
+    expect(persistence.commits).toHaveLength(1);
+    expect(derivatives.snapshot()).toHaveLength(2);
+  });
+
+  it('rejects changed content under the same processing request identity', async () => {
+    const { context, request } = await fixture();
+    const persistence = new MemoryPersistence(context);
+    const derivatives = createInMemoryPrivatePhotoDerivativeStore();
+    const service = createPhotoPrivateProcessingService({
+      persistence,
+      derivatives,
+      processor: processor(),
+    });
+    await service.process(request, processedAt);
+
+    await expect(
+      service.process({ ...request, processorVersion: 'test-codec/2.0.0' }, processedAt),
+    ).rejects.toMatchObject({ code: 'idempotency_conflict' });
+  });
+
+  it('re-hashes the exact validated bytes before invoking the processor', async () => {
+    const { context, request } = await fixture();
+    const changed = structuredClone(request);
+    changed.validation.objects[0]!.body[0] ^= 0xff;
+    const privateProcessor = processor();
+    const service = createPhotoPrivateProcessingService({
+      persistence: new MemoryPersistence(context),
+      derivatives: createInMemoryPrivatePhotoDerivativeStore(),
+      processor: privateProcessor,
+    });
+
+    await expect(service.process(changed, processedAt)).rejects.toMatchObject({
+      code: 'validation_conflict',
+    });
+    expect(privateProcessor.calls).toBe(0);
+  });
+
+  it('requires reservations consumed by the exact Photos Submission after validation', async () => {
+    const { context, request } = await fixture();
+    context.reservations[0]!.consumedBySubmissionId =
+      '10000000-0000-4000-8000-000000000099';
+    const service = createPhotoPrivateProcessingService({
+      persistence: new MemoryPersistence(context),
+      derivatives: createInMemoryPrivatePhotoDerivativeStore(),
+      processor: processor(),
+    });
+
+    await expect(service.process(request, processedAt)).rejects.toMatchObject({
+      code: 'validation_conflict',
+    });
+  });
+
+  it('rejects animated, mismatched, unstripped, or oversized derivatives', async () => {
+    const { context, request } = await fixture();
+    const cases: PhotoPrivateProcessor[] = [
+      {
+        async process() {
+          return [
+            {
+              variant: 'display',
+              body: webp(800, 600, true),
+              mimeType: 'image/webp',
+              width: 800,
+              height: 600,
+              metadataStripped: true,
+              orientationNormalized: true,
+            },
+            {
+              variant: 'thumbnail',
+              body: webp(160, 120),
+              mimeType: 'image/webp',
+              width: 160,
+              height: 120,
+              metadataStripped: true,
+              orientationNormalized: true,
+            },
+          ];
+        },
+      },
+      {
+        async process() {
+          return [
+            {
+              variant: 'display',
+              body: webp(800, 600),
+              mimeType: 'image/webp',
+              width: 801,
+              height: 600,
+              metadataStripped: true,
+              orientationNormalized: true,
+            },
+            {
+              variant: 'thumbnail',
+              body: webp(160, 120),
+              mimeType: 'image/webp',
+              width: 160,
+              height: 120,
+              metadataStripped: true,
+              orientationNormalized: true,
+            },
+          ];
+        },
+      },
+      {
+        async process() {
+          return [
+            {
+              variant: 'display',
+              body: webp(800, 600),
+              mimeType: 'image/webp',
+              width: 800,
+              height: 600,
+              metadataStripped: false as true,
+              orientationNormalized: true,
+            },
+            {
+              variant: 'thumbnail',
+              body: webp(160, 120),
+              mimeType: 'image/webp',
+              width: 160,
+              height: 120,
+              metadataStripped: true,
+              orientationNormalized: true,
+            },
+          ];
+        },
+      },
+      {
+        async process() {
+          return [
+            {
+              variant: 'display',
+              body: webp(2_049, 100),
+              mimeType: 'image/webp',
+              width: 2_049,
+              height: 100,
+              metadataStripped: true,
+              orientationNormalized: true,
+            },
+            {
+              variant: 'thumbnail',
+              body: webp(160, 120),
+              mimeType: 'image/webp',
+              width: 160,
+              height: 120,
+              metadataStripped: true,
+              orientationNormalized: true,
+            },
+          ];
+        },
+      },
+    ];
+
+    for (const privateProcessor of cases) {
+      const derivatives = createInMemoryPrivatePhotoDerivativeStore();
+      const service = createPhotoPrivateProcessingService({
+        persistence: new MemoryPersistence(context),
+        derivatives,
+        processor: privateProcessor,
+      });
+      await expect(service.process(request, processedAt)).rejects.toBeInstanceOf(
+        PhotoPrivateProcessingError,
+      );
+      expect(derivatives.snapshot()).toHaveLength(0);
+    }
+  });
+
+  it('removes newly staged derivatives when the atomic database handoff fails', async () => {
+    const { context, request } = await fixture();
+    const persistence = new MemoryPersistence(context);
+    persistence.failCommit = true;
+    const derivatives = createInMemoryPrivatePhotoDerivativeStore();
+    const service = createPhotoPrivateProcessingService({
+      persistence,
+      derivatives,
+      processor: processor(),
+    });
+
+    await expect(service.process(request, processedAt)).rejects.toMatchObject({
+      code: 'persistence_conflict',
+    });
+    expect(derivatives.snapshot()).toHaveLength(0);
+    expect(persistence.commits).toHaveLength(0);
+  });
+
+  it('fails closed when the Photos Submission is absent or terminal', async () => {
+    const { context, request } = await fixture();
+    const missing = createPhotoPrivateProcessingService({
+      persistence: new MemoryPersistence(null),
+      derivatives: createInMemoryPrivatePhotoDerivativeStore(),
+      processor: processor(),
+    });
+    await expect(missing.process(request, processedAt)).rejects.toMatchObject({
+      code: 'submission_unavailable',
+    });
+
+    const terminal = structuredClone(context) as PhotoProcessingSubmissionContext;
+    terminal.workflowStatus = 'received';
+    const persistence = new MemoryPersistence(terminal);
+    persistence.context!.submissionType = 'photos';
+    persistence.context!.normalizedPayload = null;
+    const invalid = createPhotoPrivateProcessingService({
+      persistence,
+      derivatives: createInMemoryPrivatePhotoDerivativeStore(),
+      processor: processor(),
+    });
+    await expect(invalid.process(request, processedAt)).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/tests/photo-private-processing.test.ts
+++ b/tests/photo-private-processing.test.ts
@@ -8,9 +8,12 @@ import {
   type PhotoMediaHandoffPersistence,
   type PhotoPrivateProcessingRequest,
   type PhotoPrivateProcessor,
+  type PhotoProcessedDerivative,
   type PhotoProcessingSubmissionContext,
 } from '../src/submissions/photo-private-processing';
 import { photoQuarantineObjectKey } from '../src/submissions/photo-upload-authorization';
+
+type Bytes = Uint8Array<ArrayBuffer>;
 
 const submissionId = '10000000-0000-4000-8000-000000000001';
 const intakeRequestId = '20000000-0000-4000-8000-000000000001';
@@ -54,7 +57,7 @@ function pngChunk(type: string, data: number[]): number[] {
   ];
 }
 
-function png(width: number, height: number): Uint8Array {
+function png(width: number, height: number): Bytes {
   return Uint8Array.from([
     0x89,
     0x50,
@@ -70,7 +73,7 @@ function png(width: number, height: number): Uint8Array {
   ]);
 }
 
-function webp(width: number, height: number, animated = false): Uint8Array {
+function webp(width: number, height: number, animated = false): Bytes {
   const payload = [
     animated ? 0x02 : 0x00,
     0,
@@ -89,9 +92,7 @@ function webp(width: number, height: number, animated = false): Uint8Array {
 }
 
 async function hash(bytes: Uint8Array): Promise<string> {
-  const digest = new Uint8Array(
-    await crypto.subtle.digest('SHA-256', Uint8Array.from(bytes)),
-  );
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', Uint8Array.from(bytes)));
   return [...digest].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
@@ -100,7 +101,7 @@ class MemoryPersistence implements PhotoMediaHandoffPersistence {
   readonly commits: PhotoMediaHandoffCommitCommand[] = [];
   failCommit = false;
 
-  constructor(readonly context: PhotoProcessingSubmissionContext | null) {}
+  constructor(public context: PhotoProcessingSubmissionContext | null) {}
 
   async loadSubmissionContext() {
     return this.context === null ? null : structuredClone(this.context);
@@ -113,7 +114,9 @@ class MemoryPersistence implements PhotoMediaHandoffPersistence {
 
   async commitHandoff(command: PhotoMediaHandoffCommitCommand) {
     if (this.failCommit) throw new Error('commit failed');
-    if (this.events.has(command.eventId)) throw new Error('duplicate event');
+    if (this.events.size > 0 || this.events.has(command.eventId)) {
+      throw new Error('Submission already has a Media handoff');
+    }
     if (
       this.context === null ||
       command.submissionId !== this.context.id ||
@@ -127,12 +130,10 @@ class MemoryPersistence implements PhotoMediaHandoffPersistence {
   }
 }
 
-function processor(overrides: Partial<PhotoPrivateProcessor> = {}): PhotoPrivateProcessor & {
-  calls: number;
-} {
+function processor(): PhotoPrivateProcessor & { calls: number } {
   const result: PhotoPrivateProcessor & { calls: number } = {
     calls: 0,
-    async process() {
+    async process(): Promise<PhotoProcessedDerivative[]> {
       result.calls += 1;
       return [
         {
@@ -155,7 +156,6 @@ function processor(overrides: Partial<PhotoPrivateProcessor> = {}): PhotoPrivate
         },
       ];
     },
-    ...overrides,
   };
   return result;
 }
@@ -244,7 +244,7 @@ async function fixture() {
       ],
     },
   };
-  return { body, contentHash, context, request };
+  return { contentHash, context, request };
 }
 
 function leakText(value: unknown): string {
@@ -297,7 +297,7 @@ describe('P5-05E private photo processing and Media handoff', () => {
     expect(leakText(receipt)).not.toContain('body');
   });
 
-  it('replays the same request without reprocessing or rewriting derivatives', async () => {
+  it('replays without reprocessing even if the Submission version later changes', async () => {
     const { context, request } = await fixture();
     const persistence = new MemoryPersistence(context);
     const derivatives = createInMemoryPrivatePhotoDerivativeStore();
@@ -309,7 +309,12 @@ describe('P5-05E private photo processing and Media handoff', () => {
     });
 
     const committed = await service.process(request, processedAt);
-    const replayed = await service.process(request, new Date('2026-07-15T01:00:00.000Z'));
+    persistence.context = {
+      ...context,
+      workflowStatus: 'triage',
+      updatedAt: '2026-07-15T01:00:00.000Z',
+    };
+    const replayed = await service.process(request, new Date('2026-07-15T02:00:00.000Z'));
 
     expect(committed.state).toBe('committed');
     expect(replayed).toEqual({ ...committed, state: 'replayed' });
@@ -321,10 +326,9 @@ describe('P5-05E private photo processing and Media handoff', () => {
   it('rejects changed content under the same processing request identity', async () => {
     const { context, request } = await fixture();
     const persistence = new MemoryPersistence(context);
-    const derivatives = createInMemoryPrivatePhotoDerivativeStore();
     const service = createPhotoPrivateProcessingService({
       persistence,
-      derivatives,
+      derivatives: createInMemoryPrivatePhotoDerivativeStore(),
       processor: processor(),
     });
     await service.process(request, processedAt);
@@ -337,7 +341,11 @@ describe('P5-05E private photo processing and Media handoff', () => {
   it('re-hashes the exact validated bytes before invoking the processor', async () => {
     const { context, request } = await fixture();
     const changed = structuredClone(request);
-    changed.validation.objects[0]!.body[0] ^= 0xff;
+    const changedObject = changed.validation.objects[0];
+    if (changedObject === undefined) throw new Error('fixture object is missing');
+    const changedBody = Uint8Array.from(changedObject.body);
+    changedBody[0] = (changedBody[0] ?? 0) ^ 0xff;
+    changedObject.body = changedBody;
     const privateProcessor = processor();
     const service = createPhotoPrivateProcessingService({
       persistence: new MemoryPersistence(context),
@@ -353,8 +361,7 @@ describe('P5-05E private photo processing and Media handoff', () => {
 
   it('requires reservations consumed by the exact Photos Submission after validation', async () => {
     const { context, request } = await fixture();
-    context.reservations[0]!.consumedBySubmissionId =
-      '10000000-0000-4000-8000-000000000099';
+    context.reservations[0]!.consumedBySubmissionId = '10000000-0000-4000-8000-000000000099';
     const service = createPhotoPrivateProcessingService({
       persistence: new MemoryPersistence(context),
       derivatives: createInMemoryPrivatePhotoDerivativeStore(),
@@ -370,7 +377,7 @@ describe('P5-05E private photo processing and Media handoff', () => {
     const { context, request } = await fixture();
     const cases: PhotoPrivateProcessor[] = [
       {
-        async process() {
+        async process(): Promise<PhotoProcessedDerivative[]> {
           return [
             {
               variant: 'display',
@@ -394,7 +401,7 @@ describe('P5-05E private photo processing and Media handoff', () => {
         },
       },
       {
-        async process() {
+        async process(): Promise<PhotoProcessedDerivative[]> {
           return [
             {
               variant: 'display',
@@ -418,7 +425,7 @@ describe('P5-05E private photo processing and Media handoff', () => {
         },
       },
       {
-        async process() {
+        async process(): Promise<PhotoProcessedDerivative[]> {
           return [
             {
               variant: 'display',
@@ -442,7 +449,7 @@ describe('P5-05E private photo processing and Media handoff', () => {
         },
       },
       {
-        async process() {
+        async process(): Promise<PhotoProcessedDerivative[]> {
           return [
             {
               variant: 'display',
@@ -499,7 +506,32 @@ describe('P5-05E private photo processing and Media handoff', () => {
     expect(persistence.commits).toHaveLength(0);
   });
 
-  it('fails closed when the Photos Submission is absent or terminal', async () => {
+  it('prevents a second processing identity from creating duplicate Media', async () => {
+    const { context, request } = await fixture();
+    const persistence = new MemoryPersistence(context);
+    const derivatives = createInMemoryPrivatePhotoDerivativeStore();
+    const privateProcessor = processor();
+    const service = createPhotoPrivateProcessingService({
+      persistence,
+      derivatives,
+      processor: privateProcessor,
+    });
+    await service.process(request, processedAt);
+
+    await expect(
+      service.process(
+        {
+          ...request,
+          processingRequestId: '30000000-0000-4000-8000-000000000002',
+        },
+        new Date('2026-07-15T00:07:00.000Z'),
+      ),
+    ).rejects.toMatchObject({ code: 'persistence_conflict' });
+    expect(persistence.commits).toHaveLength(1);
+    expect(derivatives.snapshot()).toHaveLength(2);
+  });
+
+  it('fails closed when the Photos Submission is absent or malformed', async () => {
     const { context, request } = await fixture();
     const missing = createPhotoPrivateProcessingService({
       persistence: new MemoryPersistence(null),
@@ -510,16 +542,17 @@ describe('P5-05E private photo processing and Media handoff', () => {
       code: 'submission_unavailable',
     });
 
-    const terminal = structuredClone(context) as PhotoProcessingSubmissionContext;
-    terminal.workflowStatus = 'received';
-    const persistence = new MemoryPersistence(terminal);
-    persistence.context!.submissionType = 'photos';
-    persistence.context!.normalizedPayload = null;
-    const invalid = createPhotoPrivateProcessingService({
-      persistence,
+    const malformedContext: PhotoProcessingSubmissionContext = {
+      ...context,
+      normalizedPayload: null,
+    };
+    const malformed = createPhotoPrivateProcessingService({
+      persistence: new MemoryPersistence(malformedContext),
       derivatives: createInMemoryPrivatePhotoDerivativeStore(),
       processor: processor(),
     });
-    await expect(invalid.process(request, processedAt)).rejects.toBeInstanceOf(Error);
+    await expect(malformed.process(request, processedAt)).rejects.toMatchObject({
+      code: 'submission_unavailable',
+    });
   });
 });


### PR DESCRIPTION
## Implementation item

P5-05E — Controlled private photo processing and protected Media handoff

## Purpose

Consume the exact P5-05D validated byte set, re-verify source hashes, require bounded metadata-stripped and orientation-normalized private derivatives, and atomically hand pending private Media to the existing protected review system.

## Included

- exact Photos Submission, target, normalized item, validated object, and consumed reservation matching
- immediate SHA-256 re-verification before processor execution
- injectable controlled processor contract
- exactly one display and one thumbnail derivative per item
- JPEG/WebP still-image, dimensions, animation, size, metadata-removal, orientation, and hash validation
- canonical private derivative keys compatible with the existing Media review storage plan
- idempotent R2-compatible private derivative writes and post-write verification
- deterministic event, Media Asset, and Media File identities
- one private pending `public_gallery_candidate` Media Asset per item
- quarantine original plus private display and thumbnail Media Files
- private Submission provenance containing bounded review context
- Submission-scoped advisory locking and one-handoff-per-Submission guard
- replay stable after later Submission workflow updates
- best-effort deletion of newly staged derivatives after failed database handoff
- executable schema check and focused replay, conflict, integrity, storage, rollback, and leakage tests

## Replay and concurrency

Identical processing UUID retries resolve from the durable private event before mutable Submission state is reloaded. The processor is not called again and derivatives or Media rows are not duplicated. Changed content under the same UUID returns an idempotency conflict. A different processing UUID cannot create a second Media handoff for the same Submission.

## Transaction boundary

Media Assets, original/display/thumbnail Media Files, and the private Submission event are inserted in one database batch guarded by an advisory lock, exact Submission status/version, and absence of any previous photo Media handoff.

## Privacy boundary

The safe receipt exposes only opaque reservation and Media identities, hashes, state, Submission identity, and processing timestamp. It excludes object bytes, storage keys, signed URLs, credentials, filenames, EXIF/GPS, contact data, status secrets, and public approval. Media remains `pending`, `private`, and `rightsStatus = unknown`.

## Explicit non-effects

No production image codec or R2 binding, public Photos route or form, asynchronous queue, privacy-content decision, duplicate/abuse-hash policy, rights/privacy/quality approval, Media decision execution, public storage copy, canonical mutation, export, publication, or deployment.

## Migration

None. P5-05E reuses existing `media_assets`, `media_files`, `submission_events`, Submission payload, and quarantine reservation persistence.

## Validation

Implementation head `c2079faba752b66471d5bcee35cfb1fb4173b837` passed the complete quality chain with 221 test files and 1,095 tests.

Final documentation head `163041d4c5d321099c54ceb4e5628437c1089df4` passed all four required workflows:

- Foundation validation
- Migration drift
- Staging review validation
- Capture representative review screenshots

Foundation included successful format, lint, Astro and TypeScript, executable schemas, migration history, all tests, build, accessibility, Phase 1, and staging artifact checks.

## Changed files

Only the bounded processing/handoff implementation, private storage adapters, focused tests/checks, and P5-05E tracking documentation are included.

## Next bounded item

P5-05F — duplicate content-hash signals and private upload lifecycle cleanup. This PR does not start it.