### PR TITLE
P5-05F: add photo duplicate signals and cleanup

### DIFF
--- a/docs/P5_05F_PHOTO_DUPLICATE_SIGNALS_AND_PRIVATE_LIFECYCLE.md
+++ b/docs/P5_05F_PHOTO_DUPLICATE_SIGNALS_AND_PRIVATE_LIFECYCLE.md
@@ -1,0 +1,151 @@
+# P5-05F photo duplicate signals and private lifecycle cleanup
+
+**Implementation item:** P5-05F  
+**Status:** Completed through #221  
+**Started:** 2026-07-15  
+**Completed:** 2026-07-15
+
+## Purpose
+
+Complete the remaining private-media safeguards in the P5-05 repository sequence before public Photos route wiring. This slice exposes exact original-image hash matches only as protected review signals and deletes retention-eligible quarantine or private objects without deleting audit, decision, relationship, or limited hash metadata.
+
+## Duplicate review signals
+
+The existing protected Media detail workspace now derives duplicate signals from the SHA-256 hash of the `original` Media File.
+
+A signal contains only:
+
+- the current original content hash;
+- the matching opaque Media Asset UUID;
+- the matching Media subject identity;
+- whether the match belongs to the same subject;
+- the matching review status and visibility;
+- the matching Media creation timestamp;
+- bounded `hasMore` and manual-review indicators.
+
+The query:
+
+- excludes the current Media Asset;
+- excludes deleted Media Assets;
+- returns at most 25 unique matching Media Assets;
+- orders matches deterministically;
+- distinguishes same-target and different-target reuse;
+- exposes no storage key, original filename, object URL, contact, status secret, or contributor identity.
+
+An exact hash match does not automatically reject Media, prove infringement, prove spam, or establish a rights decision. `automaticDecision` is always `false`, and a non-empty match set requires manual review.
+
+P5-05F does not add perceptual hashing or a known-abuse hash service.
+
+## Private cleanup reasons
+
+The cleanup contract accepts only these reasons:
+
+- `expired_authorization`;
+- `closed_submission_without_handoff`;
+- `rejected_media`;
+- `superseded_media`.
+
+Each candidate is validated before any object deletion.
+
+### Expired authorization
+
+An unconsumed quarantine reservation becomes eligible when its authorization expiry has passed. The candidate can delete only the deterministic quarantine object derived from that opaque reservation UUID.
+
+### Closed Photos Submission without Media handoff
+
+A terminal Photos Submission becomes eligible after the 30-day terminal retention boundary when:
+
+- it is duplicate, rejected as spam, withdrawn, or resolved with a non-approval, duplicate, no-change, or withdrawal outcome;
+- it has no `photo_media_handoff_created` event;
+- its consumed quarantine reservations can be identified exactly.
+
+This prevents abandoned or rejected uploads from remaining indefinitely while protecting active review material.
+
+### Rejected or superseded photo Media
+
+A P5-05 Media Asset becomes eligible after both the Media Asset and its Photos Submission have remained terminal for at least 30 days.
+
+The candidate must:
+
+- have `rejected` or `superseded` Media review status;
+- belong to a Photos Submission through the strict P5-05E handoff event;
+- retain only quarantine or private Media Files;
+- match the exact handoff payload and Submission;
+- use canonical quarantine or private derivative object keys.
+
+Pending, accepted, public, restricted-but-active, or unrelated operator-managed Media is never selected by this cleanup reader.
+
+## Canonical-key and scope guard
+
+Before deletion, every object must satisfy one of two shapes:
+
+1. a quarantine `original` using the deterministic reservation key; or
+2. a private `display` or `thumbnail` derivative using the existing canonical Media derivative key, exact Media File UUID, content hash, and JPEG or WebP type.
+
+A `public` storage scope, arbitrary path, original filename path, mismatched Media identifier, or malformed hash is rejected before deletion.
+
+## Execution and replay
+
+The provider-neutral cleanup service:
+
+- loads at most 100 candidates and honors the requested lower limit;
+- rejects duplicate candidate references;
+- validates each retention boundary before deletion;
+- caches an object result within one run so one physical object is not deleted twice;
+- treats an already missing object as an idempotent replay;
+- continues independent deletions after one failure;
+- returns `partial` when any deletion fails;
+- exposes counts and opaque reference identities without returning storage keys.
+
+The R2-compatible adapter checks object existence, deletes from the correct quarantine or private bucket, and verifies that the object is absent afterward. The in-memory adapter supports deterministic unit tests.
+
+P5-05F does not add a scheduler, production bucket binding, or automatic retry worker.
+
+## Persistence boundary
+
+No database migration is required.
+
+P5-05F deliberately leaves existing rows in place so lawful and necessary limited metadata can continue to support:
+
+- audit history;
+- review decision history;
+- content-hash duplicate control;
+- target relationships;
+- deletion and retention evidence.
+
+Private object deletion does not mutate canonical Entity, Location, Claim, Evidence, or public export state.
+
+## Explicit non-effects
+
+P5-05F does not add:
+
+- perceptual or near-duplicate hashing;
+- a malware or known-abuse hash provider;
+- an automatic duplicate, infringement, spam, or rights decision;
+- public duplicate signals;
+- cleanup of pending, accepted, or public Media;
+- public-object deletion or cache invalidation;
+- production R2 bindings or scheduled cleanup execution;
+- public Photos HTTP routes or browser form;
+- protected Media decision execution;
+- canonical mutation, export, publication, or deployment.
+
+## Completion evidence
+
+Implementation head `93efec323a9003efd50c0b8191a4d593a64adbdd` passed:
+
+- format and lint;
+- Astro and TypeScript;
+- executable runtime and submission schema checks;
+- migration history and drift;
+- 224 test files and 1,105 tests;
+- build, accessibility, Phase 1, and staging artifact checks;
+- Foundation validation, Migration drift, Staging review validation, and representative screenshot capture.
+
+No migration was required.
+
+## Next bounded item
+
+P5-05G will add the public Photos upload-authorization and private-intake HTTP boundaries. It must reuse the common Turnstile, rate-limit, status-secret, contact-protection, and safe-response conventions while keeping direct object upload, private Submission creation, processing, Media review, and publication as separate authenticated or asynchronous boundaries.
+
+The browser `/photos` form, configured object-storage and processing composition, and final P5-05 integration audit remain later bounded slices.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-05F — Photo duplicate signals and private upload lifecycle cleanup
+P5-05G — Public Photos upload authorization and private intake HTTP boundaries
 
 ## Current repository state
 
@@ -33,7 +33,8 @@ P5-05F — Photo duplicate signals and private upload lifecycle cleanup
 - P5-05C photo quarantine upload authorization and durable reservation issuance completed in #218.
 - P5-05D private object existence and byte-level validation completed in #219.
 - P5-05E controlled private processing and protected Media handoff completed in #220.
-- P5-05F is next; its bounded scope is review-only duplicate content-hash signals plus retention and cleanup of abandoned, rejected, superseded, or completed private uploads.
+- P5-05F exact original-hash review signals and retention-safe private object cleanup completed in #221.
+- P5-05G is next; its bounded scope is public Photos upload-authorization and private-intake HTTP boundaries without browser form wiring, automatic processing, Media approval, or publication.
 
 ## P5-05A completion result
 
@@ -110,6 +111,22 @@ P5-05E provides:
 - cleanup of newly staged derivatives after failed database handoff;
 - no production codec or R2 binding, Media approval, public storage copy, canonical mutation, export, or publication.
 
+## P5-05F completion result
+
+P5-05F provides:
+
+- exact original SHA-256 matches as protected Media review signals;
+- same-target and different-target match context without contributor or storage disclosure;
+- a strict maximum of 25 unique matches and no automatic duplicate, misuse, rights, or rejection decision;
+- retention candidates for expired unconsumed authorization objects;
+- 30-day terminal cleanup for closed Photos Submissions without a Media handoff;
+- 30-day terminal cleanup for rejected or superseded P5-05 Media;
+- canonical quarantine/private object-key validation before deletion;
+- explicit rejection of public-scope, pending, accepted, or unrelated Media cleanup;
+- idempotent R2-compatible deletion and partial-failure reporting;
+- limited database hash, decision, target, and audit metadata retention after object deletion;
+- no perceptual hashing, known-abuse provider, scheduler, production R2 binding, public route, canonical mutation, export, or publication.
+
 ## Current references
 
 - `docs/IMPLEMENTATION_PLAN.md`
@@ -132,6 +149,7 @@ P5-05E provides:
 - `docs/P5_05C_PHOTO_UPLOAD_AUTHORIZATION.md`
 - `docs/P5_05D_PHOTO_OBJECT_VALIDATION.md`
 - `docs/P5_05E_PHOTO_PRIVATE_PROCESSING_AND_MEDIA_HANDOFF.md`
+- `docs/P5_05F_PHOTO_DUPLICATE_SIGNALS_AND_PRIVATE_LIFECYCLE.md`
 
 ## Phase 5 sequence
 
@@ -139,19 +157,19 @@ P5-05E provides:
 2. P5-02 — Suggest Place and Online Service — Completed through #156–#192
 3. P5-03 — Payment and problem reports — Completed through #194–#202
 4. P5-04 — Business and service claims — Completed through #203–#215
-5. P5-05 — Photo and Media submission intake — In progress at P5-05F; P5-05E completed #220
+5. P5-05 — Photo and Media submission intake — In progress at P5-05G; P5-05F completed #221
 6. P5-06 — Review workflow extensions — Planned
 7. P5-07 — Canonical application transactions and retention — Planned
 8. P5-08 — MVP-B integration audit — Planned
 
 ## Next
 
-Define and implement P5-05F duplicate content-hash signals and private upload lifecycle cleanup. Exact or near-existing hashes must remain review signals rather than automatic misuse conclusions, and cleanup must distinguish active review material from expired authorization, abandoned upload, rejected Media, superseded derivative, and completed retention states.
+Define and implement P5-05G public Photos upload-authorization and private-intake HTTP boundaries. The routes must reuse trusted edge identity, Turnstile, distributed rate limiting, bounded JSON and content-type checks, opaque idempotency identity, protected contact handling, status-secret issuance, and privacy-safe error mapping. Direct object upload remains scoped and private; successful intake must not process, approve, publish, or mutate canonical Media automatically.
 
 ## Blocked
 
-No repository blocker is known. Production codec and R2 binding, asynchronous processing infrastructure, public Photos route and browser wiring, privacy-content analysis, protected Media reviewer execution, public Media approval, export activation, and production review remain separate later slices.
+No repository blocker is known. Production R2 signing/binding, configured image codec and processing execution, browser `/photos` form and direct-upload orchestration, privacy-content analysis, protected Media reviewer execution, public Media approval, export activation, and production review remain separate later slices.
 
 ## Verification rule
 
-Repository reality is determined by current `main`, merged pull requests, actual CI results, and fixed-review receipts. A private derivative and pending Media handoff are not public approval, duplicate hashes are review signals rather than proof of misuse, and opaque private storage references never become public object URLs through Submission intake.
+Repository reality is determined by current `main`, merged pull requests, actual CI results, and fixed-review receipts. Exact hashes are review signals rather than proof of misuse, private object deletion does not remove required audit metadata, and no public Photos HTTP request may create approved or public Media automatically.

--- a/scripts/check-photo-object-validation.ts
+++ b/scripts/check-photo-object-validation.ts
@@ -6,6 +6,7 @@ import {
   photoObjectValidationRequestSchema,
 } from '../src/submissions/photo-object-validation';
 import { createR2PhotoQuarantineObjectStore } from '../src/submissions/r2-photo-quarantine-object-store';
+import './check-photo-private-lifecycle';
 import './check-photo-private-processing';
 
 const parsed = photoObjectValidationRequestSchema.parse({

--- a/scripts/check-photo-private-lifecycle.ts
+++ b/scripts/check-photo-private-lifecycle.ts
@@ -1,0 +1,78 @@
+import {
+  mediaDuplicateSignalsSchema,
+  projectMediaDuplicateSignals,
+} from '../src/admin/media-review/duplicate-signals';
+import { createDrizzlePhotoPrivateCleanupCandidateReader } from '../src/submissions/drizzle-photo-private-lifecycle';
+import { createInMemoryPhotoPrivateObjectLifecycleStore } from '../src/submissions/in-memory-photo-private-lifecycle';
+import {
+  createPhotoPrivateCleanupService,
+  photoPrivateCleanupCandidateSchema,
+  photoPrivateCleanupReceiptSchema,
+  photoPrivateCleanupRequestSchema,
+} from '../src/submissions/photo-private-lifecycle';
+import { createR2PhotoPrivateObjectLifecycleStore } from '../src/submissions/r2-photo-private-lifecycle';
+import { photoQuarantineObjectKey } from '../src/submissions/photo-upload-authorization';
+
+const reservationId = '10000000-0000-4000-8000-000000000001';
+const request = photoPrivateCleanupRequestSchema.parse({
+  schemaVersion: 'photo-private-cleanup-v1',
+  runId: '20000000-0000-4000-8000-000000000001',
+  asOf: '2026-07-15T00:00:00.000Z',
+  limit: 25,
+});
+
+photoPrivateCleanupCandidateSchema.parse({
+  referenceType: 'reservation',
+  referenceId: reservationId,
+  reason: 'expired_authorization',
+  eligibleAt: '2026-07-14T00:00:00.000Z',
+  submissionId: null,
+  mediaAssetId: null,
+  objects: [
+    {
+      objectRefId: reservationId,
+      reservationId,
+      mediaAssetId: null,
+      mediaFileId: null,
+      variant: 'original',
+      storageScope: 'quarantine',
+      storageKey: photoQuarantineObjectKey(reservationId),
+      mimeType: 'application/octet-stream',
+      contentHash: null,
+    },
+  ],
+});
+
+photoPrivateCleanupReceiptSchema.parse({
+  schemaVersion: 'photo-private-cleanup-receipt-v1',
+  runId: request.runId,
+  asOf: request.asOf,
+  state: 'completed',
+  candidateCount: 0,
+  deletedObjectCount: 0,
+  missingObjectCount: 0,
+  failedObjectCount: 0,
+  candidates: [],
+});
+
+mediaDuplicateSignalsSchema.parse(
+  projectMediaDuplicateSignals(
+    { type: 'location', id: '30000000-0000-4000-8000-000000000001' },
+    null,
+    [],
+  ),
+);
+
+for (const executable of [
+  createPhotoPrivateCleanupService,
+  createDrizzlePhotoPrivateCleanupCandidateReader,
+  createInMemoryPhotoPrivateObjectLifecycleStore,
+  createR2PhotoPrivateObjectLifecycleStore,
+  projectMediaDuplicateSignals,
+]) {
+  if (typeof executable !== 'function') {
+    throw new Error('Photo private lifecycle boundary is not executable.');
+  }
+}
+
+console.log('Photo duplicate signals and private lifecycle schemas passed.');

--- a/src/admin/media-review/drizzle-workspace-backend.ts
+++ b/src/admin/media-review/drizzle-workspace-backend.ts
@@ -1,7 +1,11 @@
-import { and, asc, desc, eq, isNull, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, ne, sql } from 'drizzle-orm';
 import type { CryptoPayMapDatabase } from '../../db/client';
 import { mediaAssets, mediaFiles } from '../../db/schema';
 import type { MediaReviewSubject } from './decision';
+import {
+  MAX_MEDIA_DUPLICATE_MATCHES,
+  projectMediaDuplicateSignals,
+} from './duplicate-signals';
 import type {
   MediaReviewDetailResponse,
   MediaReviewQueueItem,
@@ -132,6 +136,48 @@ export function createDrizzleMediaReviewWorkspaceBackend(
         .where(eq(mediaFiles.mediaAssetId, mediaAssetId))
         .orderBy(asc(mediaFiles.variant), asc(mediaFiles.id));
 
+      const subject = subjectFromRow(row);
+      const originalFile = fileRows.find((file) => file.variant === 'original');
+      let duplicateSignals = projectMediaDuplicateSignals(subject, null, []);
+      if (originalFile !== undefined) {
+        const duplicateRows = await database
+          .select({
+            mediaAssetId: mediaAssets.id,
+            reviewStatus: mediaAssets.reviewStatus,
+            visibility: mediaAssets.visibility,
+            entityId: mediaAssets.entityId,
+            locationId: mediaAssets.locationId,
+            claimId: mediaAssets.claimId,
+            evidenceId: mediaAssets.evidenceId,
+            submissionId: mediaAssets.submissionId,
+            sourceRecordId: mediaAssets.sourceRecordId,
+            createdAt: mediaAssets.createdAt,
+          })
+          .from(mediaFiles)
+          .innerJoin(mediaAssets, eq(mediaAssets.id, mediaFiles.mediaAssetId))
+          .where(
+            and(
+              eq(mediaFiles.variant, 'original'),
+              eq(mediaFiles.contentHash, originalFile.contentHash),
+              ne(mediaAssets.id, mediaAssetId),
+              isNull(mediaAssets.deletedAt),
+            ),
+          )
+          .orderBy(desc(mediaAssets.createdAt), asc(mediaAssets.id))
+          .limit(MAX_MEDIA_DUPLICATE_MATCHES + 1);
+        duplicateSignals = projectMediaDuplicateSignals(
+          subject,
+          originalFile.contentHash,
+          duplicateRows.map((duplicate) => ({
+            mediaAssetId: duplicate.mediaAssetId,
+            subject: subjectFromRow(duplicate),
+            reviewStatus: duplicate.reviewStatus,
+            visibility: duplicate.visibility,
+            createdAt: duplicate.createdAt.toISOString(),
+          })),
+        );
+      }
+
       const detail: MediaReviewDetailResponse = {
         generatedAt: asOf.toISOString(),
         media: {
@@ -141,7 +187,7 @@ export function createDrizzleMediaReviewWorkspaceBackend(
           reviewStatus: row.reviewStatus,
           rightsStatus: row.rightsStatus,
           visibility: row.visibility,
-          subject: subjectFromRow(row),
+          subject,
           altText: row.altText,
           displayOrder: row.displayOrder,
           fileCount: fileRows.length,
@@ -167,6 +213,7 @@ export function createDrizzleMediaReviewWorkspaceBackend(
           contentHash: file.contentHash,
           createdAt: file.createdAt.toISOString(),
         })),
+        duplicateSignals,
       };
       return detail;
     },

--- a/src/admin/media-review/drizzle-workspace-backend.ts
+++ b/src/admin/media-review/drizzle-workspace-backend.ts
@@ -2,10 +2,7 @@ import { and, asc, desc, eq, isNull, ne, sql } from 'drizzle-orm';
 import type { CryptoPayMapDatabase } from '../../db/client';
 import { mediaAssets, mediaFiles } from '../../db/schema';
 import type { MediaReviewSubject } from './decision';
-import {
-  MAX_MEDIA_DUPLICATE_MATCHES,
-  projectMediaDuplicateSignals,
-} from './duplicate-signals';
+import { MAX_MEDIA_DUPLICATE_MATCHES, projectMediaDuplicateSignals } from './duplicate-signals';
 import type {
   MediaReviewDetailResponse,
   MediaReviewQueueItem,

--- a/src/admin/media-review/duplicate-signals.ts
+++ b/src/admin/media-review/duplicate-signals.ts
@@ -1,12 +1,6 @@
 import { z } from 'zod';
-import {
-  mediaReviewStatusValues,
-  mediaVisibilityValues,
-} from '../../db/schema';
-import {
-  mediaReviewSubjectSchema,
-  type MediaReviewSubject,
-} from './decision';
+import { mediaReviewStatusValues, mediaVisibilityValues } from '../../db/schema';
+import { mediaReviewSubjectSchema, type MediaReviewSubject } from './decision';
 
 export const MAX_MEDIA_DUPLICATE_MATCHES = 25;
 
@@ -23,7 +17,10 @@ export const mediaDuplicateMatchSchema = z
 
 export const mediaDuplicateSignalsSchema = z
   .object({
-    sourceOriginalContentHash: z.string().regex(/^[a-f0-9]{64}$/).nullable(),
+    sourceOriginalContentHash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
     matches: z.array(mediaDuplicateMatchSchema).max(MAX_MEDIA_DUPLICATE_MATCHES),
     hasMore: z.boolean(),
     automaticDecision: z.literal(false),

--- a/src/admin/media-review/duplicate-signals.ts
+++ b/src/admin/media-review/duplicate-signals.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import {
+  mediaReviewStatusValues,
+  mediaVisibilityValues,
+} from '../../db/schema';
+import {
+  mediaReviewSubjectSchema,
+  type MediaReviewSubject,
+} from './decision';
+
+export const MAX_MEDIA_DUPLICATE_MATCHES = 25;
+
+export const mediaDuplicateMatchSchema = z
+  .object({
+    mediaAssetId: z.uuid(),
+    subject: mediaReviewSubjectSchema,
+    reviewStatus: z.enum(mediaReviewStatusValues),
+    visibility: z.enum(mediaVisibilityValues),
+    sameTarget: z.boolean(),
+    createdAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const mediaDuplicateSignalsSchema = z
+  .object({
+    sourceOriginalContentHash: z.string().regex(/^[a-f0-9]{64}$/).nullable(),
+    matches: z.array(mediaDuplicateMatchSchema).max(MAX_MEDIA_DUPLICATE_MATCHES),
+    hasMore: z.boolean(),
+    automaticDecision: z.literal(false),
+    manualReviewRequired: z.boolean(),
+  })
+  .strict();
+
+export type MediaDuplicateMatch = z.infer<typeof mediaDuplicateMatchSchema>;
+export type MediaDuplicateSignals = z.infer<typeof mediaDuplicateSignalsSchema>;
+
+export interface MediaDuplicateCandidate {
+  mediaAssetId: string;
+  subject: MediaReviewSubject;
+  reviewStatus: (typeof mediaReviewStatusValues)[number];
+  visibility: (typeof mediaVisibilityValues)[number];
+  createdAt: string;
+}
+
+function sameSubject(left: MediaReviewSubject, right: MediaReviewSubject): boolean {
+  return left.type === right.type && left.id === right.id;
+}
+
+export function projectMediaDuplicateSignals(
+  currentSubject: MediaReviewSubject,
+  sourceOriginalContentHash: string | null,
+  candidates: readonly MediaDuplicateCandidate[],
+  limit = MAX_MEDIA_DUPLICATE_MATCHES,
+): MediaDuplicateSignals {
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_MEDIA_DUPLICATE_MATCHES) {
+    throw new Error('Media duplicate signal limit is invalid.');
+  }
+
+  if (sourceOriginalContentHash === null) {
+    return mediaDuplicateSignalsSchema.parse({
+      sourceOriginalContentHash: null,
+      matches: [],
+      hasMore: false,
+      automaticDecision: false,
+      manualReviewRequired: false,
+    });
+  }
+
+  const unique = new Map<string, MediaDuplicateCandidate>();
+  for (const candidate of candidates) {
+    if (!unique.has(candidate.mediaAssetId)) unique.set(candidate.mediaAssetId, candidate);
+  }
+  const sorted = [...unique.values()].sort((left, right) => {
+    const byTime = Date.parse(right.createdAt) - Date.parse(left.createdAt);
+    return byTime !== 0 ? byTime : left.mediaAssetId.localeCompare(right.mediaAssetId);
+  });
+  const selected = sorted.slice(0, limit).map((candidate) => ({
+    mediaAssetId: candidate.mediaAssetId,
+    subject: candidate.subject,
+    reviewStatus: candidate.reviewStatus,
+    visibility: candidate.visibility,
+    sameTarget: sameSubject(currentSubject, candidate.subject),
+    createdAt: candidate.createdAt,
+  }));
+
+  return mediaDuplicateSignalsSchema.parse({
+    sourceOriginalContentHash,
+    matches: selected,
+    hasMore: sorted.length > limit,
+    automaticDecision: false,
+    manualReviewRequired: selected.length > 0,
+  });
+}

--- a/src/admin/media-review/workspace.ts
+++ b/src/admin/media-review/workspace.ts
@@ -9,6 +9,7 @@ import {
   mediaVisibilityValues,
 } from '../../db/schema';
 import { mediaReviewSubjectSchema } from './decision';
+import { mediaDuplicateSignalsSchema } from './duplicate-signals';
 
 export const mediaReviewReadContextSchema = z
   .object({
@@ -92,6 +93,7 @@ export const mediaReviewDetailResponseSchema = z
       createdAt: z.iso.datetime({ offset: true }),
     }),
     files: z.array(mediaReviewWorkspaceFileSchema).max(3),
+    duplicateSignals: mediaDuplicateSignalsSchema.optional(),
   })
   .strict();
 

--- a/src/submissions/drizzle-photo-private-lifecycle.ts
+++ b/src/submissions/drizzle-photo-private-lifecycle.ts
@@ -1,14 +1,4 @@
-import {
-  and,
-  asc,
-  eq,
-  inArray,
-  isNull,
-  lte,
-  notExists,
-  or,
-  sql,
-} from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, lte, notExists, or, sql } from 'drizzle-orm';
 import type { CryptoPayMapDatabase } from '../db/client';
 import {
   mediaAssets,
@@ -178,10 +168,7 @@ export function createDrizzlePhotoPrivateCleanupCandidateReader(
         .from(mediaAssets)
         .innerJoin(
           submissionEvents,
-          and(
-            eq(submissionEvents.action, 'photo_media_handoff_created'),
-            handoffContainsAsset,
-          ),
+          and(eq(submissionEvents.action, 'photo_media_handoff_created'), handoffContainsAsset),
         )
         .innerJoin(submissions, eq(submissions.id, submissionEvents.submissionId))
         .where(
@@ -233,16 +220,20 @@ export function createDrizzlePhotoPrivateCleanupCandidateReader(
         if (row.handoffPayload === null) {
           throw new Error('Photo Media handoff payload is missing.');
         }
-        const payload = photoMediaHandoffEventPayloadSchema.parse(
-          JSON.parse(row.handoffPayload),
-        );
-        const handoffItem = payload.media.find(
-          (item) => item.mediaAssetId === row.mediaAssetId,
-        );
+        const payload = photoMediaHandoffEventPayloadSchema.parse(JSON.parse(row.handoffPayload));
+        const handoffItem = payload.media.find((item) => item.mediaAssetId === row.mediaAssetId);
         if (handoffItem === undefined || payload.submissionId !== row.submissionId) {
           throw new Error('Photo Media handoff payload does not match its terminal Media Asset.');
         }
-        const files = filesByMedia.get(row.mediaAssetId) ?? [];
+        const files = (filesByMedia.get(row.mediaAssetId) ?? []).map((file) => {
+          if (file.storageScope !== 'quarantine' && file.storageScope !== 'private') {
+            throw new Error('Photo private cleanup selected a public Media file.');
+          }
+          return {
+            ...file,
+            storageScope: file.storageScope,
+          };
+        });
         if (files.length === 0) continue;
         candidates.push({
           referenceType: 'media_asset',
@@ -253,10 +244,7 @@ export function createDrizzlePhotoPrivateCleanupCandidateReader(
           mediaAssetId: row.mediaAssetId,
           objects: files.map((file) => ({
             objectRefId: file.id,
-            reservationId:
-              file.storageScope === 'quarantine'
-                ? handoffItem.quarantineUploadId
-                : null,
+            reservationId: file.storageScope === 'quarantine' ? handoffItem.quarantineUploadId : null,
             mediaAssetId: row.mediaAssetId,
             mediaFileId: file.id,
             variant: file.variant,

--- a/src/submissions/drizzle-photo-private-lifecycle.ts
+++ b/src/submissions/drizzle-photo-private-lifecycle.ts
@@ -1,0 +1,274 @@
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNull,
+  lte,
+  notExists,
+  or,
+  sql,
+} from 'drizzle-orm';
+import type { CryptoPayMapDatabase } from '../db/client';
+import {
+  mediaAssets,
+  mediaFiles,
+  quarantineUploadReservations,
+  submissionEvents,
+  submissions,
+} from '../db/schema';
+import {
+  type PhotoPrivateCleanupCandidate,
+  type PhotoPrivateCleanupCandidateReader,
+} from './photo-private-lifecycle';
+import { photoMediaHandoffEventPayloadSchema } from './photo-private-processing';
+import { photoQuarantineObjectKey } from './photo-upload-authorization';
+
+const terminalSubmissionCondition = or(
+  inArray(submissions.workflowStatus, ['duplicate', 'rejected_spam', 'withdrawn']),
+  and(
+    eq(submissions.workflowStatus, 'resolved'),
+    inArray(submissions.resolution, ['not_approved', 'duplicate', 'no_change', 'withdrawn']),
+  ),
+);
+
+function latest(left: Date, right: Date): Date {
+  return left.getTime() >= right.getTime() ? left : right;
+}
+
+export function createDrizzlePhotoPrivateCleanupCandidateReader(
+  database: CryptoPayMapDatabase,
+): PhotoPrivateCleanupCandidateReader {
+  return {
+    async loadCleanupCandidates(cutoffs, limit) {
+      const candidates: PhotoPrivateCleanupCandidate[] = [];
+
+      const expiredReservations = await database
+        .select({
+          id: quarantineUploadReservations.id,
+          expiresAt: quarantineUploadReservations.expiresAt,
+        })
+        .from(quarantineUploadReservations)
+        .where(
+          and(
+            isNull(quarantineUploadReservations.consumedBySubmissionId),
+            lte(quarantineUploadReservations.expiresAt, cutoffs.expiredAuthorizationBefore),
+          ),
+        )
+        .orderBy(asc(quarantineUploadReservations.expiresAt), asc(quarantineUploadReservations.id))
+        .limit(limit);
+
+      for (const reservation of expiredReservations) {
+        candidates.push({
+          referenceType: 'reservation',
+          referenceId: reservation.id,
+          reason: 'expired_authorization',
+          eligibleAt: reservation.expiresAt.toISOString(),
+          submissionId: null,
+          mediaAssetId: null,
+          objects: [
+            {
+              objectRefId: reservation.id,
+              reservationId: reservation.id,
+              mediaAssetId: null,
+              mediaFileId: null,
+              variant: 'original',
+              storageScope: 'quarantine',
+              storageKey: photoQuarantineObjectKey(reservation.id),
+              mimeType: 'application/octet-stream',
+              contentHash: null,
+            },
+          ],
+        });
+      }
+
+      let remaining = limit - candidates.length;
+      if (remaining <= 0) return candidates;
+
+      const closedSubmissions = await database
+        .select({
+          id: submissions.id,
+          updatedAt: submissions.updatedAt,
+        })
+        .from(submissions)
+        .where(
+          and(
+            eq(submissions.submissionType, 'photos'),
+            terminalSubmissionCondition,
+            lte(submissions.updatedAt, cutoffs.terminalStateBefore),
+            notExists(
+              database
+                .select({ value: sql<number>`1` })
+                .from(submissionEvents)
+                .where(
+                  and(
+                    eq(submissionEvents.submissionId, submissions.id),
+                    eq(submissionEvents.action, 'photo_media_handoff_created'),
+                  ),
+                ),
+            ),
+          ),
+        )
+        .orderBy(asc(submissions.updatedAt), asc(submissions.id))
+        .limit(remaining);
+
+      if (closedSubmissions.length > 0) {
+        const submissionIds = closedSubmissions.map((submission) => submission.id);
+        const reservationRows = await database
+          .select({
+            id: quarantineUploadReservations.id,
+            submissionId: quarantineUploadReservations.consumedBySubmissionId,
+          })
+          .from(quarantineUploadReservations)
+          .where(inArray(quarantineUploadReservations.consumedBySubmissionId, submissionIds))
+          .orderBy(
+            asc(quarantineUploadReservations.consumedBySubmissionId),
+            asc(quarantineUploadReservations.id),
+          );
+        const reservationsBySubmission = new Map<string, string[]>();
+        for (const reservation of reservationRows) {
+          if (reservation.submissionId === null) continue;
+          const values = reservationsBySubmission.get(reservation.submissionId) ?? [];
+          values.push(reservation.id);
+          reservationsBySubmission.set(reservation.submissionId, values);
+        }
+
+        for (const submission of closedSubmissions) {
+          const reservationIds = reservationsBySubmission.get(submission.id) ?? [];
+          if (reservationIds.length === 0) continue;
+          candidates.push({
+            referenceType: 'submission',
+            referenceId: submission.id,
+            reason: 'closed_submission_without_handoff',
+            eligibleAt: submission.updatedAt.toISOString(),
+            submissionId: submission.id,
+            mediaAssetId: null,
+            objects: reservationIds.map((reservationId) => ({
+              objectRefId: reservationId,
+              reservationId,
+              mediaAssetId: null,
+              mediaFileId: null,
+              variant: 'original' as const,
+              storageScope: 'quarantine' as const,
+              storageKey: photoQuarantineObjectKey(reservationId),
+              mimeType: 'application/octet-stream',
+              contentHash: null,
+            })),
+          });
+        }
+      }
+
+      remaining = limit - candidates.length;
+      if (remaining <= 0) return candidates;
+
+      const handoffContainsAsset = sql<boolean>`
+        ${submissionEvents.internalNote} is not null
+        and (${submissionEvents.internalNote}::jsonb -> 'media') @>
+          jsonb_build_array(jsonb_build_object('mediaAssetId', ${mediaAssets.id}::text))
+      `;
+      const terminalMediaRows = await database
+        .select({
+          mediaAssetId: mediaAssets.id,
+          reviewStatus: mediaAssets.reviewStatus,
+          mediaUpdatedAt: mediaAssets.updatedAt,
+          submissionId: submissions.id,
+          submissionUpdatedAt: submissions.updatedAt,
+          handoffPayload: submissionEvents.internalNote,
+        })
+        .from(mediaAssets)
+        .innerJoin(
+          submissionEvents,
+          and(
+            eq(submissionEvents.action, 'photo_media_handoff_created'),
+            handoffContainsAsset,
+          ),
+        )
+        .innerJoin(submissions, eq(submissions.id, submissionEvents.submissionId))
+        .where(
+          and(
+            inArray(mediaAssets.reviewStatus, ['rejected', 'superseded']),
+            isNull(mediaAssets.deletedAt),
+            eq(submissions.submissionType, 'photos'),
+            terminalSubmissionCondition,
+            lte(mediaAssets.updatedAt, cutoffs.terminalStateBefore),
+            lte(submissions.updatedAt, cutoffs.terminalStateBefore),
+          ),
+        )
+        .orderBy(asc(mediaAssets.updatedAt), asc(mediaAssets.id))
+        .limit(remaining);
+
+      if (terminalMediaRows.length === 0) return candidates;
+
+      const uniqueMedia = new Map<string, (typeof terminalMediaRows)[number]>();
+      for (const row of terminalMediaRows) {
+        if (!uniqueMedia.has(row.mediaAssetId)) uniqueMedia.set(row.mediaAssetId, row);
+      }
+      const mediaIds = [...uniqueMedia.keys()];
+      const fileRows = await database
+        .select({
+          id: mediaFiles.id,
+          mediaAssetId: mediaFiles.mediaAssetId,
+          variant: mediaFiles.variant,
+          storageScope: mediaFiles.storageScope,
+          storageKey: mediaFiles.storageKey,
+          mimeType: mediaFiles.mimeType,
+          contentHash: mediaFiles.contentHash,
+        })
+        .from(mediaFiles)
+        .where(
+          and(
+            inArray(mediaFiles.mediaAssetId, mediaIds),
+            inArray(mediaFiles.storageScope, ['quarantine', 'private']),
+          ),
+        )
+        .orderBy(asc(mediaFiles.mediaAssetId), asc(mediaFiles.variant), asc(mediaFiles.id));
+      const filesByMedia = new Map<string, typeof fileRows>();
+      for (const file of fileRows) {
+        const values = filesByMedia.get(file.mediaAssetId) ?? [];
+        values.push(file);
+        filesByMedia.set(file.mediaAssetId, values);
+      }
+
+      for (const row of uniqueMedia.values()) {
+        if (row.handoffPayload === null) {
+          throw new Error('Photo Media handoff payload is missing.');
+        }
+        const payload = photoMediaHandoffEventPayloadSchema.parse(
+          JSON.parse(row.handoffPayload),
+        );
+        const handoffItem = payload.media.find(
+          (item) => item.mediaAssetId === row.mediaAssetId,
+        );
+        if (handoffItem === undefined || payload.submissionId !== row.submissionId) {
+          throw new Error('Photo Media handoff payload does not match its terminal Media Asset.');
+        }
+        const files = filesByMedia.get(row.mediaAssetId) ?? [];
+        if (files.length === 0) continue;
+        candidates.push({
+          referenceType: 'media_asset',
+          referenceId: row.mediaAssetId,
+          reason: row.reviewStatus === 'rejected' ? 'rejected_media' : 'superseded_media',
+          eligibleAt: latest(row.mediaUpdatedAt, row.submissionUpdatedAt).toISOString(),
+          submissionId: row.submissionId,
+          mediaAssetId: row.mediaAssetId,
+          objects: files.map((file) => ({
+            objectRefId: file.id,
+            reservationId:
+              file.storageScope === 'quarantine'
+                ? handoffItem.quarantineUploadId
+                : null,
+            mediaAssetId: row.mediaAssetId,
+            mediaFileId: file.id,
+            variant: file.variant,
+            storageScope: file.storageScope,
+            storageKey: file.storageKey,
+            mimeType: file.mimeType,
+            contentHash: file.contentHash,
+          })),
+        });
+      }
+
+      return candidates.slice(0, limit);
+    },
+  };
+}

--- a/src/submissions/drizzle-photo-private-lifecycle.ts
+++ b/src/submissions/drizzle-photo-private-lifecycle.ts
@@ -244,7 +244,8 @@ export function createDrizzlePhotoPrivateCleanupCandidateReader(
           mediaAssetId: row.mediaAssetId,
           objects: files.map((file) => ({
             objectRefId: file.id,
-            reservationId: file.storageScope === 'quarantine' ? handoffItem.quarantineUploadId : null,
+            reservationId:
+              file.storageScope === 'quarantine' ? handoffItem.quarantineUploadId : null,
             mediaAssetId: row.mediaAssetId,
             mediaFileId: file.id,
             variant: file.variant,

--- a/src/submissions/in-memory-photo-private-lifecycle.ts
+++ b/src/submissions/in-memory-photo-private-lifecycle.ts
@@ -35,15 +35,13 @@ export function createInMemoryPhotoPrivateObjectLifecycleStore(
     },
 
     list() {
-      return [...objects]
-        .sort()
-        .map((value) => {
-          const separator = value.indexOf(':');
-          return {
-            storageScope: value.slice(0, separator) as 'quarantine' | 'private',
-            storageKey: value.slice(separator + 1),
-          };
-        });
+      return [...objects].sort().map((value) => {
+        const separator = value.indexOf(':');
+        return {
+          storageScope: value.slice(0, separator) as 'quarantine' | 'private',
+          storageKey: value.slice(separator + 1),
+        };
+      });
     },
   };
 }

--- a/src/submissions/in-memory-photo-private-lifecycle.ts
+++ b/src/submissions/in-memory-photo-private-lifecycle.ts
@@ -1,0 +1,49 @@
+import type { PhotoPrivateObjectLifecycleStore } from './photo-private-lifecycle';
+
+export interface InMemoryPhotoPrivateObject {
+  storageScope: 'quarantine' | 'private';
+  storageKey: string;
+}
+
+export function createInMemoryPhotoPrivateObjectLifecycleStore(
+  initialObjects: readonly InMemoryPhotoPrivateObject[] = [],
+): PhotoPrivateObjectLifecycleStore & {
+  put(object: InMemoryPhotoPrivateObject): void;
+  fail(storageScope: 'quarantine' | 'private', storageKey: string): void;
+  list(): InMemoryPhotoPrivateObject[];
+} {
+  const objects = new Set(
+    initialObjects.map((object) => `${object.storageScope}:${object.storageKey}`),
+  );
+  const failures = new Set<string>();
+
+  return {
+    async deletePrivateObject(storageScope, storageKey) {
+      const key = `${storageScope}:${storageKey}`;
+      if (failures.has(key)) throw new Error('Synthetic private photo cleanup failure.');
+      if (!objects.has(key)) return 'missing';
+      objects.delete(key);
+      return 'deleted';
+    },
+
+    put(object) {
+      objects.add(`${object.storageScope}:${object.storageKey}`);
+    },
+
+    fail(storageScope, storageKey) {
+      failures.add(`${storageScope}:${storageKey}`);
+    },
+
+    list() {
+      return [...objects]
+        .sort()
+        .map((value) => {
+          const separator = value.indexOf(':');
+          return {
+            storageScope: value.slice(0, separator) as 'quarantine' | 'private',
+            storageKey: value.slice(separator + 1),
+          };
+        });
+    },
+  };
+}

--- a/src/submissions/photo-private-lifecycle.ts
+++ b/src/submissions/photo-private-lifecycle.ts
@@ -323,7 +323,8 @@ export function createPhotoPrivateCleanupService(dependencies: {
           referenceType: candidate.referenceType,
           referenceId: candidate.referenceId,
           reason: candidate.reason,
-          outcome: failedObjectCount > 0 ? 'partial' : deletedObjectCount > 0 ? 'deleted' : 'replayed',
+          outcome:
+            failedObjectCount > 0 ? 'partial' : deletedObjectCount > 0 ? 'deleted' : 'replayed',
           deletedObjectCount,
           missingObjectCount,
           failedObjectCount,

--- a/src/submissions/photo-private-lifecycle.ts
+++ b/src/submissions/photo-private-lifecycle.ts
@@ -24,7 +24,10 @@ export const photoPrivateCleanupObjectSchema = z
     storageScope: z.enum(['quarantine', 'private']),
     storageKey: z.string().trim().min(1).max(1_024),
     mimeType: z.string().trim().min(1).max(127),
-    contentHash: z.string().regex(/^[a-f0-9]{64}$/).nullable(),
+    contentHash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
   })
   .strict()
   .superRefine((object, context) => {
@@ -117,13 +120,12 @@ export const photoPrivateCleanupCandidateSchema = z
       context.addIssue({
         code: 'custom',
         path: ['referenceType'],
-        message: 'Terminal Media cleanup must reference its exact photo Media Asset and Submission.',
+        message:
+          'Terminal Media cleanup must reference its exact photo Media Asset and Submission.',
       });
     }
 
-    const keys = candidate.objects.map(
-      (object) => `${object.storageScope}:${object.storageKey}`,
-    );
+    const keys = candidate.objects.map((object) => `${object.storageScope}:${object.storageKey}`);
     if (new Set(keys).size !== keys.length) {
       context.addIssue({
         code: 'custom',
@@ -321,12 +323,7 @@ export function createPhotoPrivateCleanupService(dependencies: {
           referenceType: candidate.referenceType,
           referenceId: candidate.referenceId,
           reason: candidate.reason,
-          outcome:
-            failedObjectCount > 0
-              ? 'partial'
-              : deletedObjectCount > 0
-                ? 'deleted'
-                : 'replayed',
+          outcome: failedObjectCount > 0 ? 'partial' : deletedObjectCount > 0 ? 'deleted' : 'replayed',
           deletedObjectCount,
           missingObjectCount,
           failedObjectCount,

--- a/src/submissions/photo-private-lifecycle.ts
+++ b/src/submissions/photo-private-lifecycle.ts
@@ -1,0 +1,362 @@
+import { z } from 'zod';
+import { privateMediaDerivativeKey } from '../admin/media-review/storage-plan';
+import { photoQuarantineObjectKey } from './photo-upload-authorization';
+
+const MILLISECONDS_PER_DAY = 86_400_000;
+export const PHOTO_TERMINAL_RETENTION_DAYS = 30;
+export const MAX_PHOTO_CLEANUP_CANDIDATES = 100;
+
+export const photoPrivateCleanupReasonValues = [
+  'expired_authorization',
+  'closed_submission_without_handoff',
+  'rejected_media',
+  'superseded_media',
+] as const;
+export const photoPrivateCleanupReasonSchema = z.enum(photoPrivateCleanupReasonValues);
+
+export const photoPrivateCleanupObjectSchema = z
+  .object({
+    objectRefId: z.uuid(),
+    reservationId: z.uuid().nullable(),
+    mediaAssetId: z.uuid().nullable(),
+    mediaFileId: z.uuid().nullable(),
+    variant: z.enum(['original', 'display', 'thumbnail']),
+    storageScope: z.enum(['quarantine', 'private']),
+    storageKey: z.string().trim().min(1).max(1_024),
+    mimeType: z.string().trim().min(1).max(127),
+    contentHash: z.string().regex(/^[a-f0-9]{64}$/).nullable(),
+  })
+  .strict()
+  .superRefine((object, context) => {
+    if (object.storageScope === 'quarantine') {
+      if (
+        object.variant !== 'original' ||
+        object.reservationId === null ||
+        object.storageKey !== photoQuarantineObjectKey(object.reservationId)
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: ['storageKey'],
+          message: 'Quarantine cleanup requires the canonical opaque reservation object key.',
+        });
+      }
+      return;
+    }
+
+    if (
+      object.variant === 'original' ||
+      object.mediaAssetId === null ||
+      object.mediaFileId === null ||
+      object.contentHash === null ||
+      (object.mimeType !== 'image/jpeg' && object.mimeType !== 'image/webp')
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['variant'],
+        message: 'Private derivative cleanup requires a canonical display or thumbnail file.',
+      });
+      return;
+    }
+
+    const expectedKey = privateMediaDerivativeKey(object.mediaAssetId, {
+      id: object.mediaFileId,
+      contentHash: object.contentHash,
+      mimeType: object.mimeType,
+    });
+    if (object.storageKey !== expectedKey) {
+      context.addIssue({
+        code: 'custom',
+        path: ['storageKey'],
+        message: 'Private derivative cleanup requires the canonical Media storage key.',
+      });
+    }
+  });
+
+export const photoPrivateCleanupCandidateSchema = z
+  .object({
+    referenceType: z.enum(['reservation', 'submission', 'media_asset']),
+    referenceId: z.uuid(),
+    reason: photoPrivateCleanupReasonSchema,
+    eligibleAt: z.iso.datetime({ offset: true }),
+    submissionId: z.uuid().nullable(),
+    mediaAssetId: z.uuid().nullable(),
+    objects: z.array(photoPrivateCleanupObjectSchema).min(1).max(24),
+  })
+  .strict()
+  .superRefine((candidate, context) => {
+    if (
+      candidate.reason === 'expired_authorization' &&
+      (candidate.referenceType !== 'reservation' ||
+        candidate.submissionId !== null ||
+        candidate.mediaAssetId !== null)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['referenceType'],
+        message: 'Expired authorization cleanup must reference only one reservation.',
+      });
+    }
+    if (
+      candidate.reason === 'closed_submission_without_handoff' &&
+      (candidate.referenceType !== 'submission' ||
+        candidate.submissionId !== candidate.referenceId ||
+        candidate.mediaAssetId !== null)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['referenceType'],
+        message: 'Closed Submission cleanup must reference its exact Photos Submission.',
+      });
+    }
+    if (
+      (candidate.reason === 'rejected_media' || candidate.reason === 'superseded_media') &&
+      (candidate.referenceType !== 'media_asset' ||
+        candidate.mediaAssetId !== candidate.referenceId ||
+        candidate.submissionId === null)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['referenceType'],
+        message: 'Terminal Media cleanup must reference its exact photo Media Asset and Submission.',
+      });
+    }
+
+    const keys = candidate.objects.map(
+      (object) => `${object.storageScope}:${object.storageKey}`,
+    );
+    if (new Set(keys).size !== keys.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['objects'],
+        message: 'A cleanup candidate cannot contain duplicate private object keys.',
+      });
+    }
+  });
+
+export const photoPrivateCleanupRequestSchema = z
+  .object({
+    schemaVersion: z.literal('photo-private-cleanup-v1'),
+    runId: z.uuid(),
+    asOf: z.iso.datetime({ offset: true }),
+    limit: z.number().int().min(1).max(MAX_PHOTO_CLEANUP_CANDIDATES).default(50),
+  })
+  .strict();
+
+export const photoPrivateCleanupReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('photo-private-cleanup-receipt-v1'),
+    runId: z.uuid(),
+    asOf: z.iso.datetime({ offset: true }),
+    state: z.enum(['completed', 'partial']),
+    candidateCount: z.number().int().min(0).max(MAX_PHOTO_CLEANUP_CANDIDATES),
+    deletedObjectCount: z.number().int().min(0),
+    missingObjectCount: z.number().int().min(0),
+    failedObjectCount: z.number().int().min(0),
+    candidates: z
+      .array(
+        z
+          .object({
+            referenceType: z.enum(['reservation', 'submission', 'media_asset']),
+            referenceId: z.uuid(),
+            reason: photoPrivateCleanupReasonSchema,
+            outcome: z.enum(['deleted', 'replayed', 'partial']),
+            deletedObjectCount: z.number().int().min(0),
+            missingObjectCount: z.number().int().min(0),
+            failedObjectCount: z.number().int().min(0),
+          })
+          .strict(),
+      )
+      .max(MAX_PHOTO_CLEANUP_CANDIDATES),
+  })
+  .strict();
+
+export type PhotoPrivateCleanupReason = z.infer<typeof photoPrivateCleanupReasonSchema>;
+export type PhotoPrivateCleanupObject = z.infer<typeof photoPrivateCleanupObjectSchema>;
+export type PhotoPrivateCleanupCandidate = z.infer<typeof photoPrivateCleanupCandidateSchema>;
+export type PhotoPrivateCleanupRequest = z.infer<typeof photoPrivateCleanupRequestSchema>;
+export type PhotoPrivateCleanupReceipt = z.infer<typeof photoPrivateCleanupReceiptSchema>;
+
+export interface PhotoPrivateCleanupCutoffs {
+  expiredAuthorizationBefore: Date;
+  terminalStateBefore: Date;
+}
+
+export interface PhotoPrivateCleanupCandidateReader {
+  loadCleanupCandidates(
+    cutoffs: PhotoPrivateCleanupCutoffs,
+    limit: number,
+  ): Promise<PhotoPrivateCleanupCandidate[]>;
+}
+
+export interface PhotoPrivateObjectLifecycleStore {
+  deletePrivateObject(
+    storageScope: 'quarantine' | 'private',
+    storageKey: string,
+  ): Promise<'deleted' | 'missing'>;
+}
+
+export class PhotoPrivateCleanupError extends Error {
+  constructor(
+    readonly code: 'invalid_request' | 'backend_failure' | 'candidate_invalid',
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'PhotoPrivateCleanupError';
+  }
+}
+
+function cutoffs(asOf: Date): PhotoPrivateCleanupCutoffs {
+  return {
+    expiredAuthorizationBefore: asOf,
+    terminalStateBefore: new Date(
+      asOf.getTime() - PHOTO_TERMINAL_RETENTION_DAYS * MILLISECONDS_PER_DAY,
+    ),
+  };
+}
+
+function assertEligible(
+  candidate: PhotoPrivateCleanupCandidate,
+  limits: PhotoPrivateCleanupCutoffs,
+): void {
+  const eligibleAt = Date.parse(candidate.eligibleAt);
+  const threshold =
+    candidate.reason === 'expired_authorization'
+      ? limits.expiredAuthorizationBefore.getTime()
+      : limits.terminalStateBefore.getTime();
+  if (!Number.isFinite(eligibleAt) || eligibleAt > threshold) {
+    throw new PhotoPrivateCleanupError(
+      'candidate_invalid',
+      'A private photo cleanup candidate has not reached its retention boundary.',
+    );
+  }
+}
+
+export function createPhotoPrivateCleanupService(dependencies: {
+  candidates: PhotoPrivateCleanupCandidateReader;
+  objects: PhotoPrivateObjectLifecycleStore;
+}) {
+  return {
+    async run(rawInput: unknown): Promise<PhotoPrivateCleanupReceipt> {
+      let request: PhotoPrivateCleanupRequest;
+      try {
+        request = photoPrivateCleanupRequestSchema.parse(rawInput);
+      } catch (error) {
+        throw new PhotoPrivateCleanupError(
+          'invalid_request',
+          'Private photo cleanup request failed validation.',
+          { cause: error },
+        );
+      }
+
+      const asOf = new Date(request.asOf);
+      const retentionCutoffs = cutoffs(asOf);
+      let loaded: PhotoPrivateCleanupCandidate[];
+      try {
+        loaded = await dependencies.candidates.loadCleanupCandidates(
+          retentionCutoffs,
+          request.limit,
+        );
+      } catch (error) {
+        throw new PhotoPrivateCleanupError(
+          'backend_failure',
+          'Private photo cleanup candidates could not be loaded.',
+          { cause: error },
+        );
+      }
+      if (loaded.length > request.limit) {
+        throw new PhotoPrivateCleanupError(
+          'candidate_invalid',
+          'Private photo cleanup returned more candidates than requested.',
+        );
+      }
+
+      const candidates = loaded.map((candidate) => {
+        const parsed = photoPrivateCleanupCandidateSchema.safeParse(candidate);
+        if (!parsed.success) {
+          throw new PhotoPrivateCleanupError(
+            'candidate_invalid',
+            'A private photo cleanup candidate is invalid.',
+            { cause: parsed.error },
+          );
+        }
+        assertEligible(parsed.data, retentionCutoffs);
+        return parsed.data;
+      });
+      const referenceKeys = candidates.map(
+        (candidate) => `${candidate.referenceType}:${candidate.referenceId}`,
+      );
+      if (new Set(referenceKeys).size !== referenceKeys.length) {
+        throw new PhotoPrivateCleanupError(
+          'candidate_invalid',
+          'Private photo cleanup candidates contain duplicate references.',
+        );
+      }
+
+      const objectResults = new Map<string, 'deleted' | 'missing' | 'failed'>();
+      const candidateReceipts: PhotoPrivateCleanupReceipt['candidates'] = [];
+      for (const candidate of candidates) {
+        let deletedObjectCount = 0;
+        let missingObjectCount = 0;
+        let failedObjectCount = 0;
+        for (const object of candidate.objects) {
+          const key = `${object.storageScope}:${object.storageKey}`;
+          let result = objectResults.get(key);
+          if (result === undefined) {
+            try {
+              result = await dependencies.objects.deletePrivateObject(
+                object.storageScope,
+                object.storageKey,
+              );
+            } catch {
+              result = 'failed';
+            }
+            objectResults.set(key, result);
+          }
+          if (result === 'deleted') deletedObjectCount += 1;
+          else if (result === 'missing') missingObjectCount += 1;
+          else failedObjectCount += 1;
+        }
+        candidateReceipts.push({
+          referenceType: candidate.referenceType,
+          referenceId: candidate.referenceId,
+          reason: candidate.reason,
+          outcome:
+            failedObjectCount > 0
+              ? 'partial'
+              : deletedObjectCount > 0
+                ? 'deleted'
+                : 'replayed',
+          deletedObjectCount,
+          missingObjectCount,
+          failedObjectCount,
+        });
+      }
+
+      const deletedObjectCount = candidateReceipts.reduce(
+        (sum, candidate) => sum + candidate.deletedObjectCount,
+        0,
+      );
+      const missingObjectCount = candidateReceipts.reduce(
+        (sum, candidate) => sum + candidate.missingObjectCount,
+        0,
+      );
+      const failedObjectCount = candidateReceipts.reduce(
+        (sum, candidate) => sum + candidate.failedObjectCount,
+        0,
+      );
+
+      return photoPrivateCleanupReceiptSchema.parse({
+        schemaVersion: 'photo-private-cleanup-receipt-v1',
+        runId: request.runId,
+        asOf: request.asOf,
+        state: failedObjectCount > 0 ? 'partial' : 'completed',
+        candidateCount: candidates.length,
+        deletedObjectCount,
+        missingObjectCount,
+        failedObjectCount,
+        candidates: candidateReceipts,
+      });
+    },
+  };
+}

--- a/src/submissions/r2-photo-private-lifecycle.ts
+++ b/src/submissions/r2-photo-private-lifecycle.ts
@@ -1,0 +1,37 @@
+import type { R2BucketLike } from '../admin/media-review/r2-storage';
+import type { PhotoPrivateObjectLifecycleStore } from './photo-private-lifecycle';
+
+export class PhotoPrivateLifecycleStoreError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'PhotoPrivateLifecycleStoreError';
+  }
+}
+
+export function createR2PhotoPrivateObjectLifecycleStore(
+  quarantineBucket: R2BucketLike,
+  privateBucket: R2BucketLike,
+): PhotoPrivateObjectLifecycleStore {
+  return {
+    async deletePrivateObject(storageScope, storageKey) {
+      const bucket = storageScope === 'quarantine' ? quarantineBucket : privateBucket;
+      try {
+        const existing = await bucket.head(storageKey);
+        if (existing === null) return 'missing';
+        await bucket.delete(storageKey);
+        if ((await bucket.head(storageKey)) !== null) {
+          throw new PhotoPrivateLifecycleStoreError(
+            'Private photo object remained after cleanup.',
+          );
+        }
+        return 'deleted';
+      } catch (error) {
+        if (error instanceof PhotoPrivateLifecycleStoreError) throw error;
+        throw new PhotoPrivateLifecycleStoreError(
+          'Private photo object cleanup failed.',
+          { cause: error },
+        );
+      }
+    },
+  };
+}

--- a/src/submissions/r2-photo-private-lifecycle.ts
+++ b/src/submissions/r2-photo-private-lifecycle.ts
@@ -20,17 +20,14 @@ export function createR2PhotoPrivateObjectLifecycleStore(
         if (existing === null) return 'missing';
         await bucket.delete(storageKey);
         if ((await bucket.head(storageKey)) !== null) {
-          throw new PhotoPrivateLifecycleStoreError(
-            'Private photo object remained after cleanup.',
-          );
+          throw new PhotoPrivateLifecycleStoreError('Private photo object remained after cleanup.');
         }
         return 'deleted';
       } catch (error) {
         if (error instanceof PhotoPrivateLifecycleStoreError) throw error;
-        throw new PhotoPrivateLifecycleStoreError(
-          'Private photo object cleanup failed.',
-          { cause: error },
-        );
+        throw new PhotoPrivateLifecycleStoreError('Private photo object cleanup failed.', {
+          cause: error,
+        });
       }
     },
   };

--- a/tests/media-duplicate-signals.test.ts
+++ b/tests/media-duplicate-signals.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mediaDuplicateSignalsSchema,
+  projectMediaDuplicateSignals,
+} from '../src/admin/media-review/duplicate-signals';
+
+const currentSubject = {
+  type: 'location' as const,
+  id: '10000000-0000-4000-8000-000000000001',
+};
+
+function candidate(
+  mediaAssetId: string,
+  subjectId: string,
+  createdAt: string,
+) {
+  return {
+    mediaAssetId,
+    subject: { type: 'location' as const, id: subjectId },
+    reviewStatus: 'pending' as const,
+    visibility: 'private' as const,
+    createdAt,
+  };
+}
+
+describe('P5-05F Media duplicate signals', () => {
+  it('projects exact original-hash matches as bounded manual-review signals', () => {
+    const result = projectMediaDuplicateSignals(
+      currentSubject,
+      'a'.repeat(64),
+      [
+        candidate(
+          '20000000-0000-4000-8000-000000000001',
+          currentSubject.id,
+          '2026-07-15T02:00:00.000Z',
+        ),
+        candidate(
+          '20000000-0000-4000-8000-000000000002',
+          '10000000-0000-4000-8000-000000000002',
+          '2026-07-15T03:00:00.000Z',
+        ),
+      ],
+    );
+
+    expect(result).toEqual({
+      sourceOriginalContentHash: 'a'.repeat(64),
+      matches: [
+        expect.objectContaining({
+          mediaAssetId: '20000000-0000-4000-8000-000000000002',
+          sameTarget: false,
+        }),
+        expect.objectContaining({
+          mediaAssetId: '20000000-0000-4000-8000-000000000001',
+          sameTarget: true,
+        }),
+      ],
+      hasMore: false,
+      automaticDecision: false,
+      manualReviewRequired: true,
+    });
+  });
+
+  it('deduplicates Media Asset matches and reports a bounded remainder', () => {
+    const duplicate = candidate(
+      '20000000-0000-4000-8000-000000000001',
+      currentSubject.id,
+      '2026-07-15T02:00:00.000Z',
+    );
+    const result = projectMediaDuplicateSignals(
+      currentSubject,
+      'b'.repeat(64),
+      [
+        duplicate,
+        duplicate,
+        candidate(
+          '20000000-0000-4000-8000-000000000002',
+          currentSubject.id,
+          '2026-07-15T01:00:00.000Z',
+        ),
+      ],
+      1,
+    );
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.hasMore).toBe(true);
+    expect(result.automaticDecision).toBe(false);
+  });
+
+  it('returns no review requirement when no original hash is available', () => {
+    expect(projectMediaDuplicateSignals(currentSubject, null, [])).toEqual({
+      sourceOriginalContentHash: null,
+      matches: [],
+      hasMore: false,
+      automaticDecision: false,
+      manualReviewRequired: false,
+    });
+  });
+
+  it('rejects storage paths and automatic decisions from the signal contract', () => {
+    expect(
+      mediaDuplicateSignalsSchema.safeParse({
+        sourceOriginalContentHash: 'c'.repeat(64),
+        matches: [],
+        hasMore: false,
+        automaticDecision: true,
+        manualReviewRequired: false,
+        storageKey: 'media/private/secret.webp',
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/tests/media-duplicate-signals.test.ts
+++ b/tests/media-duplicate-signals.test.ts
@@ -9,11 +9,7 @@ const currentSubject = {
   id: '10000000-0000-4000-8000-000000000001',
 };
 
-function candidate(
-  mediaAssetId: string,
-  subjectId: string,
-  createdAt: string,
-) {
+function candidate(mediaAssetId: string, subjectId: string, createdAt: string) {
   return {
     mediaAssetId,
     subject: { type: 'location' as const, id: subjectId },
@@ -25,22 +21,18 @@ function candidate(
 
 describe('P5-05F Media duplicate signals', () => {
   it('projects exact original-hash matches as bounded manual-review signals', () => {
-    const result = projectMediaDuplicateSignals(
-      currentSubject,
-      'a'.repeat(64),
-      [
-        candidate(
-          '20000000-0000-4000-8000-000000000001',
-          currentSubject.id,
-          '2026-07-15T02:00:00.000Z',
-        ),
-        candidate(
-          '20000000-0000-4000-8000-000000000002',
-          '10000000-0000-4000-8000-000000000002',
-          '2026-07-15T03:00:00.000Z',
-        ),
-      ],
-    );
+    const result = projectMediaDuplicateSignals(currentSubject, 'a'.repeat(64), [
+      candidate(
+        '20000000-0000-4000-8000-000000000001',
+        currentSubject.id,
+        '2026-07-15T02:00:00.000Z',
+      ),
+      candidate(
+        '20000000-0000-4000-8000-000000000002',
+        '10000000-0000-4000-8000-000000000002',
+        '2026-07-15T03:00:00.000Z',
+      ),
+    ]);
 
     expect(result).toEqual({
       sourceOriginalContentHash: 'a'.repeat(64),

--- a/tests/photo-private-lifecycle-r2.test.ts
+++ b/tests/photo-private-lifecycle-r2.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  R2BucketLike,
+  R2ObjectBodyLike,
+  R2ObjectLike,
+} from '../src/admin/media-review/r2-storage';
+import { createR2PhotoPrivateObjectLifecycleStore } from '../src/submissions/r2-photo-private-lifecycle';
+
+class FakeBucket implements R2BucketLike {
+  readonly objects = new Map<string, R2ObjectLike>();
+
+  async head(key: string): Promise<R2ObjectLike | null> {
+    return this.objects.get(key) ?? null;
+  }
+
+  async get(key: string): Promise<R2ObjectBodyLike | null> {
+    const object = this.objects.get(key);
+    return object === undefined ? null : { ...object, body: new Uint8Array([1]) };
+  }
+
+  async put(
+    key: string,
+    value: unknown,
+    options: {
+      httpMetadata: { contentType: string };
+      customMetadata: Record<string, string>;
+    },
+  ): Promise<unknown> {
+    const size = value instanceof Uint8Array ? value.byteLength : 1;
+    this.objects.set(key, {
+      key,
+      size,
+      httpMetadata: options.httpMetadata,
+      customMetadata: options.customMetadata,
+    });
+    return undefined;
+  }
+
+  async delete(key: string): Promise<void> {
+    this.objects.delete(key);
+  }
+}
+
+describe('P5-05F R2 private lifecycle adapter', () => {
+  it('routes quarantine and private deletions to separate buckets', async () => {
+    const quarantine = new FakeBucket();
+    const privateBucket = new FakeBucket();
+    quarantine.objects.set('quarantine-key', { key: 'quarantine-key', size: 10 });
+    privateBucket.objects.set('private-key', { key: 'private-key', size: 10 });
+    const store = createR2PhotoPrivateObjectLifecycleStore(quarantine, privateBucket);
+
+    await expect(store.deletePrivateObject('quarantine', 'quarantine-key')).resolves.toBe(
+      'deleted',
+    );
+    await expect(store.deletePrivateObject('private', 'private-key')).resolves.toBe('deleted');
+    await expect(store.deletePrivateObject('private', 'missing-key')).resolves.toBe('missing');
+    expect(quarantine.objects.size).toBe(0);
+    expect(privateBucket.objects.size).toBe(0);
+  });
+});

--- a/tests/photo-private-lifecycle.test.ts
+++ b/tests/photo-private-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
 import { photoQuarantineObjectKey } from '../src/submissions/photo-upload-authorization';
 
 const reservationId = '10000000-0000-4000-8000-000000000001';
+const expiredReservationId = '10000000-0000-4000-8000-000000000002';
 const submissionId = '20000000-0000-4000-8000-000000000001';
 const mediaAssetId = '30000000-0000-4000-8000-000000000001';
 const originalFileId = '40000000-0000-4000-8000-000000000001';
@@ -22,20 +23,20 @@ const displayKey = privateMediaDerivativeKey(mediaAssetId, {
 
 const expiredAuthorization: PhotoPrivateCleanupCandidate = {
   referenceType: 'reservation',
-  referenceId: reservationId,
+  referenceId: expiredReservationId,
   reason: 'expired_authorization',
   eligibleAt: '2026-07-14T00:00:00.000Z',
   submissionId: null,
   mediaAssetId: null,
   objects: [
     {
-      objectRefId: reservationId,
-      reservationId,
+      objectRefId: expiredReservationId,
+      reservationId: expiredReservationId,
       mediaAssetId: null,
       mediaFileId: null,
       variant: 'original',
       storageScope: 'quarantine',
-      storageKey: photoQuarantineObjectKey(reservationId),
+      storageKey: photoQuarantineObjectKey(expiredReservationId),
       mimeType: 'application/octet-stream',
       contentHash: null,
     },
@@ -93,6 +94,10 @@ function reader(candidates: PhotoPrivateCleanupCandidate[]) {
 describe('P5-05F private photo lifecycle cleanup', () => {
   it('deletes only eligible private objects and emits a leakage-safe receipt', async () => {
     const objects = createInMemoryPhotoPrivateObjectLifecycleStore([
+      {
+        storageScope: 'quarantine',
+        storageKey: photoQuarantineObjectKey(expiredReservationId),
+      },
       { storageScope: 'quarantine', storageKey: photoQuarantineObjectKey(reservationId) },
       { storageScope: 'private', storageKey: displayKey },
     ]);
@@ -105,7 +110,7 @@ describe('P5-05F private photo lifecycle cleanup', () => {
 
     expect(receipt.state).toBe('completed');
     expect(receipt.candidateCount).toBe(2);
-    expect(receipt.deletedObjectCount).toBe(2);
+    expect(receipt.deletedObjectCount).toBe(3);
     expect(receipt.failedObjectCount).toBe(0);
     expect(objects.list()).toEqual([]);
     expect(JSON.stringify(receipt)).not.toContain('quarantine/photos');
@@ -128,9 +133,7 @@ describe('P5-05F private photo lifecycle cleanup', () => {
 
   it('rejects a terminal candidate before its 30-day retention boundary', async () => {
     const service = createPhotoPrivateCleanupService({
-      candidates: reader([
-        { ...rejectedMedia, eligibleAt: '2026-07-01T00:00:00.000Z' },
-      ]),
+      candidates: reader([{ ...rejectedMedia, eligibleAt: '2026-07-01T00:00:00.000Z' }]),
       objects: createInMemoryPhotoPrivateObjectLifecycleStore(),
     });
 

--- a/tests/photo-private-lifecycle.test.ts
+++ b/tests/photo-private-lifecycle.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { privateMediaDerivativeKey } from '../src/admin/media-review/storage-plan';
+import { createInMemoryPhotoPrivateObjectLifecycleStore } from '../src/submissions/in-memory-photo-private-lifecycle';
+import {
+  createPhotoPrivateCleanupService,
+  PhotoPrivateCleanupError,
+  type PhotoPrivateCleanupCandidate,
+} from '../src/submissions/photo-private-lifecycle';
+import { photoQuarantineObjectKey } from '../src/submissions/photo-upload-authorization';
+
+const reservationId = '10000000-0000-4000-8000-000000000001';
+const submissionId = '20000000-0000-4000-8000-000000000001';
+const mediaAssetId = '30000000-0000-4000-8000-000000000001';
+const originalFileId = '40000000-0000-4000-8000-000000000001';
+const displayFileId = '40000000-0000-4000-8000-000000000002';
+const displayHash = 'd'.repeat(64);
+const displayKey = privateMediaDerivativeKey(mediaAssetId, {
+  id: displayFileId,
+  contentHash: displayHash,
+  mimeType: 'image/webp',
+});
+
+const expiredAuthorization: PhotoPrivateCleanupCandidate = {
+  referenceType: 'reservation',
+  referenceId: reservationId,
+  reason: 'expired_authorization',
+  eligibleAt: '2026-07-14T00:00:00.000Z',
+  submissionId: null,
+  mediaAssetId: null,
+  objects: [
+    {
+      objectRefId: reservationId,
+      reservationId,
+      mediaAssetId: null,
+      mediaFileId: null,
+      variant: 'original',
+      storageScope: 'quarantine',
+      storageKey: photoQuarantineObjectKey(reservationId),
+      mimeType: 'application/octet-stream',
+      contentHash: null,
+    },
+  ],
+};
+
+const rejectedMedia: PhotoPrivateCleanupCandidate = {
+  referenceType: 'media_asset',
+  referenceId: mediaAssetId,
+  reason: 'rejected_media',
+  eligibleAt: '2026-06-01T00:00:00.000Z',
+  submissionId,
+  mediaAssetId,
+  objects: [
+    {
+      objectRefId: originalFileId,
+      reservationId,
+      mediaAssetId,
+      mediaFileId: originalFileId,
+      variant: 'original',
+      storageScope: 'quarantine',
+      storageKey: photoQuarantineObjectKey(reservationId),
+      mimeType: 'image/png',
+      contentHash: 'a'.repeat(64),
+    },
+    {
+      objectRefId: displayFileId,
+      reservationId: null,
+      mediaAssetId,
+      mediaFileId: displayFileId,
+      variant: 'display',
+      storageScope: 'private',
+      storageKey: displayKey,
+      mimeType: 'image/webp',
+      contentHash: displayHash,
+    },
+  ],
+};
+
+const request = {
+  schemaVersion: 'photo-private-cleanup-v1',
+  runId: '50000000-0000-4000-8000-000000000001',
+  asOf: '2026-07-15T00:00:00.000Z',
+  limit: 50,
+} as const;
+
+function reader(candidates: PhotoPrivateCleanupCandidate[]) {
+  return {
+    async loadCleanupCandidates() {
+      return structuredClone(candidates);
+    },
+  };
+}
+
+describe('P5-05F private photo lifecycle cleanup', () => {
+  it('deletes only eligible private objects and emits a leakage-safe receipt', async () => {
+    const objects = createInMemoryPhotoPrivateObjectLifecycleStore([
+      { storageScope: 'quarantine', storageKey: photoQuarantineObjectKey(reservationId) },
+      { storageScope: 'private', storageKey: displayKey },
+    ]);
+    const service = createPhotoPrivateCleanupService({
+      candidates: reader([expiredAuthorization, rejectedMedia]),
+      objects,
+    });
+
+    const receipt = await service.run(request);
+
+    expect(receipt.state).toBe('completed');
+    expect(receipt.candidateCount).toBe(2);
+    expect(receipt.deletedObjectCount).toBe(2);
+    expect(receipt.failedObjectCount).toBe(0);
+    expect(objects.list()).toEqual([]);
+    expect(JSON.stringify(receipt)).not.toContain('quarantine/photos');
+    expect(JSON.stringify(receipt)).not.toContain('media/private');
+  });
+
+  it('treats missing objects as an idempotent replay', async () => {
+    const service = createPhotoPrivateCleanupService({
+      candidates: reader([expiredAuthorization]),
+      objects: createInMemoryPhotoPrivateObjectLifecycleStore(),
+    });
+
+    const receipt = await service.run(request);
+
+    expect(receipt.state).toBe('completed');
+    expect(receipt.deletedObjectCount).toBe(0);
+    expect(receipt.missingObjectCount).toBe(1);
+    expect(receipt.candidates[0]?.outcome).toBe('replayed');
+  });
+
+  it('rejects a terminal candidate before its 30-day retention boundary', async () => {
+    const service = createPhotoPrivateCleanupService({
+      candidates: reader([
+        { ...rejectedMedia, eligibleAt: '2026-07-01T00:00:00.000Z' },
+      ]),
+      objects: createInMemoryPhotoPrivateObjectLifecycleStore(),
+    });
+
+    await expect(service.run(request)).rejects.toEqual(
+      expect.objectContaining<Partial<PhotoPrivateCleanupError>>({
+        code: 'candidate_invalid',
+      }),
+    );
+  });
+
+  it('rejects noncanonical private object keys without deleting anything', async () => {
+    const invalid = structuredClone(rejectedMedia);
+    invalid.objects[1] = {
+      ...invalid.objects[1]!,
+      storageKey: 'media/private/wrong.webp',
+    };
+    const objects = createInMemoryPhotoPrivateObjectLifecycleStore([
+      { storageScope: 'private', storageKey: displayKey },
+    ]);
+    const service = createPhotoPrivateCleanupService({
+      candidates: reader([invalid]),
+      objects,
+    });
+
+    await expect(service.run(request)).rejects.toEqual(
+      expect.objectContaining<Partial<PhotoPrivateCleanupError>>({
+        code: 'candidate_invalid',
+      }),
+    );
+    expect(objects.list()).toEqual([{ storageScope: 'private', storageKey: displayKey }]);
+  });
+
+  it('continues other deletions and reports a partial run when one object fails', async () => {
+    const objects = createInMemoryPhotoPrivateObjectLifecycleStore([
+      { storageScope: 'quarantine', storageKey: photoQuarantineObjectKey(reservationId) },
+      { storageScope: 'private', storageKey: displayKey },
+    ]);
+    objects.fail('private', displayKey);
+    const service = createPhotoPrivateCleanupService({
+      candidates: reader([rejectedMedia]),
+      objects,
+    });
+
+    const receipt = await service.run(request);
+
+    expect(receipt.state).toBe('partial');
+    expect(receipt.deletedObjectCount).toBe(1);
+    expect(receipt.failedObjectCount).toBe(1);
+    expect(receipt.candidates[0]?.outcome).toBe('partial');
+    expect(objects.list()).toEqual([{ storageScope: 'private', storageKey: displayKey }]);
+  });
+});


### PR DESCRIPTION
## Implementation item

P5-05F — Photo duplicate signals and private upload lifecycle cleanup

## Purpose

Expose exact original-content-hash matches as bounded protected review signals and delete only retention-eligible quarantine or private photo objects without changing canonical or public state.

## Included

- exact SHA-256 original-image matches in protected Media detail
- deterministic same-target versus different-target review context
- maximum 25 unique matching Media Assets
- no automatic duplicate, misuse, spam, infringement, rights, or rejection conclusion
- expired unconsumed upload-authorization cleanup
- 30-day terminal Photos Submission cleanup when no Media handoff exists
- 30-day rejected or superseded P5-05 Media cleanup
- strict P5-05E handoff-event ownership checks
- canonical quarantine and private derivative key validation before deletion
- explicit rejection of public-scope, pending, accepted, or unrelated Media cleanup
- idempotent R2-compatible and in-memory deletion adapters
- partial-failure continuation and leakage-safe cleanup receipts
- limited audit, decision, target, and hash metadata retention after object deletion
- executable schema checks and focused duplicate, retention, replay, scope, adapter, and failure tests

## Duplicate boundary

Duplicate signals are derived only from exact original SHA-256 matches. They exclude the current and deleted Media Assets, expose no contributor or storage information, and always set `automaticDecision = false`. Perceptual similarity and known-abuse services remain outside this PR.

## Retention boundary

Expired unconsumed reservations may be cleaned after authorization expiry. Closed Photos Submissions without handoff, and rejected or superseded P5-05 Media, require a 30-day terminal boundary. Pending, accepted, public, or unrelated operator-managed Media is not selected.

## Deletion boundary

A cleanup object must be either the deterministic quarantine key for its opaque reservation or a canonical private display/thumbnail derivative for the exact Media Asset, Media File, MIME type, and content hash. Public objects are never deleted by this service. Missing objects are safe replays, while independent deletions continue after a failure and produce a `partial` receipt.

## Privacy boundary

Cleanup receipts contain only run counts, opaque reference identities, reasons, and outcomes. They exclude storage keys, object URLs, filenames, object bytes, contact data, status secrets, and public Media state.

## Explicit exclusions

No perceptual hashing, known-abuse service, public duplicate exposure, production scheduler or R2 binding, cleanup of pending or accepted Media, public object deletion, cache invalidation, Media review decision, canonical mutation, export, publication, or deployment.

## Migration

None. Limited hash and decision metadata remain in existing Media and Submission records after private object deletion.

## Validation

Implementation head `93efec323a9003efd50c0b8191a4d593a64adbdd` passed the complete quality chain with 224 test files and 1,105 tests.

Final documentation head `f20814a44659e8b44e2e58395b0ebb938558ccf7` passed all four required workflows:

- Foundation validation
- Migration drift
- Staging review validation
- Capture representative review screenshots

Foundation included successful format, lint, Astro and TypeScript, executable schemas, migration history, all tests, build, accessibility, Phase 1, and staging artifact checks.

## Changed files

Only protected duplicate-signal integration, private lifecycle cleanup contracts/adapters, focused tests/checks, and P5-05F tracking documentation are included.

## Next bounded item

P5-05G — public Photos upload-authorization and private-intake HTTP boundaries. This PR does not start browser form wiring, configured processing execution, Media approval, or publication.