### PR TITLE
P5-05G: add public Photos HTTP boundaries

### DIFF
--- a/docs/P5_05G_PHOTO_PUBLIC_HTTP_BOUNDARIES.md
+++ b/docs/P5_05G_PHOTO_PUBLIC_HTTP_BOUNDARIES.md
@@ -1,0 +1,93 @@
+# P5-05G public Photos HTTP boundaries
+
+**Status:** Completed in PR #222
+
+## Result
+
+P5-05G exposes two bounded JSON POST boundaries:
+
+- `POST /api/photos/upload-authorizations`
+- `POST /api/photos`
+
+The first route issues short-lived instructions for direct upload into private quarantine. The second route commits the existing private Photos Submission intake after opaque upload reservations have been created and used by the client.
+
+## Shared controls
+
+Both routes require:
+
+- `application/json`;
+- a UUID `Idempotency-Key`;
+- a streamed request body no larger than 128 KiB;
+- trusted Cloudflare edge identity;
+- opaque distributed rate-limit buckets;
+- Turnstile verification;
+- strict schemas that reject undeclared fields;
+- `no-store`, `no-referrer`, JSON, and `nosniff` response headers;
+- bounded public error codes with no internal details.
+
+Malformed media type, body size, idempotency identity, or JSON fails before database or provider runtime composition.
+
+## Upload-authorization route
+
+The request contains the existing P5-05C authorization contract and a challenge token. The `Idempotency-Key` must exactly equal `intakeRequestId`.
+
+The execution order is:
+
+1. validate the HTTP envelope;
+2. read trusted edge identity;
+3. derive the opaque rate-limit bucket;
+4. apply distributed rate limiting;
+5. verify Turnstile;
+6. issue or replay durable reservations;
+7. return transient direct-upload instructions.
+
+The upload-authorizer dependency remains injected. This item does not claim a configured production object-storage signer.
+
+## Private-intake route
+
+The request contains the existing strict Photos Submission contract and a challenge token. The route reuses the established private intake, including:
+
+- protected optional contact handling;
+- deterministic status-secret issuance and replay;
+- private original and normalized payload persistence;
+- exact reservation ownership, purpose, expiry, and consumption checks;
+- atomic rollback on conflicts.
+
+The response contains only the public Submission reference, request-bound status secret, and submitted timestamp.
+
+## Runtime separation
+
+Upload authorization and private intake have separate runtime factories. Failure of the upload-authorizer configuration does not add an unnecessary dependency to final private intake after a client has already uploaded its objects.
+
+## Public errors
+
+The route boundary exposes only:
+
+- `photo_media_type_unsupported`;
+- `photo_request_too_large`;
+- `photo_request_invalid`;
+- `photo_rate_limited`;
+- `photo_request_conflict`;
+- `photo_unavailable`.
+
+Storage keys, private object bytes, contact values, edge addresses, persistence details, and secret hashes are not returned in errors.
+
+## Explicit non-effects
+
+P5-05G does not add:
+
+- a browser `/photos` form;
+- binary upload proxying;
+- configured production object-storage binding;
+- object validation or image processing execution;
+- Media approval or publication;
+- canonical mutation;
+- export activation or deployment.
+
+## Verification
+
+Implementation head `285aa11e0fb4381c90719f11ec55366e04fe7a9a` passed all four required workflows. Foundation validation passed format, lint, TypeScript, executable schemas, migration history, 225 test files with 1,112 tests, build, accessibility, Phase 1, and staging artifact checks.
+
+## Next bounded item
+
+P5-05H adds the browser `/photos` form and direct-upload orchestration against these two HTTP boundaries. It does not configure automatic processing, approve Media, or publish objects.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -8,7 +8,7 @@ Phase 5 — Public submissions / MVP-B
 
 ## Current implementation item
 
-P5-05G — Public Photos upload authorization and private intake HTTP boundaries
+P5-05H — Browser Photos form and direct-upload orchestration
 
 ## Current repository state
 
@@ -34,7 +34,8 @@ P5-05G — Public Photos upload authorization and private intake HTTP boundaries
 - P5-05D private object existence and byte-level validation completed in #219.
 - P5-05E controlled private processing and protected Media handoff completed in #220.
 - P5-05F exact original-hash review signals and retention-safe private object cleanup completed in #221.
-- P5-05G is next; its bounded scope is public Photos upload-authorization and private-intake HTTP boundaries without browser form wiring, automatic processing, Media approval, or publication.
+- P5-05G public upload-authorization and private-intake HTTP boundaries completed in #222.
+- P5-05H is next; its bounded scope is the browser `/photos` form and direct-upload orchestration without configured automatic processing, Media approval, or publication.
 
 ## P5-05A completion result
 
@@ -127,6 +128,20 @@ P5-05F provides:
 - limited database hash, decision, target, and audit metadata retention after object deletion;
 - no perceptual hashing, known-abuse provider, scheduler, production R2 binding, public route, canonical mutation, export, or publication.
 
+## P5-05G completion result
+
+P5-05G provides:
+
+- `POST /api/photos/upload-authorizations` and `POST /api/photos`;
+- strict JSON media type and a streamed 128 KiB request limit;
+- UUID idempotency identities and exact upload-authorization request matching;
+- trusted Cloudflare edge identity and opaque distributed rate-limit buckets;
+- rate limiting before Turnstile verification and private service invocation;
+- separate upload-authorization and private-intake runtime composition;
+- reuse of protected contact, status-secret, reservation, and private Submission persistence boundaries;
+- bounded `no-store` responses and privacy-safe error mapping;
+- no browser form, binary proxy, configured production object binding, automatic processing, Media approval, canonical mutation, export, or publication.
+
 ## Current references
 
 - `docs/IMPLEMENTATION_PLAN.md`
@@ -150,6 +165,7 @@ P5-05F provides:
 - `docs/P5_05D_PHOTO_OBJECT_VALIDATION.md`
 - `docs/P5_05E_PHOTO_PRIVATE_PROCESSING_AND_MEDIA_HANDOFF.md`
 - `docs/P5_05F_PHOTO_DUPLICATE_SIGNALS_AND_PRIVATE_LIFECYCLE.md`
+- `docs/P5_05G_PHOTO_PUBLIC_HTTP_BOUNDARIES.md`
 
 ## Phase 5 sequence
 
@@ -157,19 +173,19 @@ P5-05F provides:
 2. P5-02 — Suggest Place and Online Service — Completed through #156–#192
 3. P5-03 — Payment and problem reports — Completed through #194–#202
 4. P5-04 — Business and service claims — Completed through #203–#215
-5. P5-05 — Photo and Media submission intake — In progress at P5-05G; P5-05F completed #221
+5. P5-05 — Photo and Media submission intake — In progress at P5-05H; P5-05G completed #222
 6. P5-06 — Review workflow extensions — Planned
 7. P5-07 — Canonical application transactions and retention — Planned
 8. P5-08 — MVP-B integration audit — Planned
 
 ## Next
 
-Define and implement P5-05G public Photos upload-authorization and private-intake HTTP boundaries. The routes must reuse trusted edge identity, Turnstile, distributed rate limiting, bounded JSON and content-type checks, opaque idempotency identity, protected contact handling, status-secret issuance, and privacy-safe error mapping. Direct object upload remains scoped and private; successful intake must not process, approve, publish, or mutate canonical Media automatically.
+Define and implement P5-05H browser `/photos` form and direct-upload orchestration. The client must obtain one opaque idempotency identity, pass Turnstile, request upload authorizations, upload each file directly with the exact returned method and headers, submit only the opaque reservation UUIDs and declared metadata, and display the private Submission reference and status secret without persisting them insecurely. Client retry must preserve request identity and must not proxy binary objects through the application route.
 
 ## Blocked
 
-No repository blocker is known. Production R2 signing/binding, configured image codec and processing execution, browser `/photos` form and direct-upload orchestration, privacy-content analysis, protected Media reviewer execution, public Media approval, export activation, and production review remain separate later slices.
+No repository blocker is known. Production object-storage signing and binding, configured image codec and processing execution, privacy-content analysis, protected Media reviewer execution, public Media approval, export activation, deployment, and production review remain separate later slices.
 
 ## Verification rule
 
-Repository reality is determined by current `main`, merged pull requests, actual CI results, and fixed-review receipts. Exact hashes are review signals rather than proof of misuse, private object deletion does not remove required audit metadata, and no public Photos HTTP request may create approved or public Media automatically.
+Repository reality is determined by current `main`, merged pull requests, actual CI results, and fixed-review receipts. Public Photos HTTP success creates only upload reservations or a private Submission receipt; it does not create approved or public Media automatically.

--- a/functions/api/photos.ts
+++ b/functions/api/photos.ts
@@ -1,0 +1,14 @@
+import {
+  createPhotoPrivateIntakeHttpRuntimeFromEnvironment,
+  type PhotoHttpEnvironment,
+} from '../../src/submissions/photo-http-environment';
+import {
+  createPhotoPrivateIntakeHttpHandler,
+  type PhotoHttpPagesContext,
+} from '../../src/submissions/photo-http';
+
+export type PhotoPrivateIntakePagesContext = PhotoHttpPagesContext<PhotoHttpEnvironment>;
+
+export const onRequestPost = createPhotoPrivateIntakeHttpHandler({
+  runtimeFromEnvironment: createPhotoPrivateIntakeHttpRuntimeFromEnvironment,
+});

--- a/functions/api/photos/upload-authorizations.ts
+++ b/functions/api/photos/upload-authorizations.ts
@@ -1,0 +1,14 @@
+import {
+  createPhotoUploadAuthorizationHttpRuntimeFromEnvironment,
+  type PhotoHttpEnvironment,
+} from '../../../src/submissions/photo-http-environment';
+import {
+  createPhotoUploadAuthorizationHttpHandler,
+  type PhotoHttpPagesContext,
+} from '../../../src/submissions/photo-http';
+
+export type PhotoUploadAuthorizationPagesContext = PhotoHttpPagesContext<PhotoHttpEnvironment>;
+
+export const onRequestPost = createPhotoUploadAuthorizationHttpHandler({
+  runtimeFromEnvironment: createPhotoUploadAuthorizationHttpRuntimeFromEnvironment,
+});

--- a/scripts/check-photo-http.ts
+++ b/scripts/check-photo-http.ts
@@ -1,0 +1,93 @@
+import {
+  createPhotoPrivateIntakeHttpRuntimeFromEnvironment,
+  createPhotoUploadAuthorizationHttpRuntimeFromEnvironment,
+} from '../src/submissions/photo-http-environment';
+import {
+  createPhotoPrivateIntakeHttpHandler,
+  createPhotoUploadAuthorizationHttpHandler,
+  photoPrivateIntakeHttpRequestSchema,
+  photoPrivateIntakeHttpResponseSchema,
+  photoUploadAuthorizationHttpRequestSchema,
+} from '../src/submissions/photo-http';
+
+const requestId = '10000000-0000-4000-8000-000000000001';
+const targetId = '20000000-0000-4000-8000-000000000001';
+const quarantineUploadId = '30000000-0000-4000-8000-000000000001';
+
+photoUploadAuthorizationHttpRequestSchema.parse({
+  challengeToken: 'turnstile-token',
+  authorization: {
+    schemaVersion: 'photo-upload-authorization-v1',
+    intakeRequestId: requestId,
+    targetType: 'location',
+    targetId,
+    media: [
+      {
+        purpose: 'public_gallery_candidate',
+        declaredMimeType: 'image/jpeg',
+        declaredByteSize: 1_000,
+      },
+    ],
+  },
+});
+
+photoPrivateIntakeHttpRequestSchema.parse({
+  challengeToken: 'turnstile-token',
+  submission: {
+    schemaVersion: 'submission-common-v1',
+    submissionType: 'photos',
+    targetType: 'location',
+    targetId,
+    relationship: 'customer',
+    contact: null,
+    evidenceLinks: [],
+    originalPayload: {
+      schemaVersion: 'photo-media-v1',
+      media: [
+        {
+          quarantineUploadId,
+          purpose: 'public_gallery_candidate',
+          role: 'exterior',
+          declaredMimeType: 'image/jpeg',
+          declaredByteSize: 1_000,
+          capturedAt: null,
+          description: null,
+          suggestedAltText: null,
+          photographerPresent: true,
+          rights: {
+            rightsStatus: 'submitted_with_permission',
+            rightsHolderPresent: true,
+            permissionReferencePresent: false,
+            licenseName: null,
+            licenseUrl: null,
+            publicDisplayPermission: true,
+          },
+        },
+      ],
+      submitterNote: null,
+    },
+    acknowledgements: {
+      privacyNoticeAccepted: true,
+      submissionTermsAccepted: true,
+    },
+  },
+});
+
+photoPrivateIntakeHttpResponseSchema.parse({
+  submissionReference: 'CPM-S-2026-000123',
+  statusSecret: 'cpmss_private-status-secret',
+  submittedAt: '2026-07-15T07:00:00.000Z',
+});
+
+for (const executable of [
+  createPhotoUploadAuthorizationHttpHandler,
+  createPhotoPrivateIntakeHttpHandler,
+  createPhotoUploadAuthorizationHttpRuntimeFromEnvironment,
+  createPhotoPrivateIntakeHttpRuntimeFromEnvironment,
+]) {
+  if (typeof executable !== 'function') {
+    throw new Error('Photos HTTP boundary is not executable.');
+  }
+}
+
+console.log('Photos public HTTP boundary schemas passed.');

--- a/scripts/check-photo-object-validation.ts
+++ b/scripts/check-photo-object-validation.ts
@@ -6,6 +6,7 @@ import {
   photoObjectValidationRequestSchema,
 } from '../src/submissions/photo-object-validation';
 import { createR2PhotoQuarantineObjectStore } from '../src/submissions/r2-photo-quarantine-object-store';
+import './check-photo-http';
 import './check-photo-private-lifecycle';
 import './check-photo-private-processing';
 

--- a/src/submissions/photo-http-environment.ts
+++ b/src/submissions/photo-http-environment.ts
@@ -1,0 +1,147 @@
+import { z } from 'zod';
+import { createDatabase } from '../db/client';
+import { requiredDatabaseEnvironmentSchema } from '../schemas/environment';
+import { createAbuseControlledSubmissionIntakeService } from './abuse-controlled-intake';
+import { createSubmissionContactProtectorFromEnvironment } from './contact-protection-environment';
+import { createDrizzleSubmissionPersistenceBackend } from './drizzle-persistence';
+import { createDrizzlePhotoUploadReservationPersistence } from './drizzle-photo-upload-reservations';
+import {
+  createDurableObjectSubmissionRateLimiter,
+  type SubmissionRateLimitDurableObjectNamespace,
+} from './durable-object-rate-limit';
+import type {
+  PhotoPrivateIntakeHttpRuntime,
+  PhotoUploadAuthorizationHttpRuntime,
+} from './photo-http';
+import { createPhotoPrivateIntakeService } from './photo-intake-service';
+import {
+  createPhotoUploadAuthorizationService,
+  type QuarantineUploadAuthorizer,
+} from './photo-upload-authorization';
+import { createSubmissionRateLimitBucketDeriverFromEnvironment } from './rate-limit-bucket-environment';
+import { createSubmissionStatusSecretProviderFromEnvironment } from './status-secret-environment';
+import { createSubmissionTurnstileConfigurationFromEnvironment } from './turnstile-environment';
+
+const positiveIntegerStringSchema = z.string().regex(/^[1-9][0-9]*$/);
+const rateLimitPolicySchema = z
+  .object({
+    CPM_SUBMISSION_RATE_LIMIT_MAX_REQUESTS: positiveIntegerStringSchema,
+    CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: positiveIntegerStringSchema,
+  })
+  .strict()
+  .transform((value, context) => {
+    const limit = Number(value.CPM_SUBMISSION_RATE_LIMIT_MAX_REQUESTS);
+    const windowSeconds = Number(value.CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS);
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1_000) {
+      context.addIssue({ code: 'custom', message: 'Invalid request limit.' });
+      return z.NEVER;
+    }
+    if (!Number.isSafeInteger(windowSeconds) || windowSeconds < 1 || windowSeconds > 86_400) {
+      context.addIssue({ code: 'custom', message: 'Invalid rate-limit window.' });
+      return z.NEVER;
+    }
+    return { limit, windowMs: windowSeconds * 1_000 };
+  });
+
+export type PhotoHttpEnvironment = Readonly<
+  Record<string, unknown> & {
+    DATABASE_URL?: unknown;
+    SUBMISSION_RATE_LIMIT_BUCKETS?: unknown;
+    CPM_SUBMISSION_RATE_LIMIT_MAX_REQUESTS?: unknown;
+    CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS?: unknown;
+    PHOTO_UPLOAD_AUTHORIZER?: unknown;
+  }
+>;
+
+export class PhotoHttpEnvironmentConfigurationError extends Error {
+  constructor() {
+    super('Photos HTTP environment configuration is unavailable.');
+    this.name = 'PhotoHttpEnvironmentConfigurationError';
+  }
+}
+
+function isDurableObjectNamespace(
+  value: unknown,
+): value is SubmissionRateLimitDurableObjectNamespace {
+  if (value === null || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.idFromName === 'function' && typeof candidate.get === 'function';
+}
+
+function isQuarantineUploadAuthorizer(value: unknown): value is QuarantineUploadAuthorizer {
+  if (value === null || typeof value !== 'object') return false;
+  return typeof (value as Record<string, unknown>).authorizeUpload === 'function';
+}
+
+function commonRuntime(environment: PhotoHttpEnvironment) {
+  const databaseEnvironment = requiredDatabaseEnvironmentSchema.parse({
+    DATABASE_URL: environment.DATABASE_URL,
+  });
+  const rateLimitPolicy = rateLimitPolicySchema.parse({
+    CPM_SUBMISSION_RATE_LIMIT_MAX_REQUESTS: environment.CPM_SUBMISSION_RATE_LIMIT_MAX_REQUESTS,
+    CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS:
+      environment.CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS,
+  });
+  if (!isDurableObjectNamespace(environment.SUBMISSION_RATE_LIMIT_BUCKETS)) {
+    throw new PhotoHttpEnvironmentConfigurationError();
+  }
+
+  const database = createDatabase(databaseEnvironment.DATABASE_URL);
+  const turnstile = createSubmissionTurnstileConfigurationFromEnvironment(environment);
+  return {
+    database,
+    bucketDeriver: createSubmissionRateLimitBucketDeriverFromEnvironment(environment),
+    rateLimiter: createDurableObjectSubmissionRateLimiter(
+      environment.SUBMISSION_RATE_LIMIT_BUCKETS,
+      rateLimitPolicy,
+    ),
+    challengeVerifier: turnstile.verifier,
+  };
+}
+
+export function createPhotoUploadAuthorizationHttpRuntimeFromEnvironment(
+  environment: PhotoHttpEnvironment,
+): PhotoUploadAuthorizationHttpRuntime {
+  try {
+    if (!isQuarantineUploadAuthorizer(environment.PHOTO_UPLOAD_AUTHORIZER)) {
+      throw new PhotoHttpEnvironmentConfigurationError();
+    }
+    const common = commonRuntime(environment);
+    return {
+      bucketDeriver: common.bucketDeriver,
+      rateLimiter: common.rateLimiter,
+      challengeVerifier: common.challengeVerifier,
+      uploadAuthorizations: createPhotoUploadAuthorizationService({
+        persistence: createDrizzlePhotoUploadReservationPersistence(common.database),
+        authorizer: environment.PHOTO_UPLOAD_AUTHORIZER,
+      }),
+    };
+  } catch (error) {
+    if (error instanceof PhotoHttpEnvironmentConfigurationError) throw error;
+    throw new PhotoHttpEnvironmentConfigurationError();
+  }
+}
+
+export function createPhotoPrivateIntakeHttpRuntimeFromEnvironment(
+  environment: PhotoHttpEnvironment,
+): PhotoPrivateIntakeHttpRuntime {
+  try {
+    const common = commonRuntime(environment);
+    const privateIntake = createPhotoPrivateIntakeService({
+      persistence: createDrizzleSubmissionPersistenceBackend(common.database),
+      statusSecrets: createSubmissionStatusSecretProviderFromEnvironment(environment),
+      contactProtector: createSubmissionContactProtectorFromEnvironment(environment),
+    });
+    return {
+      bucketDeriver: common.bucketDeriver,
+      intake: createAbuseControlledSubmissionIntakeService({
+        rateLimiter: common.rateLimiter,
+        challengeVerifier: common.challengeVerifier,
+        intake: privateIntake,
+      }),
+    };
+  } catch (error) {
+    if (error instanceof PhotoHttpEnvironmentConfigurationError) throw error;
+    throw new PhotoHttpEnvironmentConfigurationError();
+  }
+}

--- a/src/submissions/photo-http-environment.ts
+++ b/src/submissions/photo-http-environment.ts
@@ -79,8 +79,7 @@ function commonRuntime(environment: PhotoHttpEnvironment) {
   });
   const rateLimitPolicy = rateLimitPolicySchema.parse({
     CPM_SUBMISSION_RATE_LIMIT_MAX_REQUESTS: environment.CPM_SUBMISSION_RATE_LIMIT_MAX_REQUESTS,
-    CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS:
-      environment.CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS,
+    CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS: environment.CPM_SUBMISSION_RATE_LIMIT_WINDOW_SECONDS,
   });
   if (!isDurableObjectNamespace(environment.SUBMISSION_RATE_LIMIT_BUCKETS)) {
     throw new PhotoHttpEnvironmentConfigurationError();

--- a/src/submissions/photo-http.ts
+++ b/src/submissions/photo-http.ts
@@ -178,7 +178,11 @@ function mapPhotoUploadAuthorizationError(error: unknown): Response {
 function mapPhotoPrivateIntakeError(error: unknown): Response {
   if (error instanceof SubmissionAbuseControlError) {
     if (error.code === 'rate_limited') {
-      return jsonResponse(429, { error: 'photo_rate_limited' }, boundedRetryAfter(error.retryAfterSeconds));
+      return jsonResponse(
+        429,
+        { error: 'photo_rate_limited' },
+        boundedRetryAfter(error.retryAfterSeconds),
+      );
     }
     if (error.code === 'abuse_request_invalid' || error.code === 'challenge_rejected') {
       return jsonResponse(400, { error: 'photo_request_invalid' });

--- a/src/submissions/photo-http.ts
+++ b/src/submissions/photo-http.ts
@@ -1,0 +1,342 @@
+import { z } from 'zod';
+import {
+  SubmissionAbuseControlError,
+  type AbuseControlledSubmissionIntakeService,
+} from './abuse-controlled-intake';
+import type { SubmissionChallengeVerifier } from './challenge-verification';
+import {
+  readTrustedCloudflareEdgeIdentity,
+  SubmissionEdgeIdentityError,
+} from './cloudflare-edge-identity';
+import { submissionPublicIdSchema } from './contract';
+import { SubmissionIntakeError } from './intake-service';
+import { photosSubmissionIntakeSchema } from './photo-media-contract';
+import {
+  PhotoUploadAuthorizationError,
+  photoUploadAuthorizationReceiptSchema,
+  photoUploadAuthorizationRequestSchema,
+  type PhotoUploadAuthorizationReceipt,
+} from './photo-upload-authorization';
+import type { SubmissionRateLimitBucketDeriver } from './rate-limit-bucket-environment';
+import type { SubmissionRateLimiter } from './rate-limit';
+
+export const photoHttpMaximumBodyBytes = 128 * 1024;
+
+const requestIdSchema = z.uuid();
+const challengeTokenSchema = z.string().min(1).max(2_048);
+
+export const photoUploadAuthorizationHttpRequestSchema = z
+  .object({
+    challengeToken: challengeTokenSchema,
+    authorization: photoUploadAuthorizationRequestSchema,
+  })
+  .strict();
+
+export const photoPrivateIntakeHttpRequestSchema = z
+  .object({
+    challengeToken: challengeTokenSchema,
+    submission: photosSubmissionIntakeSchema,
+  })
+  .strict();
+
+export const photoPrivateIntakeHttpResponseSchema = z
+  .object({
+    submissionReference: submissionPublicIdSchema,
+    statusSecret: z.string().min(1).max(512),
+    submittedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export interface PhotoUploadAuthorizationService {
+  authorize(rawInput: unknown, requestedAt?: Date): Promise<PhotoUploadAuthorizationReceipt>;
+}
+
+export interface PhotoUploadAuthorizationHttpRuntime {
+  bucketDeriver: SubmissionRateLimitBucketDeriver;
+  rateLimiter: SubmissionRateLimiter;
+  challengeVerifier: SubmissionChallengeVerifier;
+  uploadAuthorizations: PhotoUploadAuthorizationService;
+}
+
+export interface PhotoPrivateIntakeHttpRuntime {
+  bucketDeriver: SubmissionRateLimitBucketDeriver;
+  intake: AbuseControlledSubmissionIntakeService;
+}
+
+export interface PhotoHttpPagesContext<Environment = Record<string, unknown>> {
+  request: Request;
+  env: Environment;
+  params: Record<string, string | string[]>;
+  data: Record<string, unknown>;
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+export interface PhotoUploadAuthorizationHttpHandlerDependencies<
+  Environment = Record<string, unknown>,
+> {
+  runtimeFromEnvironment(environment: Environment): PhotoUploadAuthorizationHttpRuntime;
+  now?: () => Date;
+}
+
+export interface PhotoPrivateIntakeHttpHandlerDependencies<Environment = Record<string, unknown>> {
+  runtimeFromEnvironment(environment: Environment): PhotoPrivateIntakeHttpRuntime;
+  now?: () => Date;
+}
+
+class PhotoHttpBodyTooLargeError extends Error {
+  constructor() {
+    super('Photos request body is too large.');
+    this.name = 'PhotoHttpBodyTooLargeError';
+  }
+}
+
+function jsonResponse(status: number, body: unknown, retryAfterSeconds?: number): Response {
+  const headers = new Headers({
+    'Cache-Control': 'no-store',
+    'Content-Type': 'application/json; charset=utf-8',
+    'Referrer-Policy': 'no-referrer',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  if (retryAfterSeconds !== undefined) {
+    headers.set('Retry-After', String(retryAfterSeconds));
+  }
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+function mediaType(request: Request): string | null {
+  const contentType = request.headers.get('Content-Type');
+  if (contentType === null) return null;
+  return contentType.split(';', 1)[0]?.trim().toLowerCase() ?? null;
+}
+
+function contentLengthExceedsLimit(request: Request): boolean {
+  const raw = request.headers.get('Content-Length');
+  if (raw === null || !/^[0-9]+$/.test(raw)) return false;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value > photoHttpMaximumBodyBytes;
+}
+
+async function readBoundedBody(request: Request): Promise<Uint8Array> {
+  if (request.body === null) return new Uint8Array();
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > photoHttpMaximumBodyBytes) {
+        await reader.cancel();
+        throw new PhotoHttpBodyTooLargeError();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+async function parseJsonBody(request: Request): Promise<unknown> {
+  const bytes = await readBoundedBody(request);
+  if (bytes.byteLength === 0) throw new SyntaxError('Empty JSON request body.');
+  return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+}
+
+function boundedRetryAfter(value: number | null | undefined): number | undefined {
+  if (value === null || value === undefined || !Number.isFinite(value) || value < 1) {
+    return undefined;
+  }
+  return Math.min(86_400, Math.ceil(value));
+}
+
+function mapPhotoUploadAuthorizationError(error: unknown): Response {
+  if (error instanceof PhotoUploadAuthorizationError) {
+    if (error.code === 'invalid_request') {
+      return jsonResponse(400, { error: 'photo_request_invalid' });
+    }
+    if (error.code === 'idempotency_conflict' || error.code === 'reservation_unavailable') {
+      return jsonResponse(409, { error: 'photo_request_conflict' });
+    }
+    return jsonResponse(503, { error: 'photo_unavailable' });
+  }
+  if (error instanceof SubmissionEdgeIdentityError) {
+    return jsonResponse(503, { error: 'photo_unavailable' });
+  }
+  return jsonResponse(503, { error: 'photo_unavailable' });
+}
+
+function mapPhotoPrivateIntakeError(error: unknown): Response {
+  if (error instanceof SubmissionAbuseControlError) {
+    if (error.code === 'rate_limited') {
+      return jsonResponse(429, { error: 'photo_rate_limited' }, boundedRetryAfter(error.retryAfterSeconds));
+    }
+    if (error.code === 'abuse_request_invalid' || error.code === 'challenge_rejected') {
+      return jsonResponse(400, { error: 'photo_request_invalid' });
+    }
+    return jsonResponse(503, { error: 'photo_unavailable' });
+  }
+
+  if (error instanceof SubmissionIntakeError) {
+    if (error.code === 'invalid_request') {
+      return jsonResponse(400, { error: 'photo_request_invalid' });
+    }
+    if (error.code === 'idempotency_conflict') {
+      return jsonResponse(409, { error: 'photo_request_conflict' });
+    }
+    return jsonResponse(503, { error: 'photo_unavailable' });
+  }
+
+  if (error instanceof SubmissionEdgeIdentityError) {
+    return jsonResponse(503, { error: 'photo_unavailable' });
+  }
+  return jsonResponse(503, { error: 'photo_unavailable' });
+}
+
+function validateRequestPreamble(request: Request): Response | null {
+  if (mediaType(request) !== 'application/json') {
+    return jsonResponse(415, { error: 'photo_media_type_unsupported' });
+  }
+  if (contentLengthExceedsLimit(request)) {
+    return jsonResponse(413, { error: 'photo_request_too_large' });
+  }
+  return null;
+}
+
+export function createPhotoUploadAuthorizationHttpHandler<Environment = Record<string, unknown>>(
+  dependencies: PhotoUploadAuthorizationHttpHandlerDependencies<Environment>,
+) {
+  const now = dependencies.now ?? (() => new Date());
+
+  return async (context: PhotoHttpPagesContext<Environment>): Promise<Response> => {
+    const preambleFailure = validateRequestPreamble(context.request);
+    if (preambleFailure !== null) return preambleFailure;
+
+    const requestIdResult = requestIdSchema.safeParse(
+      context.request.headers.get('Idempotency-Key'),
+    );
+    if (!requestIdResult.success) {
+      return jsonResponse(400, { error: 'photo_request_invalid' });
+    }
+
+    let parsedBody: z.infer<typeof photoUploadAuthorizationHttpRequestSchema>;
+    try {
+      parsedBody = photoUploadAuthorizationHttpRequestSchema.parse(
+        await parseJsonBody(context.request),
+      );
+    } catch (error) {
+      if (error instanceof PhotoHttpBodyTooLargeError) {
+        return jsonResponse(413, { error: 'photo_request_too_large' });
+      }
+      return jsonResponse(400, { error: 'photo_request_invalid' });
+    }
+
+    if (parsedBody.authorization.intakeRequestId !== requestIdResult.data) {
+      return jsonResponse(400, { error: 'photo_request_invalid' });
+    }
+
+    try {
+      const requestedAt = now();
+      const edgeIdentity = readTrustedCloudflareEdgeIdentity(context.request);
+      const runtime = dependencies.runtimeFromEnvironment(context.env);
+      const rateLimitKey = await runtime.bucketDeriver.deriveBucketKey(edgeIdentity);
+      const rateLimit = await runtime.rateLimiter.consume({
+        requestId: requestIdResult.data,
+        bucketKey: rateLimitKey,
+        receivedAt: requestedAt,
+      });
+      if (rateLimit.outcome === 'deny') {
+        return jsonResponse(
+          429,
+          { error: 'photo_rate_limited' },
+          boundedRetryAfter(rateLimit.retryAfterSeconds),
+        );
+      }
+      if (rateLimit.outcome === 'unavailable') {
+        return jsonResponse(503, { error: 'photo_unavailable' });
+      }
+
+      const challenge = await runtime.challengeVerifier.verify({
+        requestId: requestIdResult.data,
+        token: parsedBody.challengeToken,
+        remoteIp: edgeIdentity,
+      });
+      if (challenge.outcome === 'deny') {
+        return jsonResponse(400, { error: 'photo_request_invalid' });
+      }
+      if (challenge.outcome === 'unavailable') {
+        return jsonResponse(503, { error: 'photo_unavailable' });
+      }
+
+      const receipt = photoUploadAuthorizationReceiptSchema.parse(
+        await runtime.uploadAuthorizations.authorize(parsedBody.authorization, requestedAt),
+      );
+      return jsonResponse(200, receipt);
+    } catch (error) {
+      return mapPhotoUploadAuthorizationError(error);
+    }
+  };
+}
+
+export function createPhotoPrivateIntakeHttpHandler<Environment = Record<string, unknown>>(
+  dependencies: PhotoPrivateIntakeHttpHandlerDependencies<Environment>,
+) {
+  const now = dependencies.now ?? (() => new Date());
+
+  return async (context: PhotoHttpPagesContext<Environment>): Promise<Response> => {
+    const preambleFailure = validateRequestPreamble(context.request);
+    if (preambleFailure !== null) return preambleFailure;
+
+    const requestIdResult = requestIdSchema.safeParse(
+      context.request.headers.get('Idempotency-Key'),
+    );
+    if (!requestIdResult.success) {
+      return jsonResponse(400, { error: 'photo_request_invalid' });
+    }
+
+    let parsedBody: z.infer<typeof photoPrivateIntakeHttpRequestSchema>;
+    try {
+      parsedBody = photoPrivateIntakeHttpRequestSchema.parse(await parseJsonBody(context.request));
+    } catch (error) {
+      if (error instanceof PhotoHttpBodyTooLargeError) {
+        return jsonResponse(413, { error: 'photo_request_too_large' });
+      }
+      return jsonResponse(400, { error: 'photo_request_invalid' });
+    }
+
+    try {
+      const receivedAt = now();
+      const edgeIdentity = readTrustedCloudflareEdgeIdentity(context.request);
+      const runtime = dependencies.runtimeFromEnvironment(context.env);
+      const rateLimitKey = await runtime.bucketDeriver.deriveBucketKey(edgeIdentity);
+      const receipt = await runtime.intake.submit({
+        requestId: requestIdResult.data,
+        challengeToken: parsedBody.challengeToken,
+        rateLimitKey,
+        remoteIp: edgeIdentity,
+        rawInput: parsedBody.submission,
+        receivedAt,
+      });
+
+      return jsonResponse(
+        202,
+        photoPrivateIntakeHttpResponseSchema.parse({
+          submissionReference: receipt.publicId,
+          statusSecret: receipt.statusSecret,
+          submittedAt: receipt.submittedAt,
+        }),
+      );
+    } catch (error) {
+      return mapPhotoPrivateIntakeError(error);
+    }
+  };
+}

--- a/tests/photo-http.test.ts
+++ b/tests/photo-http.test.ts
@@ -46,10 +46,7 @@ function validPhotoSubmission() {
     targetType: 'location',
     targetId,
     relationship: 'customer',
-    contact: {
-      email: 'submitter@example.com',
-      contactAllowed: true,
-    },
+    contact: { email: 'submitter@example.com', contactAllowed: true },
     evidenceLinks: [],
     originalPayload: {
       schemaVersion: 'photo-media-v1',
@@ -83,14 +80,8 @@ function validPhotoSubmission() {
   };
 }
 
-function authorizationRequest(
-  body: unknown = {
-    challengeToken: 'turnstile-token',
-    authorization: validAuthorization(),
-  },
-  idempotencyKey = requestId,
-) {
-  return new Request('https://example.test/api/photos/upload-authorizations', {
+function jsonRequest(url: string, body: unknown, idempotencyKey = requestId): Request {
+  return new Request(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
@@ -99,6 +90,20 @@ function authorizationRequest(
     },
     body: JSON.stringify(body),
   });
+}
+
+function authorizationRequest(
+  idempotencyKey = requestId,
+  body: unknown = {
+    challengeToken: 'turnstile-token',
+    authorization: validAuthorization(),
+  },
+): Request {
+  return jsonRequest(
+    'https://example.test/api/photos/upload-authorizations',
+    body,
+    idempotencyKey,
+  );
 }
 
 function intakeRequest(
@@ -106,22 +111,13 @@ function intakeRequest(
     challengeToken: 'turnstile-token',
     submission: validPhotoSubmission(),
   },
-  idempotencyKey = requestId,
-) {
-  return new Request('https://example.test/api/photos', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Idempotency-Key': idempotencyKey,
-      'CF-Connecting-IP': '203.0.113.10',
-    },
-    body: JSON.stringify(body),
-  });
+): Request {
+  return jsonRequest('https://example.test/api/photos', body);
 }
 
-function pagesContext(inputRequest: Request): PhotoHttpPagesContext<Record<string, unknown>> {
+function pagesContext(request: Request): PhotoHttpPagesContext<Record<string, unknown>> {
   return {
-    request: inputRequest,
+    request,
     env: {},
     params: {},
     data: {},
@@ -148,7 +144,7 @@ const authorizationReceipt: PhotoUploadAuthorizationReceipt = {
   ],
 };
 
-function uploadRuntimeFixture(options?: {
+function uploadFixture(options?: {
   rateLimitOutcome?: 'allow' | 'deny' | 'unavailable';
   challengeOutcome?: 'allow' | 'deny' | 'unavailable';
   authorizationError?: Error;
@@ -177,7 +173,7 @@ function uploadRuntimeFixture(options?: {
   });
   const authorize = vi.fn(async () => {
     order.push('authorize');
-    if (options?.authorizationError) throw options.authorizationError;
+    if (options?.authorizationError !== undefined) throw options.authorizationError;
     return structuredClone(authorizationReceipt);
   });
   const runtime: PhotoUploadAuthorizationHttpRuntime = {
@@ -186,23 +182,18 @@ function uploadRuntimeFixture(options?: {
     challengeVerifier: { verify },
     uploadAuthorizations: { authorize },
   };
-  return { runtime, order, deriveBucketKey, consume, verify, authorize };
-}
-
-function uploadHandlerFor(options?: Parameters<typeof uploadRuntimeFixture>[0]) {
-  const fixture = uploadRuntimeFixture(options);
-  const runtimeFromEnvironment = vi.fn(() => fixture.runtime);
+  const runtimeFromEnvironment = vi.fn(() => runtime);
   const handler = createPhotoUploadAuthorizationHttpHandler({
     runtimeFromEnvironment,
     now: () => now,
   });
-  return { handler, runtimeFromEnvironment, ...fixture };
+  return { handler, runtimeFromEnvironment, order, deriveBucketKey, consume, verify, authorize };
 }
 
-function intakeRuntimeFixture(submitError?: Error) {
+function intakeFixture(submitError?: Error) {
   const deriveBucketKey = vi.fn(async () => opaqueBucket);
   const submit = vi.fn(async () => {
-    if (submitError) throw submitError;
+    if (submitError !== undefined) throw submitError;
     return {
       state: 'committed' as const,
       publicId: 'CPM-S-2026-000123',
@@ -214,22 +205,17 @@ function intakeRuntimeFixture(submitError?: Error) {
     bucketDeriver: { deriveBucketKey },
     intake: { submit } satisfies AbuseControlledSubmissionIntakeService,
   };
-  return { runtime, deriveBucketKey, submit };
-}
-
-function intakeHandlerFor(submitError?: Error) {
-  const fixture = intakeRuntimeFixture(submitError);
-  const runtimeFromEnvironment = vi.fn(() => fixture.runtime);
+  const runtimeFromEnvironment = vi.fn(() => runtime);
   const handler = createPhotoPrivateIntakeHttpHandler({
     runtimeFromEnvironment,
     now: () => now,
   });
-  return { handler, runtimeFromEnvironment, ...fixture };
+  return { handler, runtimeFromEnvironment, deriveBucketKey, submit };
 }
 
 describe('P5-05G public Photos HTTP boundaries', () => {
-  it('authorizes private uploads only after edge, rate-limit, and challenge checks', async () => {
-    const fixture = uploadHandlerFor();
+  it('authorizes a private upload only after edge, rate-limit, and challenge checks', async () => {
+    const fixture = uploadFixture();
     const response = await fixture.handler(pagesContext(authorizationRequest()));
 
     expect(response.status).toBe(200);
@@ -253,12 +239,10 @@ describe('P5-05G public Photos HTTP boundaries', () => {
     expect(fixture.authorize).toHaveBeenCalledWith(validAuthorization(), now);
   });
 
-  it('requires the idempotency header to match the authorization intake identity', async () => {
-    const fixture = uploadHandlerFor();
+  it('requires the header identity to match the authorization intake identity', async () => {
+    const fixture = uploadFixture();
     const response = await fixture.handler(
-      pagesContext(
-        authorizationRequest(undefined, '10000000-0000-4000-8000-000000000002'),
-      ),
+      pagesContext(authorizationRequest('10000000-0000-4000-8000-000000000002')),
     );
 
     expect(response.status).toBe(400);
@@ -266,34 +250,34 @@ describe('P5-05G public Photos HTTP boundaries', () => {
     expect(fixture.runtimeFromEnvironment).not.toHaveBeenCalled();
   });
 
-  it('maps upload rate-limit, challenge, and reservation conflicts to bounded errors', async () => {
-    const limited = uploadHandlerFor({ rateLimitOutcome: 'deny' });
+  it('maps upload abuse and reservation failures to bounded public errors', async () => {
+    const limited = uploadFixture({ rateLimitOutcome: 'deny' });
     const limitedResponse = await limited.handler(pagesContext(authorizationRequest()));
     expect(limitedResponse.status).toBe(429);
     expect(limitedResponse.headers.get('Retry-After')).toBe('17');
     expect(limited.verify).not.toHaveBeenCalled();
     expect(limited.authorize).not.toHaveBeenCalled();
 
-    const challenged = uploadHandlerFor({ challengeOutcome: 'deny' });
+    const challenged = uploadFixture({ challengeOutcome: 'deny' });
     const challengeResponse = await challenged.handler(pagesContext(authorizationRequest()));
     expect(challengeResponse.status).toBe(400);
     expect(challenged.authorize).not.toHaveBeenCalled();
 
-    const conflicted = uploadHandlerFor({
+    const conflicted = uploadFixture({
       authorizationError: new PhotoUploadAuthorizationError(
         'idempotency_conflict',
         'private reservation detail',
       ),
     });
     const conflictResponse = await conflicted.handler(pagesContext(authorizationRequest()));
-    expect(conflictResponse.status).toBe(409);
     const conflictText = await conflictResponse.text();
+    expect(conflictResponse.status).toBe(409);
     expect(JSON.parse(conflictText)).toEqual({ error: 'photo_request_conflict' });
     expect(conflictText).not.toContain('private reservation detail');
   });
 
-  it('creates only a private Submission receipt through the intake route', async () => {
-    const fixture = intakeHandlerFor();
+  it('returns only the private Submission receipt from intake', async () => {
+    const fixture = intakeFixture();
     const response = await fixture.handler(pagesContext(intakeRequest()));
 
     expect(response.status).toBe(202);
@@ -318,25 +302,25 @@ describe('P5-05G public Photos HTTP boundaries', () => {
     });
   });
 
-  it('maps private intake rate-limit and idempotency errors without internal detail', async () => {
-    const limited = await intakeHandlerFor(
+  it('maps intake rate-limit and idempotency failures without private detail', async () => {
+    const limited = await intakeFixture(
       new SubmissionAbuseControlError('rate_limited', 'private rate detail', 11),
     ).handler(pagesContext(intakeRequest()));
     expect(limited.status).toBe(429);
     expect(limited.headers.get('Retry-After')).toBe('11');
     await expect(limited.json()).resolves.toEqual({ error: 'photo_rate_limited' });
 
-    const conflict = await intakeHandlerFor(
+    const conflict = await intakeFixture(
       new SubmissionIntakeError('idempotency_conflict', 'private submission detail'),
     ).handler(pagesContext(intakeRequest()));
+    const conflictText = await conflict.text();
     expect(conflict.status).toBe(409);
-    const text = await conflict.text();
-    expect(JSON.parse(text)).toEqual({ error: 'photo_request_conflict' });
-    expect(text).not.toContain('private submission detail');
+    expect(JSON.parse(conflictText)).toEqual({ error: 'photo_request_conflict' });
+    expect(conflictText).not.toContain('private submission detail');
   });
 
   it('rejects unsupported media, oversized bodies, and undeclared storage fields early', async () => {
-    const unsupportedFixture = intakeHandlerFor();
+    const unsupportedFixture = intakeFixture();
     const unsupported = intakeRequest();
     const unsupportedHeaders = new Headers(unsupported.headers);
     unsupportedHeaders.set('Content-Type', 'text/plain');
@@ -352,7 +336,7 @@ describe('P5-05G public Photos HTTP boundaries', () => {
     expect(unsupportedResponse.status).toBe(415);
     expect(unsupportedFixture.runtimeFromEnvironment).not.toHaveBeenCalled();
 
-    const oversizedFixture = uploadHandlerFor();
+    const oversizedFixture = uploadFixture();
     const oversizedResponse = await oversizedFixture.handler(
       pagesContext(
         new Request('https://example.test/api/photos/upload-authorizations', {
@@ -369,10 +353,10 @@ describe('P5-05G public Photos HTTP boundaries', () => {
     expect(oversizedResponse.status).toBe(413);
     expect(oversizedFixture.runtimeFromEnvironment).not.toHaveBeenCalled();
 
-    const leakedFixture = uploadHandlerFor();
+    const leakedFixture = uploadFixture();
     const leakedResponse = await leakedFixture.handler(
       pagesContext(
-        authorizationRequest({
+        authorizationRequest(requestId, {
           challengeToken: 'turnstile-token',
           authorization: {
             ...validAuthorization(),
@@ -385,8 +369,8 @@ describe('P5-05G public Photos HTTP boundaries', () => {
     expect(leakedFixture.runtimeFromEnvironment).not.toHaveBeenCalled();
   });
 
-  it('fails closed when trusted Cloudflare edge identity is missing', async () => {
-    const fixture = intakeHandlerFor();
+  it('fails closed without trusted Cloudflare edge identity', async () => {
+    const fixture = intakeFixture();
     const input = intakeRequest();
     const headers = new Headers(input.headers);
     headers.delete('CF-Connecting-IP');

--- a/tests/photo-http.test.ts
+++ b/tests/photo-http.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SubmissionAbuseControlError,
+  type AbuseControlledSubmissionIntakeService,
+} from '../src/submissions/abuse-controlled-intake';
+import { SubmissionIntakeError } from '../src/submissions/intake-service';
+import {
+  createPhotoPrivateIntakeHttpHandler,
+  createPhotoUploadAuthorizationHttpHandler,
+  photoHttpMaximumBodyBytes,
+  type PhotoHttpPagesContext,
+  type PhotoPrivateIntakeHttpRuntime,
+  type PhotoUploadAuthorizationHttpRuntime,
+} from '../src/submissions/photo-http';
+import {
+  PhotoUploadAuthorizationError,
+  type PhotoUploadAuthorizationReceipt,
+} from '../src/submissions/photo-upload-authorization';
+
+const requestId = '10000000-0000-4000-8000-000000000001';
+const targetId = '20000000-0000-4000-8000-000000000001';
+const quarantineUploadId = '30000000-0000-4000-8000-000000000001';
+const opaqueBucket = `rl_${'A'.repeat(43)}`;
+const now = new Date('2026-07-15T07:00:00.000Z');
+
+function validAuthorization() {
+  return {
+    schemaVersion: 'photo-upload-authorization-v1',
+    intakeRequestId: requestId,
+    targetType: 'location',
+    targetId,
+    media: [
+      {
+        purpose: 'public_gallery_candidate',
+        declaredMimeType: 'image/jpeg',
+        declaredByteSize: 1_234,
+      },
+    ],
+  };
+}
+
+function validPhotoSubmission() {
+  return {
+    schemaVersion: 'submission-common-v1',
+    submissionType: 'photos',
+    targetType: 'location',
+    targetId,
+    relationship: 'customer',
+    contact: {
+      email: 'submitter@example.com',
+      contactAllowed: true,
+    },
+    evidenceLinks: [],
+    originalPayload: {
+      schemaVersion: 'photo-media-v1',
+      media: [
+        {
+          quarantineUploadId,
+          purpose: 'public_gallery_candidate',
+          role: 'exterior',
+          declaredMimeType: 'image/jpeg',
+          declaredByteSize: 1_234,
+          capturedAt: null,
+          description: 'Storefront exterior.',
+          suggestedAltText: null,
+          photographerPresent: true,
+          rights: {
+            rightsStatus: 'submitted_with_permission',
+            rightsHolderPresent: true,
+            permissionReferencePresent: false,
+            licenseName: null,
+            licenseUrl: null,
+            publicDisplayPermission: true,
+          },
+        },
+      ],
+      submitterNote: null,
+    },
+    acknowledgements: {
+      privacyNoticeAccepted: true,
+      submissionTermsAccepted: true,
+    },
+  };
+}
+
+function authorizationRequest(
+  body: unknown = {
+    challengeToken: 'turnstile-token',
+    authorization: validAuthorization(),
+  },
+  idempotencyKey = requestId,
+) {
+  return new Request('https://example.test/api/photos/upload-authorizations', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Idempotency-Key': idempotencyKey,
+      'CF-Connecting-IP': '203.0.113.10',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function intakeRequest(
+  body: unknown = {
+    challengeToken: 'turnstile-token',
+    submission: validPhotoSubmission(),
+  },
+  idempotencyKey = requestId,
+) {
+  return new Request('https://example.test/api/photos', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Idempotency-Key': idempotencyKey,
+      'CF-Connecting-IP': '203.0.113.10',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function pagesContext(inputRequest: Request): PhotoHttpPagesContext<Record<string, unknown>> {
+  return {
+    request: inputRequest,
+    env: {},
+    params: {},
+    data: {},
+    waitUntil() {},
+  };
+}
+
+const authorizationReceipt: PhotoUploadAuthorizationReceipt = {
+  schemaVersion: 'photo-upload-authorization-receipt-v1',
+  state: 'committed',
+  intakeRequestId: requestId,
+  expiresAt: '2026-07-15T07:10:00.000Z',
+  uploads: [
+    {
+      quarantineUploadId,
+      method: 'PUT',
+      uploadUrl: 'https://uploads.example.test/private-signed-upload',
+      requiredHeaders: {
+        'content-type': 'image/jpeg',
+        'x-amz-meta-cpm-reservation-id': quarantineUploadId,
+      },
+      declaredByteSize: 1_234,
+    },
+  ],
+};
+
+function uploadRuntimeFixture(options?: {
+  rateLimitOutcome?: 'allow' | 'deny' | 'unavailable';
+  challengeOutcome?: 'allow' | 'deny' | 'unavailable';
+  authorizationError?: Error;
+}) {
+  const order: string[] = [];
+  const deriveBucketKey = vi.fn(async () => opaqueBucket);
+  const consume = vi.fn(async () => {
+    order.push('rate-limit');
+    if (options?.rateLimitOutcome === 'deny') {
+      return { outcome: 'deny' as const, retryAfterSeconds: 17 };
+    }
+    if (options?.rateLimitOutcome === 'unavailable') {
+      return { outcome: 'unavailable' as const, reasonCode: 'synthetic' };
+    }
+    return { outcome: 'allow' as const, remaining: 4 };
+  });
+  const verify = vi.fn(async () => {
+    order.push('challenge');
+    if (options?.challengeOutcome === 'deny') {
+      return { outcome: 'deny' as const, reasonCode: 'synthetic' };
+    }
+    if (options?.challengeOutcome === 'unavailable') {
+      return { outcome: 'unavailable' as const, reasonCode: 'synthetic' };
+    }
+    return { outcome: 'allow' as const, reasonCode: 'ok' };
+  });
+  const authorize = vi.fn(async () => {
+    order.push('authorize');
+    if (options?.authorizationError) throw options.authorizationError;
+    return structuredClone(authorizationReceipt);
+  });
+  const runtime: PhotoUploadAuthorizationHttpRuntime = {
+    bucketDeriver: { deriveBucketKey },
+    rateLimiter: { consume },
+    challengeVerifier: { verify },
+    uploadAuthorizations: { authorize },
+  };
+  return { runtime, order, deriveBucketKey, consume, verify, authorize };
+}
+
+function uploadHandlerFor(options?: Parameters<typeof uploadRuntimeFixture>[0]) {
+  const fixture = uploadRuntimeFixture(options);
+  const runtimeFromEnvironment = vi.fn(() => fixture.runtime);
+  const handler = createPhotoUploadAuthorizationHttpHandler({
+    runtimeFromEnvironment,
+    now: () => now,
+  });
+  return { handler, runtimeFromEnvironment, ...fixture };
+}
+
+function intakeRuntimeFixture(submitError?: Error) {
+  const deriveBucketKey = vi.fn(async () => opaqueBucket);
+  const submit = vi.fn(async () => {
+    if (submitError) throw submitError;
+    return {
+      state: 'committed' as const,
+      publicId: 'CPM-S-2026-000123',
+      statusSecret: 'cpmss_private-status-secret',
+      submittedAt: now.toISOString(),
+    };
+  });
+  const runtime: PhotoPrivateIntakeHttpRuntime = {
+    bucketDeriver: { deriveBucketKey },
+    intake: { submit } satisfies AbuseControlledSubmissionIntakeService,
+  };
+  return { runtime, deriveBucketKey, submit };
+}
+
+function intakeHandlerFor(submitError?: Error) {
+  const fixture = intakeRuntimeFixture(submitError);
+  const runtimeFromEnvironment = vi.fn(() => fixture.runtime);
+  const handler = createPhotoPrivateIntakeHttpHandler({
+    runtimeFromEnvironment,
+    now: () => now,
+  });
+  return { handler, runtimeFromEnvironment, ...fixture };
+}
+
+describe('P5-05G public Photos HTTP boundaries', () => {
+  it('authorizes private uploads only after edge, rate-limit, and challenge checks', async () => {
+    const fixture = uploadHandlerFor();
+    const response = await fixture.handler(pagesContext(authorizationRequest()));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
+    const responseText = await response.text();
+    expect(JSON.parse(responseText)).toEqual(authorizationReceipt);
+    expect(responseText).not.toContain('203.0.113.10');
+    expect(fixture.order).toEqual(['rate-limit', 'challenge', 'authorize']);
+    expect(fixture.deriveBucketKey).toHaveBeenCalledWith('203.0.113.10');
+    expect(fixture.consume).toHaveBeenCalledWith({
+      requestId,
+      bucketKey: opaqueBucket,
+      receivedAt: now,
+    });
+    expect(fixture.verify).toHaveBeenCalledWith({
+      requestId,
+      token: 'turnstile-token',
+      remoteIp: '203.0.113.10',
+    });
+    expect(fixture.authorize).toHaveBeenCalledWith(validAuthorization(), now);
+  });
+
+  it('requires the idempotency header to match the authorization intake identity', async () => {
+    const fixture = uploadHandlerFor();
+    const response = await fixture.handler(
+      pagesContext(
+        authorizationRequest(undefined, '10000000-0000-4000-8000-000000000002'),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'photo_request_invalid' });
+    expect(fixture.runtimeFromEnvironment).not.toHaveBeenCalled();
+  });
+
+  it('maps upload rate-limit, challenge, and reservation conflicts to bounded errors', async () => {
+    const limited = uploadHandlerFor({ rateLimitOutcome: 'deny' });
+    const limitedResponse = await limited.handler(pagesContext(authorizationRequest()));
+    expect(limitedResponse.status).toBe(429);
+    expect(limitedResponse.headers.get('Retry-After')).toBe('17');
+    expect(limited.verify).not.toHaveBeenCalled();
+    expect(limited.authorize).not.toHaveBeenCalled();
+
+    const challenged = uploadHandlerFor({ challengeOutcome: 'deny' });
+    const challengeResponse = await challenged.handler(pagesContext(authorizationRequest()));
+    expect(challengeResponse.status).toBe(400);
+    expect(challenged.authorize).not.toHaveBeenCalled();
+
+    const conflicted = uploadHandlerFor({
+      authorizationError: new PhotoUploadAuthorizationError(
+        'idempotency_conflict',
+        'private reservation detail',
+      ),
+    });
+    const conflictResponse = await conflicted.handler(pagesContext(authorizationRequest()));
+    expect(conflictResponse.status).toBe(409);
+    const conflictText = await conflictResponse.text();
+    expect(JSON.parse(conflictText)).toEqual({ error: 'photo_request_conflict' });
+    expect(conflictText).not.toContain('private reservation detail');
+  });
+
+  it('creates only a private Submission receipt through the intake route', async () => {
+    const fixture = intakeHandlerFor();
+    const response = await fixture.handler(pagesContext(intakeRequest()));
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    const responseText = await response.text();
+    expect(JSON.parse(responseText)).toEqual({
+      submissionReference: 'CPM-S-2026-000123',
+      statusSecret: 'cpmss_private-status-secret',
+      submittedAt: now.toISOString(),
+    });
+    expect(responseText).not.toContain('submitter@example.com');
+    expect(responseText).not.toContain(quarantineUploadId);
+    expect(responseText).not.toContain('203.0.113.10');
+    expect(fixture.deriveBucketKey).toHaveBeenCalledWith('203.0.113.10');
+    expect(fixture.submit).toHaveBeenCalledWith({
+      requestId,
+      challengeToken: 'turnstile-token',
+      rateLimitKey: opaqueBucket,
+      remoteIp: '203.0.113.10',
+      rawInput: validPhotoSubmission(),
+      receivedAt: now,
+    });
+  });
+
+  it('maps private intake rate-limit and idempotency errors without internal detail', async () => {
+    const limited = await intakeHandlerFor(
+      new SubmissionAbuseControlError('rate_limited', 'private rate detail', 11),
+    ).handler(pagesContext(intakeRequest()));
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get('Retry-After')).toBe('11');
+    await expect(limited.json()).resolves.toEqual({ error: 'photo_rate_limited' });
+
+    const conflict = await intakeHandlerFor(
+      new SubmissionIntakeError('idempotency_conflict', 'private submission detail'),
+    ).handler(pagesContext(intakeRequest()));
+    expect(conflict.status).toBe(409);
+    const text = await conflict.text();
+    expect(JSON.parse(text)).toEqual({ error: 'photo_request_conflict' });
+    expect(text).not.toContain('private submission detail');
+  });
+
+  it('rejects unsupported media, oversized bodies, and undeclared storage fields early', async () => {
+    const unsupportedFixture = intakeHandlerFor();
+    const unsupported = intakeRequest();
+    const unsupportedHeaders = new Headers(unsupported.headers);
+    unsupportedHeaders.set('Content-Type', 'text/plain');
+    const unsupportedResponse = await unsupportedFixture.handler(
+      pagesContext(
+        new Request(unsupported.url, {
+          method: 'POST',
+          headers: unsupportedHeaders,
+          body: 'not json',
+        }),
+      ),
+    );
+    expect(unsupportedResponse.status).toBe(415);
+    expect(unsupportedFixture.runtimeFromEnvironment).not.toHaveBeenCalled();
+
+    const oversizedFixture = uploadHandlerFor();
+    const oversizedResponse = await oversizedFixture.handler(
+      pagesContext(
+        new Request('https://example.test/api/photos/upload-authorizations', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Idempotency-Key': requestId,
+            'CF-Connecting-IP': '203.0.113.10',
+          },
+          body: 'x'.repeat(photoHttpMaximumBodyBytes + 1),
+        }),
+      ),
+    );
+    expect(oversizedResponse.status).toBe(413);
+    expect(oversizedFixture.runtimeFromEnvironment).not.toHaveBeenCalled();
+
+    const leakedFixture = uploadHandlerFor();
+    const leakedResponse = await leakedFixture.handler(
+      pagesContext(
+        authorizationRequest({
+          challengeToken: 'turnstile-token',
+          authorization: {
+            ...validAuthorization(),
+            storageKey: 'quarantine/photos/private-secret',
+          },
+        }),
+      ),
+    );
+    expect(leakedResponse.status).toBe(400);
+    expect(leakedFixture.runtimeFromEnvironment).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when trusted Cloudflare edge identity is missing', async () => {
+    const fixture = intakeHandlerFor();
+    const input = intakeRequest();
+    const headers = new Headers(input.headers);
+    headers.delete('CF-Connecting-IP');
+    const response = await fixture.handler(
+      pagesContext(
+        new Request(input.url, {
+          method: 'POST',
+          headers,
+          body: await input.text(),
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: 'photo_unavailable' });
+    expect(fixture.submit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/photo-http.test.ts
+++ b/tests/photo-http.test.ts
@@ -99,11 +99,7 @@ function authorizationRequest(
     authorization: validAuthorization(),
   },
 ): Request {
-  return jsonRequest(
-    'https://example.test/api/photos/upload-authorizations',
-    body,
-    idempotencyKey,
-  );
+  return jsonRequest('https://example.test/api/photos/upload-authorizations', body, idempotencyKey);
 }
 
 function intakeRequest(


### PR DESCRIPTION
## Implementation item

P5-05G — Public Photos upload authorization and private intake HTTP boundaries

## Purpose

Expose the completed private Photos authorization and intake services through bounded public JSON routes while keeping browser form wiring, configured production object storage, image processing, Media approval, canonical mutation, export, and publication outside this PR.

## Included

- `POST /api/photos/upload-authorizations`
- `POST /api/photos`
- strict `application/json` handling
- streamed 128 KiB request limit
- UUID `Idempotency-Key` validation
- exact `Idempotency-Key` and authorization `intakeRequestId` matching
- trusted Cloudflare edge identity
- opaque distributed rate-limit bucket derivation
- rate limiting before Turnstile verification
- strict request schemas that reject undeclared storage fields
- separate upload-authorization and private-intake runtime composition
- existing protected contact and deterministic status-secret boundaries
- bounded `no-store`, `no-referrer`, and `nosniff` JSON responses
- privacy-safe error mapping
- executable schema-chain integration
- focused ordering, conflict, leakage, body-limit, media-type, and fail-closed tests

## Upload-authorization boundary

The route applies edge identity, bucket derivation, distributed rate limiting, and Turnstile before issuing or replaying P5-05C reservations. The transient direct-upload URL and required headers are returned only to the requesting client and are not persisted by this HTTP layer.

The upload authorizer remains an injected environment dependency. This PR does not claim a configured production signer or object-storage binding.

## Private-intake boundary

The route reuses P5-05B private Photos intake, including protected optional contact handling, deterministic status-secret replay, exact reservation ownership and consumption checks, private original and normalized payload persistence, and atomic rollback on conflict.

Its successful response contains only the public Submission reference, request-bound status secret, and submitted timestamp. It does not create Media Assets, process image bytes, approve Media, publish objects, or mutate canonical records.

## Public errors

The HTTP layer exposes only bounded codes:

- `photo_media_type_unsupported`
- `photo_request_too_large`
- `photo_request_invalid`
- `photo_rate_limited`
- `photo_request_conflict`
- `photo_unavailable`

Internal storage, reservation, contact, edge, persistence, and secret details are not returned.

## Explicit exclusions

No browser `/photos` form, binary upload proxy, configured production object binding, object validation, configured image processing, asynchronous queue, Media decision, public object copy, canonical mutation, export, publication, deployment, or launch claim.

## Migration

None.

## Validation

Implementation head `285aa11e0fb4381c90719f11ec55366e04fe7a9a` passed all four required workflows and the complete Foundation chain with 225 test files and 1,112 tests.

Final documentation head `70a5525ebcc5a763b6ca72fcd6e1ffd679b47614` passed:

- Foundation validation
- Migration drift
- Staging review validation
- Capture representative review screenshots

Foundation included successful format, lint, Astro and TypeScript, executable schemas, migration history, all tests, build, accessibility, Phase 1, and staging artifact checks.

## Changed files

Only the two public Function entries, shared Photos HTTP/runtime contracts, focused tests/checks, and P5-05G tracking documentation are included.

## Next bounded item

P5-05H — browser `/photos` form and direct-upload orchestration. Configured automatic processing, Media approval, and publication remain later work.