### PR TITLE
P5-06B2A: connect report review-entry controls

### DIFF
--- a/docs/P5_06B2A_REPORT_REVIEW_ENTRY_UI.md
+++ b/docs/P5_06B2A_REPORT_REVIEW_ENTRY_UI.md
@@ -1,0 +1,43 @@
+# P5-06B2A report review-entry UI
+
+**Status:** In progress
+
+## Purpose
+
+Connect the P5-06B1 protected review-entry API to the existing payment and problem report reviewer workspace.
+
+## Result
+
+The report detail page now loads the current private Submission state before showing any mutation control.
+
+Supported controls:
+
+```text
+received -> triage
+triage -> in_review
+```
+
+Each request includes:
+
+- one UUID request identity;
+- the exact report Submission type;
+- the expected current workflow status;
+- the exact current `updatedAt` value.
+
+The client parses both the protected report detail response and the review-entry receipt. A failed retry reuses the same request identity, while a stale-state conflict directs the reviewer to reload current state.
+
+## Explicit non-effects
+
+This UI does not:
+
+- make a positive or negative Evidence decision;
+- create a recheck;
+- change Claim status or visibility;
+- apply a correction;
+- mutate canonical records;
+- export or publish;
+- expose private contact, restricted evidence, reviewer identity, or backend details.
+
+## Follow-up
+
+P5-06B2B adds the Photos parent Submission queue/detail workspace and reuses the same review-entry boundary. P5-06C adds information, hold, and resume transitions.

--- a/scripts/check-report-submission-reviewer-artifact.mjs
+++ b/scripts/check-report-submission-reviewer-artifact.mjs
@@ -10,7 +10,7 @@ const requiredPages = [
     markers: [
       'Payment and problem report',
       'P5-06B review-entry boundary',
-      'P5-06B protected review entry',
+      'Protected report review-entry controls',
       'Protected report detail',
     ],
   },

--- a/scripts/check-report-submission-reviewer-artifact.mjs
+++ b/scripts/check-report-submission-reviewer-artifact.mjs
@@ -7,18 +7,23 @@ const requiredPages = [
   },
   {
     path: 'dist/admin/submissions/report-detail/index.html',
-    markers: ['Payment and problem report', 'P5-03D read-only boundary', 'Protected report detail'],
+    markers: [
+      'Payment and problem report',
+      'P5-06B review-entry boundary',
+      'P5-06B protected review entry',
+      'Protected report detail',
+    ],
   },
 ];
 
 for (const page of requiredPages) {
   if (!existsSync(page.path)) {
-    throw new Error(`Missing P5-03D built page: ${page.path}`);
+    throw new Error(`Missing P5-06B2A built page: ${page.path}`);
   }
   const html = readFileSync(page.path, 'utf8');
   for (const marker of page.markers) {
     if (!html.includes(marker)) {
-      throw new Error(`Missing P5-03D marker ${JSON.stringify(marker)} in ${page.path}`);
+      throw new Error(`Missing P5-06B2A marker ${JSON.stringify(marker)} in ${page.path}`);
     }
   }
   for (const forbidden of ['statusTokenHash', 'encryptedEmail', 'requestFingerprint']) {
@@ -28,4 +33,4 @@ for (const page of requiredPages) {
   }
 }
 
-console.log('P5-03D report reviewer artifacts are present and bounded.');
+console.log('P5-06B2A report reviewer artifacts are present and bounded.');

--- a/src/components/admin/ReportReviewEntryControls.tsx
+++ b/src/components/admin/ReportReviewEntryControls.tsx
@@ -39,7 +39,10 @@ function StatusPanel({
   action?: ReactNode;
 }) {
   return (
-    <section className="rounded-card border border-border bg-surface p-5 shadow-sm" aria-live="polite">
+    <section
+      className="rounded-card border border-border bg-surface p-5 shadow-sm"
+      aria-live="polite"
+    >
       <div className="flex items-start gap-4">
         <span
           className="flex size-11 shrink-0 items-center justify-center rounded-control bg-canvas text-muted"
@@ -76,7 +79,8 @@ function nextAction(detail: ReportSubmissionReviewDetailResponse): {
       action: 'begin_review',
       expectedStatus: 'triage',
       label: 'Begin review',
-      description: 'Move this triaged report into protected review so typed decisions become reachable.',
+      description:
+        'Move this triaged report into protected review so typed decisions become reachable.',
     };
   }
   return null;
@@ -117,7 +121,9 @@ export function ReportReviewEntryControls({ submissionId }: { submissionId: stri
         return;
       }
       const result = reportSubmissionReviewDetailResponseSchema.safeParse(await response.json());
-      setDetailState(result.success ? { status: 'ready', detail: result.data } : { status: 'error' });
+      setDetailState(
+        result.success ? { status: 'ready', detail: result.data } : { status: 'error' },
+      );
     } catch {
       setDetailState({ status: 'error' });
     }
@@ -171,7 +177,8 @@ export function ReportReviewEntryControls({ submissionId }: { submissionId: stri
           setMutationState({
             status: 'failed',
             request,
-            message: 'The Submission changed before this transition was applied. Reload the current state.',
+            message:
+              'The Submission changed before this transition was applied. Reload the current state.',
           });
           return;
         }
@@ -249,7 +256,10 @@ export function ReportReviewEntryControls({ submissionId }: { submissionId: stri
 
   const transition = nextAction(detailState.detail);
   return (
-    <section className="rounded-card border border-brand-600 bg-brand-50 p-5 shadow-sm" aria-live="polite">
+    <section
+      className="rounded-card border border-brand-600 bg-brand-50 p-5 shadow-sm"
+      aria-live="polite"
+    >
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <p className="m-0 text-xs font-semibold uppercase tracking-[0.08em] text-brand-800">
@@ -259,7 +269,8 @@ export function ReportReviewEntryControls({ submissionId }: { submissionId: stri
             Current state: {detailState.detail.submission.workflowStatus.replaceAll('_', ' ')}
           </h2>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
-            These controls only move the private Submission into the normal review workflow. They do not accept Evidence, decide the report, change canonical data, export, or publish.
+            These controls only move the private Submission into the normal review workflow. They do
+            not accept Evidence, decide the report, change canonical data, export, or publish.
           </p>
         </div>
         <span className="rounded-pill border border-brand-200 bg-white px-3 py-1 text-xs font-semibold text-brand-800">
@@ -281,7 +292,10 @@ export function ReportReviewEntryControls({ submissionId }: { submissionId: stri
         <div className="mt-4 rounded-control border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
           <p className="m-0">{mutationState.message}</p>
           <div className="mt-3 flex flex-wrap gap-3">
-            <Button variant="secondary" onClick={() => void submitTransition(mutationState.request)}>
+            <Button
+              variant="secondary"
+              onClick={() => void submitTransition(mutationState.request)}
+            >
               Retry same request
             </Button>
             <Button variant="ghost" onClick={() => void loadDetail()}>

--- a/src/components/admin/ReportReviewEntryControls.tsx
+++ b/src/components/admin/ReportReviewEntryControls.tsx
@@ -1,0 +1,316 @@
+import { AlertTriangle, CheckCircle2, PlayCircle, RefreshCw, ShieldAlert } from 'lucide-react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import {
+  reportSubmissionReviewDetailResponseSchema,
+  type ReportSubmissionReviewDetailResponse,
+} from '../../admin/submissions/report-detail';
+import {
+  reviewEntryReceiptSchema,
+  reviewEntryRequestSchema,
+  type ReviewEntryReceipt,
+  type ReviewEntryRequest,
+} from '../../admin/submissions/review-entry';
+import { Button } from '../ui/Button';
+
+type DetailState =
+  | { status: 'loading' }
+  | { status: 'ready'; detail: ReportSubmissionReviewDetailResponse }
+  | { status: 'missing_id' }
+  | { status: 'denied' }
+  | { status: 'not_found' }
+  | { status: 'unavailable' }
+  | { status: 'error' };
+
+type MutationState =
+  | { status: 'idle' }
+  | { status: 'submitting'; request: ReviewEntryRequest }
+  | { status: 'failed'; request: ReviewEntryRequest; message: string }
+  | { status: 'committed'; receipt: ReviewEntryReceipt };
+
+function StatusPanel({
+  title,
+  description,
+  icon,
+  action,
+}: {
+  title: string;
+  description: string;
+  icon: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <section className="rounded-card border border-border bg-surface p-5 shadow-sm" aria-live="polite">
+      <div className="flex items-start gap-4">
+        <span
+          className="flex size-11 shrink-0 items-center justify-center rounded-control bg-canvas text-muted"
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+        <div>
+          <h2 className="m-0 text-lg font-semibold tracking-tight text-ink">{title}</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">{description}</p>
+          {action ? <div className="mt-4">{action}</div> : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function nextAction(detail: ReportSubmissionReviewDetailResponse): {
+  action: 'begin_triage' | 'begin_review';
+  expectedStatus: 'received' | 'triage';
+  label: string;
+  description: string;
+} | null {
+  if (detail.submission.workflowStatus === 'received') {
+    return {
+      action: 'begin_triage',
+      expectedStatus: 'received',
+      label: 'Begin triage',
+      description: 'Move this report into protected triage without making a report decision.',
+    };
+  }
+  if (detail.submission.workflowStatus === 'triage') {
+    return {
+      action: 'begin_review',
+      expectedStatus: 'triage',
+      label: 'Begin review',
+      description: 'Move this triaged report into protected review so typed decisions become reachable.',
+    };
+  }
+  return null;
+}
+
+export function ReportReviewEntryControls({ submissionId }: { submissionId: string | null }) {
+  const [detailState, setDetailState] = useState<DetailState>(
+    submissionId ? { status: 'loading' } : { status: 'missing_id' },
+  );
+  const [mutationState, setMutationState] = useState<MutationState>({ status: 'idle' });
+
+  const loadDetail = useCallback(async () => {
+    if (!submissionId) {
+      setDetailState({ status: 'missing_id' });
+      return;
+    }
+    setDetailState({ status: 'loading' });
+    try {
+      const response = await fetch(`/admin/api/reports/${encodeURIComponent(submissionId)}`, {
+        cache: 'no-store',
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' },
+      });
+      if (response.status === 403) {
+        setDetailState({ status: 'denied' });
+        return;
+      }
+      if (response.status === 404) {
+        setDetailState({ status: 'not_found' });
+        return;
+      }
+      if (response.status === 503) {
+        setDetailState({ status: 'unavailable' });
+        return;
+      }
+      if (!response.ok) {
+        setDetailState({ status: 'error' });
+        return;
+      }
+      const result = reportSubmissionReviewDetailResponseSchema.safeParse(await response.json());
+      setDetailState(result.success ? { status: 'ready', detail: result.data } : { status: 'error' });
+    } catch {
+      setDetailState({ status: 'error' });
+    }
+  }, [submissionId]);
+
+  useEffect(() => {
+    void loadDetail();
+  }, [loadDetail]);
+
+  const submitTransition = useCallback(
+    async (retryRequest?: ReviewEntryRequest) => {
+      if (!submissionId || detailState.status !== 'ready') return;
+      const transition = nextAction(detailState.detail);
+      if (!transition) return;
+
+      const request =
+        retryRequest ??
+        reviewEntryRequestSchema.parse({
+          schemaVersion: 'submission-review-entry-v1',
+          requestId: globalThis.crypto.randomUUID(),
+          submissionType: detailState.detail.submission.submissionType,
+          action: transition.action,
+          expectedStatus: transition.expectedStatus,
+          expectedUpdatedAt: detailState.detail.submission.updatedAt,
+        });
+      setMutationState({ status: 'submitting', request });
+
+      try {
+        const response = await fetch(
+          `/admin/api/review-entry/${encodeURIComponent(submissionId)}`,
+          {
+            method: 'POST',
+            cache: 'no-store',
+            credentials: 'same-origin',
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(request),
+          },
+        );
+        if (response.status === 403) {
+          setMutationState({
+            status: 'failed',
+            request,
+            message: 'Your verified administration identity cannot perform review entry.',
+          });
+          return;
+        }
+        if (response.status === 409) {
+          setMutationState({
+            status: 'failed',
+            request,
+            message: 'The Submission changed before this transition was applied. Reload the current state.',
+          });
+          return;
+        }
+        if (!response.ok) {
+          setMutationState({
+            status: 'failed',
+            request,
+            message: 'The protected transition could not complete safely.',
+          });
+          return;
+        }
+        const result = reviewEntryReceiptSchema.safeParse(await response.json());
+        if (!result.success) {
+          setMutationState({
+            status: 'failed',
+            request,
+            message: 'The transition response could not be verified.',
+          });
+          return;
+        }
+        setMutationState({ status: 'committed', receipt: result.data });
+        await loadDetail();
+      } catch {
+        setMutationState({
+          status: 'failed',
+          request,
+          message: 'The protected transition request could not be completed.',
+        });
+      }
+    },
+    [detailState, loadDetail, submissionId],
+  );
+
+  if (detailState.status === 'loading') {
+    return (
+      <StatusPanel
+        title="Loading review-entry controls"
+        description="The current private workflow state is being verified before any mutation control is shown."
+        icon={<RefreshCw className="size-5 animate-spin motion-reduce:animate-none" />}
+      />
+    );
+  }
+  if (detailState.status === 'missing_id' || detailState.status === 'not_found') {
+    return (
+      <StatusPanel
+        title="Report Submission unavailable"
+        description="Open a valid payment or problem report from the protected queue."
+        icon={<AlertTriangle className="size-5" />}
+      />
+    );
+  }
+  if (detailState.status === 'denied') {
+    return (
+      <StatusPanel
+        title="Review-entry access denied"
+        description="Your verified administration identity cannot read this protected Submission."
+        icon={<ShieldAlert className="size-5" />}
+      />
+    );
+  }
+  if (detailState.status === 'unavailable' || detailState.status === 'error') {
+    return (
+      <StatusPanel
+        title="Review-entry controls unavailable"
+        description="The current workflow state could not be verified, so no mutation control is displayed."
+        icon={<AlertTriangle className="size-5" />}
+        action={
+          <Button variant="secondary" onClick={() => void loadDetail()}>
+            Reload current state
+          </Button>
+        }
+      />
+    );
+  }
+
+  const transition = nextAction(detailState.detail);
+  return (
+    <section className="rounded-card border border-brand-600 bg-brand-50 p-5 shadow-sm" aria-live="polite">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="m-0 text-xs font-semibold uppercase tracking-[0.08em] text-brand-800">
+            P5-06B protected review entry
+          </p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-ink">
+            Current state: {detailState.detail.submission.workflowStatus.replaceAll('_', ' ')}
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
+            These controls only move the private Submission into the normal review workflow. They do not accept Evidence, decide the report, change canonical data, export, or publish.
+          </p>
+        </div>
+        <span className="rounded-pill border border-brand-200 bg-white px-3 py-1 text-xs font-semibold text-brand-800">
+          {detailState.detail.submission.publicId}
+        </span>
+      </div>
+
+      {mutationState.status === 'committed' ? (
+        <div className="mt-4 flex items-start gap-3 rounded-control border border-green-200 bg-green-50 p-4 text-sm text-green-900">
+          <CheckCircle2 className="mt-0.5 size-5 shrink-0" aria-hidden="true" />
+          <p className="m-0">
+            Transition {mutationState.receipt.state}: {mutationState.receipt.fromStatus} →{' '}
+            {mutationState.receipt.toStatus}.
+          </p>
+        </div>
+      ) : null}
+
+      {mutationState.status === 'failed' ? (
+        <div className="mt-4 rounded-control border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+          <p className="m-0">{mutationState.message}</p>
+          <div className="mt-3 flex flex-wrap gap-3">
+            <Button variant="secondary" onClick={() => void submitTransition(mutationState.request)}>
+              Retry same request
+            </Button>
+            <Button variant="ghost" onClick={() => void loadDetail()}>
+              Reload current state
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {transition ? (
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-4 rounded-control border border-brand-200 bg-white p-4">
+          <div>
+            <p className="m-0 text-sm font-semibold text-ink">{transition.label}</p>
+            <p className="mt-1 text-sm text-muted">{transition.description}</p>
+          </div>
+          <Button
+            loading={mutationState.status === 'submitting'}
+            disabled={mutationState.status === 'submitting'}
+            onClick={() => void submitTransition()}
+          >
+            <PlayCircle className="size-4" aria-hidden="true" />
+            {transition.label}
+          </Button>
+        </div>
+      ) : (
+        <p className="mt-5 rounded-control border border-border bg-white p-4 text-sm text-muted">
+          No P5-06B review-entry transition is available from the current state.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/pages/admin/submissions/report-detail.astro
+++ b/src/pages/admin/submissions/report-detail.astro
@@ -1,4 +1,5 @@
 ---
+import { ReportReviewEntryControls } from '../../../components/admin/ReportReviewEntryControls';
 import { ReportSubmissionReview } from '../../../components/admin/ReportSubmissionReview';
 import AdminLayout from '../../../layouts/AdminLayout.astro';
 
@@ -8,16 +9,20 @@ const submissionId = Astro.url.searchParams.get('id');
 <AdminLayout
   title="Report review | CryptoPayMap Admin"
   heading="Payment and problem report"
-  description="A protected read-only report workspace. Normalized report fields, bounded canonical target context, exact Claim-context signals, and workflow summaries are displayed without decision or mutation controls."
+  description="A protected report workspace with bounded review-entry controls. Normalized report fields, canonical target context, Claim-context signals, and workflow summaries remain separated from report decisions and canonical mutation."
 >
   <section class="rounded-card border border-brand-600 bg-brand-50 p-5 sm:p-6" aria-labelledby="report-review-boundary-title">
-    <p class="m-0 text-sm font-semibold text-brand-800">P5-03D read-only boundary</p>
+    <p class="m-0 text-sm font-semibold text-brand-800">P5-06B review-entry boundary</p>
     <h2 id="report-review-boundary-title" class="mt-1 text-xl font-semibold tracking-tight text-ink">
-      Review report context before any Evidence, recheck, visibility, or canonical decision
+      Move a private report into triage and review before any typed decision
     </h2>
     <p class="mt-3 max-w-3xl text-sm leading-6 text-muted">
-      This page does not accept Evidence, reconfirm Claims, create rechecks, hide records, apply corrections, change canonical data, export, or publish. Those actions remain separate guarded operations.
+      Review entry only changes the private Submission workflow state. This page does not accept Evidence, reconfirm Claims, create rechecks, hide records, apply corrections, change canonical data, export, or publish. Those actions remain separate guarded operations.
     </p>
+  </section>
+
+  <section class="mt-8" aria-label="Protected report review-entry controls">
+    <ReportReviewEntryControls submissionId={submissionId} client:load />
   </section>
 
   <section class="mt-8" aria-label="Protected report detail">

--- a/tests/report-review-entry-controls.test.tsx
+++ b/tests/report-review-entry-controls.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReportSubmissionReviewDetailResponse } from '../src/admin/submissions/report-detail';
+import { ReportReviewEntryControls } from '../src/components/admin/ReportReviewEntryControls';
+
+const submissionId = '10000000-0000-4000-8000-000000000001';
+const entityId = '20000000-0000-4000-8000-000000000001';
+const requestId = '30000000-0000-4000-8000-000000000001';
+
+function detailResponse(
+  workflowStatus: 'received' | 'triage',
+  updatedAt = '2026-07-15T16:00:00.000Z',
+): ReportSubmissionReviewDetailResponse {
+  return {
+    generatedAt: '2026-07-15T16:00:00.000Z',
+    submission: {
+      id: submissionId,
+      publicId: 'CPM-S-2026-000001',
+      submissionType: 'problem_report',
+      targetType: 'entity',
+      targetId: entityId,
+      workflowStatus,
+      resolution: null,
+      priority: 100,
+      submittedAt: '2026-07-15T15:00:00.000Z',
+      updatedAt,
+    },
+    projection: {
+      reportKind: 'problem_report',
+      targetType: 'entity',
+      targetId: entityId,
+      reportType: 'privacy_issue',
+      observedAt: '2026-07-15',
+      explanation: 'The public record appears to expose personal information.',
+      proposedCorrection: null,
+      duplicateTarget: null,
+      evidenceLinks: [],
+      restrictedEvidence: { privateEvidenceUrlPresent: true },
+    },
+    events: [],
+    eventsTruncated: false,
+    targetContext: {
+      generatedAt: '2026-07-15T16:00:00.000Z',
+      target: {
+        targetType: 'entity',
+        targetId: entityId,
+        canonicalPath: '/service/example-service',
+        entity: {
+          id: entityId,
+          entityType: 'online_service',
+          name: 'Example Service',
+          slug: 'example-service',
+          websiteUrl: 'https://service.example/',
+          countryCode: 'US',
+          entityStatus: 'active',
+          visibility: 'public',
+          updatedAt: '2026-07-15T14:00:00.000Z',
+        },
+        location: null,
+        selectedClaimId: null,
+      },
+      reportability: { publiclyReachable: true, reasons: [] },
+      claimSignals: [],
+      coverage: {
+        targetLookupComplete: true,
+        claimContextComplete: true,
+        absenceIsConclusive: false,
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('P5-06B2A report review-entry controls', () => {
+  it('moves a received report into triage with exact state guards and reloads the workspace', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(detailResponse('received')), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            state: 'committed',
+            submissionId,
+            submissionType: 'problem_report',
+            fromStatus: 'received',
+            toStatus: 'triage',
+            action: 'begin_triage',
+            changedAt: '2026-07-15T16:01:00.000Z',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(detailResponse('triage', '2026-07-15T16:01:00.000Z')), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('crypto', { randomUUID: () => requestId });
+
+    render(<ReportReviewEntryControls submissionId={submissionId} />);
+
+    await user.click(await screen.findByRole('button', { name: 'Begin triage' }));
+
+    await screen.findByRole('button', { name: 'Begin review' });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    const transitionCall = fetchMock.mock.calls[1];
+    expect(transitionCall?.[0]).toBe(`/admin/api/review-entry/${submissionId}`);
+    expect(transitionCall?.[1]).toMatchObject({
+      method: 'POST',
+      credentials: 'same-origin',
+    });
+    expect(JSON.parse(String(transitionCall?.[1]?.body))).toEqual({
+      schemaVersion: 'submission-review-entry-v1',
+      requestId,
+      submissionType: 'problem_report',
+      action: 'begin_triage',
+      expectedStatus: 'received',
+      expectedUpdatedAt: '2026-07-15T16:00:00.000Z',
+    });
+  });
+});


### PR DESCRIPTION
## Implementation item

P5-06B2A — Report reviewer workspace controls

## Purpose

Connect the merged P5-06B1 protected review-entry API to the existing payment and problem report detail workspace.

## Included

- protected current-state loading before any mutation control is shown;
- `received → triage` and `triage → in_review` actions;
- UUID request identity, exact Submission type, expected status, and exact `updatedAt` guards;
- strict request and receipt schema parsing;
- same-request retry after transient failure;
- stale-state reload path;
- bounded denied, unavailable, invalid-response, committed, and no-action states;
- focused browser test covering exact request content and post-transition reload;
- implementation boundary documentation.

## Explicit exclusions

No Evidence decision, recheck, visibility action, typed report resolution, information request, hold, resume, Photos parent workspace, canonical mutation, export, publication, deployment, or launch claim.

P5-06B2B will add the Photos parent Submission workspace using the same review-entry boundary.

## Migration

None.

## Validation

All normal repository workflows must pass before merge.