### PR TITLE
P5-06B2B1: add Photos parent review APIs

### DIFF
--- a/docs/P5_06B2B_PHOTOS_PARENT_REVIEW_API.md
+++ b/docs/P5_06B2B_PHOTOS_PARENT_REVIEW_API.md
@@ -1,0 +1,49 @@
+# P5-06B2B Photos parent review API
+
+**Status:** In progress
+
+## Purpose
+
+Create the protected parent-Submission read boundary required before the Photos reviewer workspace can expose review-entry controls.
+
+## Protected routes
+
+```text
+GET /admin/api/photo-submissions
+GET /admin/api/photo-submissions/:submissionId
+```
+
+The queue returns bounded normalized summaries for actionable `photos` Submissions. The detail route returns:
+
+- parent Submission metadata and workflow state;
+- normalized target, relationship, and one-to-eight public-gallery candidate summaries;
+- bounded workflow history.
+
+## Privacy boundary
+
+The responses do not include:
+
+- object-storage keys;
+- signed upload URLs;
+- image bytes or private derivatives;
+- contact values;
+- status secrets or hashes;
+- reviewer identity or private notes;
+- internal persistence detail.
+
+## Exact identity rules
+
+The stored parent Submission type must be `photos`. Stored target type and target ID must exactly match the normalized review projection. Invalid or incomplete rows fail closed rather than returning a partial workspace.
+
+## Explicit non-effects
+
+This item does not:
+
+- process or approve Media;
+- publish an image;
+- resolve the parent Submission;
+- apply canonical data;
+- export or deploy;
+- add public access.
+
+The following bounded UI item will connect these routes to a protected Photos parent queue/detail page and reuse the P5-06B1 review-entry API.

--- a/functions/admin/api/photo-submissions.ts
+++ b/functions/admin/api/photo-submissions.ts
@@ -1,0 +1,121 @@
+import { withAdminSecurityHeaders } from '../../../src/admin/access/config';
+import {
+  SubmissionReviewAuthorizationError,
+  authorizeSubmissionReviewRead,
+  readSubmissionReviewAuthorizationPolicy,
+  type SubmissionReviewAuthorizationEnvironment,
+} from '../../../src/admin/submissions/authorization';
+import { createDrizzlePhotoSubmissionQueueBackend } from '../../../src/admin/submissions/drizzle-photo-parent-backend';
+import {
+  loadPhotoSubmissionQueue,
+  parsePhotoSubmissionQueueQuery,
+  PhotoParentReviewError,
+  type PhotoSubmissionQueueQuery,
+  type PhotoSubmissionQueueResponse,
+} from '../../../src/admin/submissions/photo-parent';
+import { readProtectedAdminIdentity } from '../../../src/admin/dashboard/identity-context';
+import { createDatabase } from '../../../src/db/client';
+import { requiredDatabaseEnvironmentSchema } from '../../../src/schemas/environment';
+
+interface PhotoQueueEnvironment extends SubmissionReviewAuthorizationEnvironment {
+  DATABASE_URL?: string;
+}
+
+interface PhotoQueuePagesContext {
+  request: Request;
+  env: PhotoQueueEnvironment;
+  params: Record<string, string | string[]>;
+  data: Record<string, unknown>;
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+type PhotoQueueLoader = (
+  context: ReturnType<typeof authorizeSubmissionReviewRead>,
+  query: PhotoSubmissionQueueQuery,
+  environment: PhotoQueueEnvironment,
+  asOf: Date,
+) => Promise<PhotoSubmissionQueueResponse>;
+
+export interface PhotoQueueHandlerDependencies {
+  loadQueue?: PhotoQueueLoader;
+  now?: () => Date;
+}
+
+function jsonResponse(status: number, body: Record<string, unknown>): Response {
+  return withAdminSecurityHeaders(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    }),
+  );
+}
+
+async function loadQueueFromDatabase(
+  context: ReturnType<typeof authorizeSubmissionReviewRead>,
+  query: PhotoSubmissionQueueQuery,
+  environment: PhotoQueueEnvironment,
+  asOf: Date,
+): Promise<PhotoSubmissionQueueResponse> {
+  const databaseEnvironment = requiredDatabaseEnvironmentSchema.safeParse({
+    DATABASE_URL:
+      typeof environment.DATABASE_URL === 'string' ? environment.DATABASE_URL : undefined,
+  });
+  if (!databaseEnvironment.success) {
+    throw new PhotoParentReviewError(
+      'backend_failure',
+      'The Photos queue database is unavailable.',
+    );
+  }
+  const database = createDatabase(databaseEnvironment.data.DATABASE_URL);
+  return loadPhotoSubmissionQueue(
+    context,
+    createDrizzlePhotoSubmissionQueueBackend(database),
+    query,
+    asOf,
+  );
+}
+
+export function createPhotoQueueHandler(dependencies: PhotoQueueHandlerDependencies = {}) {
+  const loadQueue = dependencies.loadQueue ?? loadQueueFromDatabase;
+  const now = dependencies.now ?? (() => new Date());
+
+  return async (pagesContext: PhotoQueuePagesContext): Promise<Response> => {
+    let context: ReturnType<typeof authorizeSubmissionReviewRead>;
+    try {
+      const identity = readProtectedAdminIdentity(pagesContext.data.adminIdentity);
+      const policy = readSubmissionReviewAuthorizationPolicy(pagesContext.env);
+      context = authorizeSubmissionReviewRead(identity, policy);
+    } catch (error) {
+      if (
+        error instanceof SubmissionReviewAuthorizationError &&
+        error.code === 'configuration'
+      ) {
+        return jsonResponse(503, { error: 'photo_submission_queue_unavailable' });
+      }
+      return jsonResponse(403, { error: 'photo_submission_queue_denied' });
+    }
+
+    let query: PhotoSubmissionQueueQuery;
+    try {
+      query = parsePhotoSubmissionQueueQuery(new URL(pagesContext.request.url));
+    } catch {
+      return jsonResponse(400, { error: 'photo_submission_queue_invalid_query' });
+    }
+
+    try {
+      return jsonResponse(200, await loadQueue(context, query, pagesContext.env, now()));
+    } catch (error) {
+      if (error instanceof PhotoParentReviewError) {
+        if (error.code === 'unauthorized') {
+          return jsonResponse(403, { error: 'photo_submission_queue_denied' });
+        }
+        if (error.code === 'invalid_query') {
+          return jsonResponse(400, { error: 'photo_submission_queue_invalid_query' });
+        }
+      }
+      return jsonResponse(503, { error: 'photo_submission_queue_unavailable' });
+    }
+  };
+}
+
+export const onRequestGet = createPhotoQueueHandler();

--- a/functions/admin/api/photo-submissions/[submissionId].ts
+++ b/functions/admin/api/photo-submissions/[submissionId].ts
@@ -1,0 +1,123 @@
+import { withAdminSecurityHeaders } from '../../../../src/admin/access/config';
+import {
+  SubmissionReviewAuthorizationError,
+  authorizeSubmissionReviewRead,
+  readSubmissionReviewAuthorizationPolicy,
+  type SubmissionReviewAuthorizationEnvironment,
+} from '../../../../src/admin/submissions/authorization';
+import { createDrizzlePhotoSubmissionDetailBackend } from '../../../../src/admin/submissions/drizzle-photo-parent-backend';
+import {
+  loadPhotoSubmissionDetail,
+  PhotoParentReviewError,
+  type PhotoSubmissionDetailResponse,
+} from '../../../../src/admin/submissions/photo-parent';
+import { readProtectedAdminIdentity } from '../../../../src/admin/dashboard/identity-context';
+import { createDatabase } from '../../../../src/db/client';
+import { requiredDatabaseEnvironmentSchema } from '../../../../src/schemas/environment';
+
+interface PhotoDetailEnvironment extends SubmissionReviewAuthorizationEnvironment {
+  DATABASE_URL?: string;
+}
+
+interface PhotoDetailPagesContext {
+  request: Request;
+  env: PhotoDetailEnvironment;
+  params: Record<string, string | string[]>;
+  data: Record<string, unknown>;
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+type PhotoDetailLoader = (
+  context: ReturnType<typeof authorizeSubmissionReviewRead>,
+  submissionId: string,
+  environment: PhotoDetailEnvironment,
+  asOf: Date,
+) => Promise<PhotoSubmissionDetailResponse>;
+
+export interface PhotoDetailHandlerDependencies {
+  loadDetail?: PhotoDetailLoader;
+  now?: () => Date;
+}
+
+function jsonResponse(status: number, body: Record<string, unknown>): Response {
+  return withAdminSecurityHeaders(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    }),
+  );
+}
+
+async function loadDetailFromDatabase(
+  context: ReturnType<typeof authorizeSubmissionReviewRead>,
+  submissionId: string,
+  environment: PhotoDetailEnvironment,
+  asOf: Date,
+): Promise<PhotoSubmissionDetailResponse> {
+  const databaseEnvironment = requiredDatabaseEnvironmentSchema.safeParse({
+    DATABASE_URL:
+      typeof environment.DATABASE_URL === 'string' ? environment.DATABASE_URL : undefined,
+  });
+  if (!databaseEnvironment.success) {
+    throw new PhotoParentReviewError(
+      'backend_failure',
+      'The Photos detail database is unavailable.',
+    );
+  }
+  const database = createDatabase(databaseEnvironment.data.DATABASE_URL);
+  return loadPhotoSubmissionDetail(
+    context,
+    createDrizzlePhotoSubmissionDetailBackend(database),
+    submissionId,
+    asOf,
+  );
+}
+
+export function createPhotoDetailHandler(dependencies: PhotoDetailHandlerDependencies = {}) {
+  const loadDetail = dependencies.loadDetail ?? loadDetailFromDatabase;
+  const now = dependencies.now ?? (() => new Date());
+
+  return async (pagesContext: PhotoDetailPagesContext): Promise<Response> => {
+    let context: ReturnType<typeof authorizeSubmissionReviewRead>;
+    try {
+      const identity = readProtectedAdminIdentity(pagesContext.data.adminIdentity);
+      const policy = readSubmissionReviewAuthorizationPolicy(pagesContext.env);
+      context = authorizeSubmissionReviewRead(identity, policy);
+    } catch (error) {
+      if (
+        error instanceof SubmissionReviewAuthorizationError &&
+        error.code === 'configuration'
+      ) {
+        return jsonResponse(503, { error: 'photo_submission_detail_unavailable' });
+      }
+      return jsonResponse(403, { error: 'photo_submission_detail_denied' });
+    }
+
+    const submissionId = pagesContext.params.submissionId;
+    if (typeof submissionId !== 'string') {
+      return jsonResponse(400, { error: 'photo_submission_detail_invalid_id' });
+    }
+
+    try {
+      return jsonResponse(
+        200,
+        await loadDetail(context, submissionId, pagesContext.env, now()),
+      );
+    } catch (error) {
+      if (error instanceof PhotoParentReviewError) {
+        if (error.code === 'unauthorized') {
+          return jsonResponse(403, { error: 'photo_submission_detail_denied' });
+        }
+        if (error.code === 'invalid_query') {
+          return jsonResponse(400, { error: 'photo_submission_detail_invalid_id' });
+        }
+        if (error.code === 'not_found') {
+          return jsonResponse(404, { error: 'photo_submission_detail_not_found' });
+        }
+      }
+      return jsonResponse(503, { error: 'photo_submission_detail_unavailable' });
+    }
+  };
+}
+
+export const onRequestGet = createPhotoDetailHandler();

--- a/src/admin/submissions/drizzle-photo-parent-backend.ts
+++ b/src/admin/submissions/drizzle-photo-parent-backend.ts
@@ -1,0 +1,198 @@
+import { and, asc, desc, eq, gt, inArray, isNotNull, or, sql, type SQL } from 'drizzle-orm';
+import type { CryptoPayMapDatabase } from '../../db/client';
+import { submissionEvents, submissionPayloads, submissions } from '../../db/schema';
+import {
+  encodePhotoSubmissionQueueCursor,
+  PhotoParentReviewError,
+  type PhotoSubmissionDetailBackend,
+  type PhotoSubmissionDetailData,
+  type PhotoSubmissionQueueBackend,
+  type PhotoSubmissionQueueItem,
+  type PhotoSubmissionQueuePageData,
+  type PhotoSubmissionQueueQuery,
+} from './photo-parent';
+
+const eventLimit = 100;
+
+function cursorFilter(query: PhotoSubmissionQueueQuery): SQL | undefined {
+  if (query.cursor === null) return undefined;
+  const submittedAt = new Date(query.cursor.submittedAt);
+  return or(
+    sql`${submissions.priority} < ${query.cursor.priority}`,
+    and(eq(submissions.priority, query.cursor.priority), gt(submissions.submittedAt, submittedAt)),
+    and(
+      eq(submissions.priority, query.cursor.priority),
+      eq(submissions.submittedAt, submittedAt),
+      gt(submissions.id, query.cursor.id),
+    ),
+  );
+}
+
+function assertIdentity(row: {
+  submissionType: string;
+  storedTargetType: string | null;
+  storedTargetId: string | null;
+  normalizedTargetType: string;
+  normalizedTargetId: string;
+}): void {
+  if (
+    row.submissionType !== 'photos' ||
+    row.storedTargetType !== row.normalizedTargetType ||
+    row.storedTargetId !== row.normalizedTargetId
+  ) {
+    throw new PhotoParentReviewError(
+      'invalid_page',
+      'Stored Photos metadata does not match the normalized review projection.',
+    );
+  }
+}
+
+export function createDrizzlePhotoSubmissionQueueBackend(
+  database: CryptoPayMapDatabase,
+): PhotoSubmissionQueueBackend {
+  return {
+    async loadPage(query): Promise<PhotoSubmissionQueuePageData> {
+      const targetType = sql<string>`${submissionPayloads.normalizedPayload} #>> '{targetType}'`;
+      const targetId = sql<string>`${submissionPayloads.normalizedPayload} #>> '{targetId}'`;
+      const relationship = sql<string>`${submissionPayloads.normalizedPayload} #>> '{relationship}'`;
+      const mediaCount = sql<number>`jsonb_array_length(${submissionPayloads.normalizedPayload} -> 'media')`;
+
+      const rows = await database
+        .select({
+          id: submissions.id,
+          publicId: submissions.publicId,
+          submissionType: submissions.submissionType,
+          storedTargetType: submissions.targetType,
+          storedTargetId: submissions.targetId,
+          normalizedTargetType: targetType,
+          normalizedTargetId: targetId,
+          relationship,
+          mediaCount,
+          workflowStatus: submissions.workflowStatus,
+          priority: submissions.priority,
+          submittedAt: submissions.submittedAt,
+          updatedAt: submissions.updatedAt,
+        })
+        .from(submissions)
+        .innerJoin(submissionPayloads, eq(submissionPayloads.submissionId, submissions.id))
+        .where(
+          and(
+            eq(submissions.submissionType, 'photos'),
+            isNotNull(submissionPayloads.normalizedPayload),
+            inArray(submissions.workflowStatus, query.statuses),
+            cursorFilter(query),
+          ),
+        )
+        .orderBy(desc(submissions.priority), asc(submissions.submittedAt), asc(submissions.id))
+        .limit(query.limit + 1);
+
+      const hasNextPage = rows.length > query.limit;
+      const pageRows = hasNextPage ? rows.slice(0, query.limit) : rows;
+      const items: PhotoSubmissionQueueItem[] = pageRows.map((row) => {
+        assertIdentity(row);
+        return {
+          id: row.id,
+          publicId: row.publicId,
+          targetType: row.storedTargetType as PhotoSubmissionQueueItem['targetType'],
+          targetId: row.storedTargetId as string,
+          workflowStatus: row.workflowStatus,
+          priority: row.priority,
+          mediaCount: row.mediaCount,
+          relationship: row.relationship as PhotoSubmissionQueueItem['relationship'],
+          submittedAt: row.submittedAt.toISOString(),
+          updatedAt: row.updatedAt.toISOString(),
+        };
+      });
+
+      const lastRow = pageRows.at(-1);
+      return {
+        items,
+        hasNextPage,
+        nextCursor:
+          hasNextPage && lastRow
+            ? encodePhotoSubmissionQueueCursor({
+                priority: lastRow.priority,
+                submittedAt: lastRow.submittedAt.toISOString(),
+                id: lastRow.id,
+              })
+            : null,
+      };
+    },
+  };
+}
+
+export function createDrizzlePhotoSubmissionDetailBackend(
+  database: CryptoPayMapDatabase,
+): PhotoSubmissionDetailBackend {
+  return {
+    async loadDetail(submissionId): Promise<PhotoSubmissionDetailData | null> {
+      const rows = await database
+        .select({
+          id: submissions.id,
+          publicId: submissions.publicId,
+          submissionType: submissions.submissionType,
+          targetType: submissions.targetType,
+          targetId: submissions.targetId,
+          workflowStatus: submissions.workflowStatus,
+          resolution: submissions.resolution,
+          priority: submissions.priority,
+          submittedAt: submissions.submittedAt,
+          updatedAt: submissions.updatedAt,
+          normalizedPayload: submissionPayloads.normalizedPayload,
+        })
+        .from(submissions)
+        .leftJoin(submissionPayloads, eq(submissionPayloads.submissionId, submissions.id))
+        .where(and(eq(submissions.id, submissionId), eq(submissions.submissionType, 'photos')))
+        .limit(1);
+      const row = rows[0];
+      if (row === undefined) return null;
+      if (row.normalizedPayload === null || row.targetType === null || row.targetId === null) {
+        throw new PhotoParentReviewError(
+          'invalid_detail',
+          'The stored Photos Submission detail is incomplete.',
+        );
+      }
+
+      const eventRows = await database
+        .select({
+          fromStatus: submissionEvents.fromStatus,
+          toStatus: submissionEvents.toStatus,
+          action: submissionEvents.action,
+          reasonCode: submissionEvents.reasonCode,
+          actorType: submissionEvents.actorType,
+          createdAt: submissionEvents.createdAt,
+        })
+        .from(submissionEvents)
+        .where(eq(submissionEvents.submissionId, submissionId))
+        .orderBy(asc(submissionEvents.createdAt), asc(submissionEvents.id))
+        .limit(eventLimit + 1);
+
+      const eventsTruncated = eventRows.length > eventLimit;
+      const boundedEvents = eventsTruncated ? eventRows.slice(0, eventLimit) : eventRows;
+      return {
+        submission: {
+          id: row.id,
+          publicId: row.publicId,
+          submissionType: 'photos',
+          targetType: row.targetType as 'entity' | 'location',
+          targetId: row.targetId,
+          workflowStatus: row.workflowStatus,
+          resolution: row.resolution,
+          priority: row.priority,
+          submittedAt: row.submittedAt.toISOString(),
+          updatedAt: row.updatedAt.toISOString(),
+        },
+        projection: row.normalizedPayload as PhotoSubmissionDetailData['projection'],
+        events: boundedEvents.map((event) => ({
+          fromStatus: event.fromStatus,
+          toStatus: event.toStatus,
+          action: event.action,
+          reasonCode: event.reasonCode,
+          actorType: event.actorType,
+          createdAt: event.createdAt.toISOString(),
+        })),
+        eventsTruncated,
+      };
+    },
+  };
+}

--- a/src/admin/submissions/photo-parent.ts
+++ b/src/admin/submissions/photo-parent.ts
@@ -1,0 +1,296 @@
+import { z } from 'zod';
+import {
+  submissionResolutionSchema,
+  submissionWorkflowStatusSchema,
+  submissionWorkflowStatusValues,
+} from '../../submissions/contract';
+import { photosReviewProjectionSchema } from '../../submissions/photo-media-contract';
+import type { SubmissionReviewContext } from './authorization';
+import { reportSubmissionReviewContextSchema } from './report-queue';
+
+const timestampSchema = z.iso.datetime({ offset: true });
+const photoTargetTypeSchema = z.enum(['entity', 'location']);
+
+const photoSubmissionQueueCursorSchema = z
+  .object({
+    priority: z.number().int().min(0).max(1_000),
+    submittedAt: timestampSchema,
+    id: z.uuid(),
+  })
+  .strict();
+
+export const actionablePhotoSubmissionStatuses = [
+  'received',
+  'triage',
+  'in_review',
+  'needs_information',
+  'on_hold',
+] as const;
+
+export const photoSubmissionQueueQuerySchema = z
+  .object({
+    statuses: z
+      .array(submissionWorkflowStatusSchema)
+      .min(1)
+      .max(submissionWorkflowStatusValues.length)
+      .default([...actionablePhotoSubmissionStatuses]),
+    limit: z.number().int().min(1).max(50).default(25),
+    cursor: photoSubmissionQueueCursorSchema.nullable().default(null),
+  })
+  .strict();
+
+export const photoSubmissionQueueItemSchema = z
+  .object({
+    id: z.uuid(),
+    publicId: z.string().regex(/^CPM-S-\d{4}-\d{6}$/),
+    targetType: photoTargetTypeSchema,
+    targetId: z.uuid(),
+    workflowStatus: submissionWorkflowStatusSchema,
+    priority: z.number().int().min(0).max(1_000),
+    mediaCount: z.number().int().min(1).max(8),
+    relationship: photosReviewProjectionSchema.shape.relationship,
+    submittedAt: timestampSchema,
+    updatedAt: timestampSchema,
+  })
+  .strict();
+
+export const photoSubmissionQueuePageDataSchema = z
+  .object({
+    items: z.array(photoSubmissionQueueItemSchema).max(50),
+    hasNextPage: z.boolean(),
+    nextCursor: z.string().max(1_024).nullable(),
+  })
+  .strict()
+  .superRefine((page, context) => {
+    if (page.hasNextPage !== (page.nextCursor !== null)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['nextCursor'],
+        message: 'nextCursor must be present exactly when hasNextPage is true.',
+      });
+    }
+  });
+
+export const photoSubmissionQueueResponseSchema = photoSubmissionQueuePageDataSchema.safeExtend({
+  generatedAt: timestampSchema,
+});
+
+export const photoSubmissionReviewEventSchema = z
+  .object({
+    fromStatus: submissionWorkflowStatusSchema.nullable(),
+    toStatus: submissionWorkflowStatusSchema,
+    action: z.string().trim().min(1).max(96),
+    reasonCode: z.string().trim().min(1).max(96).nullable(),
+    actorType: z.enum(['submitter', 'reviewer', 'system']),
+    createdAt: timestampSchema,
+  })
+  .strict();
+
+export const photoSubmissionDetailDataSchema = z
+  .object({
+    submission: z
+      .object({
+        id: z.uuid(),
+        publicId: z.string().regex(/^CPM-S-\d{4}-\d{6}$/),
+        submissionType: z.literal('photos'),
+        targetType: photoTargetTypeSchema,
+        targetId: z.uuid(),
+        workflowStatus: submissionWorkflowStatusSchema,
+        resolution: submissionResolutionSchema.nullable(),
+        priority: z.number().int().min(0).max(1_000),
+        submittedAt: timestampSchema,
+        updatedAt: timestampSchema,
+      })
+      .strict(),
+    projection: photosReviewProjectionSchema,
+    events: z.array(photoSubmissionReviewEventSchema).max(100),
+    eventsTruncated: z.boolean(),
+  })
+  .strict()
+  .superRefine((detail, context) => {
+    if (
+      detail.submission.targetType !== detail.projection.targetType ||
+      detail.submission.targetId !== detail.projection.targetId
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Stored Photos target metadata must match the normalized review projection.',
+      });
+    }
+  });
+
+export const photoSubmissionDetailResponseSchema = photoSubmissionDetailDataSchema.safeExtend({
+  generatedAt: timestampSchema,
+});
+
+export type PhotoSubmissionQueueQuery = z.infer<typeof photoSubmissionQueueQuerySchema>;
+export type PhotoSubmissionQueueCursor = z.infer<typeof photoSubmissionQueueCursorSchema>;
+export type PhotoSubmissionQueueItem = z.infer<typeof photoSubmissionQueueItemSchema>;
+export type PhotoSubmissionQueuePageData = z.infer<typeof photoSubmissionQueuePageDataSchema>;
+export type PhotoSubmissionQueueResponse = z.infer<typeof photoSubmissionQueueResponseSchema>;
+export type PhotoSubmissionDetailData = z.infer<typeof photoSubmissionDetailDataSchema>;
+export type PhotoSubmissionDetailResponse = z.infer<typeof photoSubmissionDetailResponseSchema>;
+
+export interface PhotoSubmissionQueueBackend {
+  loadPage(query: PhotoSubmissionQueueQuery, asOf: Date): Promise<PhotoSubmissionQueuePageData>;
+}
+
+export interface PhotoSubmissionDetailBackend {
+  loadDetail(submissionId: string): Promise<PhotoSubmissionDetailData | null>;
+}
+
+export class PhotoParentReviewError extends Error {
+  constructor(
+    readonly code:
+      | 'unauthorized'
+      | 'invalid_query'
+      | 'invalid_page'
+      | 'not_found'
+      | 'invalid_detail'
+      | 'backend_failure',
+    message: string,
+    readonly issues: readonly string[] = [],
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'PhotoParentReviewError';
+  }
+}
+
+function parseMultiValue(searchParameters: URLSearchParams, key: string): string[] {
+  return searchParameters
+    .getAll(key)
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+export function encodePhotoSubmissionQueueCursor(cursor: PhotoSubmissionQueueCursor): string {
+  const validated = photoSubmissionQueueCursorSchema.parse(cursor);
+  return globalThis
+    .btoa(JSON.stringify(validated))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+export function decodePhotoSubmissionQueueCursor(value: string): PhotoSubmissionQueueCursor {
+  if (value.length === 0 || value.length > 1_024) {
+    throw new PhotoParentReviewError('invalid_query', 'Photos queue cursor is invalid.');
+  }
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = (4 - (normalized.length % 4)) % 4;
+    return photoSubmissionQueueCursorSchema.parse(
+      JSON.parse(globalThis.atob(normalized.padEnd(normalized.length + padding, '='))),
+    );
+  } catch (error) {
+    throw new PhotoParentReviewError('invalid_query', 'Photos queue cursor is invalid.', [], {
+      cause: error,
+    });
+  }
+}
+
+export function parsePhotoSubmissionQueueQuery(url: URL): PhotoSubmissionQueueQuery {
+  const statuses = parseMultiValue(url.searchParams, 'status');
+  const limitValue = url.searchParams.get('limit');
+  const cursorValue = url.searchParams.get('cursor');
+  const result = photoSubmissionQueueQuerySchema.safeParse({
+    ...(statuses.length > 0 ? { statuses } : {}),
+    limit: limitValue === null ? undefined : Number(limitValue),
+    cursor: cursorValue === null ? undefined : decodePhotoSubmissionQueueCursor(cursorValue),
+  });
+  if (!result.success) {
+    throw new PhotoParentReviewError(
+      'invalid_query',
+      'Photos queue query is invalid.',
+      result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+    );
+  }
+  return result.data;
+}
+
+function authorize(context: SubmissionReviewContext): void {
+  const result = reportSubmissionReviewContextSchema.safeParse(context);
+  if (!result.success || !context.capabilities.includes('submission:read')) {
+    throw new PhotoParentReviewError(
+      'unauthorized',
+      'The actor is not authorized to read Photos Submissions.',
+    );
+  }
+}
+
+export async function loadPhotoSubmissionQueue(
+  context: SubmissionReviewContext,
+  backend: PhotoSubmissionQueueBackend,
+  query: PhotoSubmissionQueueQuery,
+  asOf = new Date(),
+): Promise<PhotoSubmissionQueueResponse> {
+  authorize(context);
+  if (Number.isNaN(asOf.getTime())) {
+    throw new PhotoParentReviewError('invalid_query', 'Photos queue time is invalid.');
+  }
+  let page: PhotoSubmissionQueuePageData;
+  try {
+    page = await backend.loadPage(query, asOf);
+  } catch (error) {
+    if (error instanceof PhotoParentReviewError) throw error;
+    throw new PhotoParentReviewError(
+      'backend_failure',
+      'The Photos Submission queue could not be loaded.',
+      [],
+      { cause: error },
+    );
+  }
+  const result = photoSubmissionQueueResponseSchema.safeParse({
+    ...page,
+    generatedAt: asOf.toISOString(),
+  });
+  if (!result.success) {
+    throw new PhotoParentReviewError(
+      'invalid_page',
+      'The Photos Submission queue backend returned an invalid page.',
+      result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+    );
+  }
+  return result.data;
+}
+
+export async function loadPhotoSubmissionDetail(
+  context: SubmissionReviewContext,
+  backend: PhotoSubmissionDetailBackend,
+  submissionId: string,
+  asOf = new Date(),
+): Promise<PhotoSubmissionDetailResponse> {
+  authorize(context);
+  if (!z.uuid().safeParse(submissionId).success || Number.isNaN(asOf.getTime())) {
+    throw new PhotoParentReviewError('invalid_query', 'Photos detail request is invalid.');
+  }
+  let detail: PhotoSubmissionDetailData | null;
+  try {
+    detail = await backend.loadDetail(submissionId);
+  } catch (error) {
+    if (error instanceof PhotoParentReviewError) throw error;
+    throw new PhotoParentReviewError(
+      'backend_failure',
+      'The Photos Submission detail could not be loaded.',
+      [],
+      { cause: error },
+    );
+  }
+  if (detail === null) {
+    throw new PhotoParentReviewError('not_found', 'The Photos Submission was not found.');
+  }
+  const result = photoSubmissionDetailResponseSchema.safeParse({
+    ...detail,
+    generatedAt: asOf.toISOString(),
+  });
+  if (!result.success) {
+    throw new PhotoParentReviewError(
+      'invalid_detail',
+      'The Photos Submission backend returned invalid detail.',
+      result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+    );
+  }
+  return result.data;
+}

--- a/tests/photo-parent-review.test.ts
+++ b/tests/photo-parent-review.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPhotoDetailHandler } from '../functions/admin/api/photo-submissions/[submissionId]';
+import { createPhotoQueueHandler } from '../functions/admin/api/photo-submissions';
+import {
+  loadPhotoSubmissionDetail,
+  loadPhotoSubmissionQueue,
+  type PhotoSubmissionDetailData,
+  type PhotoSubmissionQueuePageData,
+} from '../src/admin/submissions/photo-parent';
+
+const submissionId = '10000000-0000-4000-8000-000000000001';
+const targetId = '20000000-0000-4000-8000-000000000001';
+const uploadId = '30000000-0000-4000-8000-000000000001';
+const now = new Date('2026-07-15T17:00:00.000Z');
+const identity = {
+  actorId: 'cloudflare-access:reviewer-subject',
+  actorType: 'human' as const,
+  subject: 'reviewer-subject',
+  email: 'reviewer@example.com',
+};
+const reviewContext = {
+  actorId: identity.actorId,
+  actorType: identity.actorType,
+  capabilities: ['submission:read'] as const,
+};
+
+function queuePage(): PhotoSubmissionQueuePageData {
+  return {
+    items: [
+      {
+        id: submissionId,
+        publicId: 'CPM-S-2026-000001',
+        targetType: 'location',
+        targetId,
+        workflowStatus: 'received',
+        priority: 50,
+        mediaCount: 1,
+        relationship: 'customer',
+        submittedAt: '2026-07-15T16:00:00.000Z',
+        updatedAt: '2026-07-15T16:00:00.000Z',
+      },
+    ],
+    hasNextPage: false,
+    nextCursor: null,
+  };
+}
+
+function detailData(): PhotoSubmissionDetailData {
+  return {
+    submission: {
+      id: submissionId,
+      publicId: 'CPM-S-2026-000001',
+      submissionType: 'photos',
+      targetType: 'location',
+      targetId,
+      workflowStatus: 'received',
+      resolution: null,
+      priority: 50,
+      submittedAt: '2026-07-15T16:00:00.000Z',
+      updatedAt: '2026-07-15T16:00:00.000Z',
+    },
+    projection: {
+      targetType: 'location',
+      targetId,
+      relationship: 'customer',
+      media: [
+        {
+          quarantineUploadId: uploadId,
+          purpose: 'public_gallery_candidate',
+          role: 'exterior',
+          declaredMimeType: 'image/jpeg',
+          declaredByteSize: 1_024,
+          capturedAt: null,
+          description: 'Storefront and payment sign.',
+          suggestedAltText: 'Storefront with a crypto payment sign.',
+          photographerPresent: true,
+          rightsStatus: 'submitted_with_permission',
+          rightsHolderPresent: true,
+          permissionReferencePresent: false,
+          licenseName: null,
+          licenseUrl: null,
+          publicDisplayPermission: true,
+        },
+      ],
+      submitterNote: 'Recent exterior photo.',
+    },
+    events: [],
+    eventsTruncated: false,
+  };
+}
+
+function pagesContext(url: string, submissionIdParam: string | string[] = submissionId) {
+  return {
+    request: new Request(url),
+    env: {
+      CPM_ADMIN_SUBMISSION_SUBJECTS: JSON.stringify(['reviewer-subject']),
+    },
+    params: { submissionId: submissionIdParam },
+    data: { adminIdentity: identity },
+    waitUntil: vi.fn(),
+  };
+}
+
+describe('P5-06B2B Photos parent review', () => {
+  it('loads a bounded Photos parent queue and detail without storage values', async () => {
+    const queue = await loadPhotoSubmissionQueue(
+      reviewContext,
+      { loadPage: vi.fn(async () => queuePage()) },
+      { statuses: ['received'], limit: 25, cursor: null },
+      now,
+    );
+    expect(queue).toEqual({ ...queuePage(), generatedAt: now.toISOString() });
+
+    const detail = await loadPhotoSubmissionDetail(
+      reviewContext,
+      { loadDetail: vi.fn(async () => detailData()) },
+      submissionId,
+      now,
+    );
+    expect(detail.submission.submissionType).toBe('photos');
+    expect(detail.projection.media).toHaveLength(1);
+    expect(JSON.stringify(detail)).not.toContain('storageKey');
+    expect(JSON.stringify(detail)).not.toContain('signedUrl');
+  });
+
+  it('exposes protected queue and detail APIs with bounded errors', async () => {
+    const loadQueue = vi.fn(async () => ({ ...queuePage(), generatedAt: now.toISOString() }));
+    const queueResponse = await createPhotoQueueHandler({ loadQueue, now: () => now })(
+      pagesContext('https://example.test/admin/api/photo-submissions'),
+    );
+    expect(queueResponse.status).toBe(200);
+    expect(queueResponse.headers.get('cache-control')).toBe('private, no-store');
+    expect(loadQueue).toHaveBeenCalledWith(
+      reviewContext,
+      expect.any(Object),
+      expect.any(Object),
+      now,
+    );
+
+    const loadDetail = vi.fn(async () => ({ ...detailData(), generatedAt: now.toISOString() }));
+    const detailResponse = await createPhotoDetailHandler({ loadDetail, now: () => now })(
+      pagesContext(`https://example.test/admin/api/photo-submissions/${submissionId}`),
+    );
+    expect(detailResponse.status).toBe(200);
+    expect(loadDetail).toHaveBeenCalledWith(
+      reviewContext,
+      submissionId,
+      expect.any(Object),
+      now,
+    );
+
+    const invalid = await createPhotoDetailHandler({ loadDetail })(
+      pagesContext('https://example.test/admin/api/photo-submissions/invalid', [submissionId]),
+    );
+    expect(invalid.status).toBe(400);
+    expect(loadDetail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/photo-parent-review.test.ts
+++ b/tests/photo-parent-review.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createPhotoDetailHandler } from '../functions/admin/api/photo-submissions/[submissionId]';
 import { createPhotoQueueHandler } from '../functions/admin/api/photo-submissions';
+import type { SubmissionReviewContext } from '../src/admin/submissions/authorization';
 import {
   loadPhotoSubmissionDetail,
   loadPhotoSubmissionQueue,
@@ -18,10 +19,10 @@ const identity = {
   subject: 'reviewer-subject',
   email: 'reviewer@example.com',
 };
-const reviewContext = {
+const reviewContext: SubmissionReviewContext = {
   actorId: identity.actorId,
   actorType: identity.actorType,
-  capabilities: ['submission:read'] as const,
+  capabilities: ['submission:read'],
 };
 
 function queuePage(): PhotoSubmissionQueuePageData {
@@ -142,12 +143,7 @@ describe('P5-06B2B Photos parent review', () => {
       pagesContext(`https://example.test/admin/api/photo-submissions/${submissionId}`),
     );
     expect(detailResponse.status).toBe(200);
-    expect(loadDetail).toHaveBeenCalledWith(
-      reviewContext,
-      submissionId,
-      expect.any(Object),
-      now,
-    );
+    expect(loadDetail).toHaveBeenCalledWith(reviewContext, submissionId, expect.any(Object), now);
 
     const invalid = await createPhotoDetailHandler({ loadDetail })(
       pagesContext('https://example.test/admin/api/photo-submissions/invalid', [submissionId]),


### PR DESCRIPTION
## Implementation item

P5-06B2B1 — Photos parent Submission queue and detail APIs

## Purpose

Create the protected parent-Submission read boundary needed before the Photos reviewer UI can expose P5-06B review-entry controls.

## Included

- strict bounded Photos parent queue query, cursor, item, page, and response contracts;
- strict Photos parent detail and workflow-event contracts;
- exact stored-vs-normalized target identity validation;
- Drizzle queue and detail backends restricted to `photos` Submissions;
- protected `GET /admin/api/photo-submissions` endpoint;
- protected `GET /admin/api/photo-submissions/:submissionId` endpoint;
- shared Submission read authorization and private no-store responses;
- bounded error mapping without backend leakage;
- tests for queue/detail projection, authorization integration, exact request routing, and storage-value exclusion;
- implementation boundary documentation.

## Explicit exclusions

No Photos parent reviewer UI, review-entry mutation control, Media decision, parent resolution synchronization, canonical mutation, export, publication, deployment, or launch claim.

P5-06B2B2 will add the protected Photos parent queue/detail UI and reuse the merged P5-06B1 review-entry API.

## Migration

None.

## Validation

All normal repository workflows must pass before merge.