### PR TITLE
P6-01: establish launch evidence register and data QA baseline

### DIFF
--- a/.github/workflows/p6-01-launch-evidence-register-data-qa-baseline.yml
+++ b/.github/workflows/p6-01-launch-evidence-register-data-qa-baseline.yml
@@ -1,0 +1,19 @@
+name: P6-01 launch evidence register and data QA baseline
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Run P6-01 launch evidence register audit
+        run: node scripts/check-p6-01-launch-evidence-register-data-qa-baseline.js

--- a/docs/P6_01_LAUNCH_EVIDENCE_REGISTER_DATA_QA_BASELINE.md
+++ b/docs/P6_01_LAUNCH_EVIDENCE_REGISTER_DATA_QA_BASELINE.md
@@ -1,0 +1,84 @@
+# P6-01 — Launch evidence register and data QA baseline
+
+## Decision
+
+Phase 6 begins with an evidence control plane. Repository-complete work is necessary but cannot by itself satisfy a configured launch gate.
+
+Every launch item has one current proof state:
+
+- `unproven`
+- `blocked`
+- `failed`
+- `expired`
+- `passed`
+
+`passed` requires an executed procedure and retained artifact. Documentation presence, implementation presence, or a previously successful unrelated workflow is insufficient.
+
+## Required evidence metadata
+
+Each receipt records:
+
+- evidence id;
+- launch domain;
+- owner;
+- environment;
+- procedure or command;
+- source revision;
+- artifact location and digest;
+- execution timestamp;
+- result;
+- exceptions;
+- expiry or recheck rule.
+
+## Evidence environments
+
+- Repository-executable
+- Configured staging
+- Configured production
+- Manual device
+- Operational drill
+
+Evidence from one environment does not silently satisfy another.
+
+## Launch evidence register
+
+| Domain | Initial owner | Required environment | Initial state | Blocking rule |
+| --- | --- | --- | --- | --- |
+| Data QA | Data operations | Repository-executable plus configured production | unproven | Any orphan, projection leak, count mismatch, or false publication state blocks launch |
+| Legacy export | Migration operations | Configured production | unproven | Missing complete immutable export blocks migration |
+| Migration audit | Migration operations | Configured staging and production | unproven | Unmapped or silently promoted legacy records block cutover |
+| License audit | Data governance | Repository-executable plus manual review | unproven | Missing provenance, rights basis, or attribution blocks affected records |
+| Privacy audit | Privacy operations | Configured staging and production | unproven | Secret leakage, retention mismatch, or unreceipted deletion blocks launch |
+| Mobile QA | Product QA | Manual device | unproven | Critical discovery or contribution flow failure blocks launch |
+| Accessibility QA | Accessibility owner | Repository-executable plus manual assistive technology | unproven | Critical WCAG 2.2 AA flow defect blocks launch |
+| Performance QA | Performance owner | Configured production-like environment | unproven | Severe interaction or loading failure blocks launch |
+| Security QA | Security owner | Configured staging and production | unproven | High-severity unresolved defect blocks launch |
+| Redirects | Migration operations | Configured staging and production | unproven | Broken high-value legacy mapping blocks cutover |
+| Sitemap and robots | Release operations | Configured production | unproven | Candidate/private URLs or invalid canonical indexing blocks launch |
+| Domain cutover | Release lead | Operational drill and configured production | blocked | Cannot pass before all prerequisite gates pass |
+| Backup | Database operations | Configured production | unproven | Missing verified backup blocks launch |
+| Rollback | Release lead | Operational drill | unproven | Unproven rollback blocks cutover |
+| Monitoring | Operations | Configured production | unproven | Missing failure detection and escalation blocks launch |
+
+## Initial data QA baseline
+
+The first data QA execution must prove:
+
+1. Canonical integrity: no orphan public entities, locations, claims, evidence, assets, networks, routes, methods, or media.
+2. Public projection integrity: allowlisted fields only; private fields fail validation; manifests, versions, counts, Stats, and Updates agree.
+3. Provenance and license integrity: public records and media retain source identity, rights basis, and required attribution.
+4. Migration integrity: legacy identities and decisions are auditable; imported candidates remain private until reviewed.
+5. Candidate exclusion: candidates do not appear in map pins, search, generated pages, Stats, Updates, or public exports.
+6. Publication-state consistency: canonical application, export validation, release, and public visibility remain separately receipted; no false public state is permitted.
+
+## Phase 5 preservation
+
+P5-08A through P5-08F remain fixed repository evidence. P6-01 does not weaken or replace them.
+
+## Boundary
+
+This document does not prove production deployment, configured identity, live database execution, object-store behavior, domain ownership, DNS readiness, release activation, retention deletion, rollback success, or launch readiness.
+
+## Next owner
+
+P6-02 owns configured identity-aware access, deployed capability allowlists, and protected Admin journey evidence.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -4,11 +4,11 @@
 
 ## Current phase
 
-Phase 5 — Public submissions / MVP-B final close
+Phase 6 — Launch and cutover evidence
 
 ## Current implementation item
 
-P5-08F — MVP-B final integration close and Phase 6 evidence handoff
+P6-01 — Launch evidence register and data QA baseline
 
 ## Current repository state
 
@@ -42,37 +42,39 @@ P5-08F — MVP-B final integration close and Phase 6 evidence handoff
 - P5-08D — Canonical application and publication-handoff integration audit completed in #271 for Issue #270.
 - P5-08D completed in #271; its fixed audit receipt remains required by later P5-08 slices.
 - P5-08E — Privacy, retention, replay, conflict, and partial-failure integration audit completed in #273 for Issue #272.
-- P5-08F is active in Issue #274 on `p5-08f-mvp-b-final-close-phase6-handoff`.
+- P5-08F — MVP-B final integration close and Phase 6 evidence handoff completed in #275 for Issue #274.
+- Phase 5 is repository-complete.
+- P6-01 is active in Issue #276 on `p6-01-launch-evidence-register-data-qa-baseline`.
 
 ## Latest verified main
 
 ```text
-b99ba72a889b181ab3c61dd98b4fad7d2ab0e8fe
+75ade3eb6acc4b633be26f5943789503d3b1866e
 ```
 
-The final P5-08E head passed Foundation validation, Migration drift, and the retained P5-08A through P5-08E audits before merge.
+The final P5-08F head passed Foundation validation, Migration drift, and the retained P5-08A through P5-08F audits before merge.
 
 ## Active pull request
 
 ```text
-#275 — P5-08F MVP-B final close and Phase 6 evidence handoff
+Pending — P6-01 launch evidence register and data QA baseline
 ```
 
 ## Current boundary
 
-P5-08F closes Phase 5 repository work by retaining all P5-08A through P5-08E audits on one final head and by documenting configured-production evidence that remains unproven.
+P6-01 defines one fail-closed evidence register across data QA, migration, licensing, privacy, mobile, accessibility, performance, security, redirects, indexing, domain cutover, backup, rollback, and monitoring.
 
-It does not activate production export, release, publication, deletion, deployment, DNS, or live data mutation.
+It establishes the repository-executable data QA baseline but does not mark configured-staging, configured-production, manual-device, or operational-drill evidence as passed.
 
 ## Next
 
-Pass normal repository workflows and the dedicated P5-08F audit, merge #275, then begin Phase 6 configured-production evidence collection.
+Pass normal repository workflows and the dedicated P6-01 audit, merge P6-01, then begin P6-02 configured identity-aware access, capability allowlist, and protected Admin journey evidence.
 
 ## Blocked
 
 No repository blocker is known.
 
-Phase 6 remains blocked on configured environments and evidence collection for Cloudflare Access, deployed capability allowlists, protected Admin journeys, live Neon transaction and receipt persistence, R2/Media lifecycle, export/release/restore, publication reconciliation, retention scheduling and deletion receipts, rollback, privacy verification, and restore drills.
+Launch remains blocked until required configured-production, manual-device, and operational-drill evidence is executed and retained. Documentation or repository implementation alone cannot satisfy those gates.
 
 ## Verification rule
 
@@ -80,6 +82,7 @@ Repository reality is determined by current `main`, merged pull requests, actual
 
 ## Current references
 
+- `docs/P6_01_LAUNCH_EVIDENCE_REGISTER_DATA_QA_BASELINE.md`
 - `docs/P5_08A_MVP_B_INTEGRATION_AUDIT_MATRIX.md`
 - `docs/P5_08B_PUBLIC_INTAKE_PRIVATE_STATUS_AUDIT.md`
 - `docs/P5_08C_PROTECTED_REVIEW_FINAL_DECISION_AUDIT.md`
@@ -96,5 +99,6 @@ Repository reality is determined by current `main`, merged pull requests, actual
 - `docs/P5_07E4_BUSINESS_CLAIM_PAYMENT_APPLICATION.md`
 - `docs/P5_07E5_BUSINESS_CLAIM_FIELD_PROVENANCE.md`
 - `docs/P5_07F_PHOTO_MEDIA_RECEIPT_BINDING.md`
-- `docs/SUBMISSION_WORKFLOW.md`
+- `docs/LAUNCH_CRITERIA.md`
+- `docs/MIGRATION_AND_CUTOVER.md`
 - `docs/SECURITY_AND_PRIVACY.md`

--- a/scripts/check-p6-01-launch-evidence-register-data-qa-baseline.js
+++ b/scripts/check-p6-01-launch-evidence-register-data-qa-baseline.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const [doc, status, launchCriteria] = await Promise.all([
+  readFile('docs/P6_01_LAUNCH_EVIDENCE_REGISTER_DATA_QA_BASELINE.md', 'utf8'),
+  readFile('docs/PROJECT_STATUS.md', 'utf8'),
+  readFile('docs/LAUNCH_CRITERIA.md', 'utf8'),
+]);
+
+for (const state of ['unproven', 'blocked', 'failed', 'expired', 'passed']) {
+  assert.ok(doc.includes(`\`${state}\``), `P6-01 audit failed: missing evidence state ${state}`);
+}
+
+for (const environment of [
+  'Repository-executable',
+  'Configured staging',
+  'Configured production',
+  'Manual device',
+  'Operational drill',
+]) {
+  assert.ok(doc.includes(environment), `P6-01 audit failed: missing evidence environment ${environment}`);
+}
+
+for (const domain of [
+  'Data QA',
+  'Legacy export',
+  'Migration audit',
+  'License audit',
+  'Privacy audit',
+  'Mobile QA',
+  'Accessibility QA',
+  'Performance QA',
+  'Security QA',
+  'Redirects',
+  'Sitemap and robots',
+  'Domain cutover',
+  'Backup',
+  'Rollback',
+  'Monitoring',
+]) {
+  assert.ok(doc.includes(`| ${domain} |`), `P6-01 audit failed: missing launch domain ${domain}`);
+}
+
+for (const baseline of [
+  'Canonical integrity',
+  'Public projection integrity',
+  'Provenance and license integrity',
+  'Migration integrity',
+  'Candidate exclusion',
+  'Publication-state consistency',
+]) {
+  assert.ok(doc.includes(baseline), `P6-01 audit failed: missing data QA baseline ${baseline}`);
+}
+
+for (const marker of [
+  'P5-08A',
+  'P5-08B',
+  'P5-08C',
+  'P5-08D',
+  'P5-08E',
+  'P5-08F',
+  'P6-01',
+  'P6-02',
+  'No repository blocker is known.',
+]) {
+  assert.ok(status.includes(marker), `P6-01 audit failed: project status marker missing: ${marker}`);
+}
+
+for (const criterion of [
+  'Quality before volume.',
+  'Candidate records do not appear in:',
+  'public files are generated from explicit allowlisted projections;',
+  'old service remains recoverable through cutover',
+]) {
+  assert.ok(launchCriteria.includes(criterion), `P6-01 audit failed: launch criterion missing: ${criterion}`);
+}
+
+assert.ok(
+  doc.includes('Documentation presence, implementation presence, or a previously successful unrelated workflow is insufficient.'),
+  'P6-01 audit failed: documentation-only pass prohibition missing.',
+);
+
+console.log(JSON.stringify({ audit: 'P6-01', result: 'pass', launchEvidenceRegister: true, dataQaBaseline: true }, null, 2));


### PR DESCRIPTION
## Implementation item

Closes #276.

## Included

- authoritative Phase 6 launch evidence register;
- fail-closed proof states and required evidence metadata;
- repository, staging, production, manual-device, and operational-drill environment separation;
- launch-domain ownership and blocking rules;
- canonical, projection, provenance/license, migration, candidate-exclusion, and publication-state data QA baseline;
- explicit prohibition on documentation-only pass claims;
- dedicated P6-01 executable audit and workflow;
- project status advancement to Phase 6 with P6-02 next.

## Explicit exclusions

No production deployment, live database/object-store mutation, domain or DNS cutover, export/release activation, retention deletion, or launch-readiness claim.