### PR TITLE
OPS-P6-001A: classify configured staging readiness failures

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,14 +10,19 @@ Phase 6 — Launch and cutover evidence
 
 OPS-P6-001 — Configured launch authorization, bounded go-live execution, external verification, observation, and launch close (Issue #293)
 
+## Current operational slice
+
+OPS-P6-001A — Diagnose configured staging readiness failure (Issue #295)
+
 ## Authoritative current state
 
 - P6-08 repository definition work completed in PR #291 for Issue #290.
-- Latest verified main is `46b89747797e06d62e94f8d974fd1ab0d72dfaff`.
-- The P6-08 merge workflows completed successfully, including Foundation validation, Migration drift, retained P5-08 audits, P6-01 through P6-07, and the dedicated P6-08 audit.
-- No product implementation pull request was active when this tracking correction began.
-- FIX-P6-001 is the bounded tracking correction in Issue #292 and PR #294.
-- OPS-P6-001 in Issue #293 owns the next real execution work.
+- FIX-P6-001 tracking reconciliation completed in PR #294 for Issue #292.
+- Latest verified main is `dbc1620be37244657d7882ca163d25855eb338f9`.
+- The fixed-review deployment receipt is bound to that exact main commit.
+- Cloudflare credentials, configured inputs, Durable Object Worker deployment, Pages secret synchronization, and Pages deployment succeeded.
+- Configured verification failed because the bearer-protected readiness endpoint returned HTTP 503 after 18 attempts.
+- OPS-P6-001A in Issue #295 owns bounded failure-stage diagnosis before any staging authorization claim.
 
 Configured state remains:
 
@@ -33,21 +38,23 @@ Repository CI, documentation, provider control-plane success, or an operator ass
 
 ## Next
 
-Execute OPS-P6-001 in Issue #293:
+Execute OPS-P6-001A in Issue #295:
 
-1. reconcile current configured P6-01 through P6-07 receipts against the exact intended commit, immutable release, data snapshot, schema, migration state, environment, domain, and credential generation;
-2. authorize and verify configured staging first;
-3. retain redacted staging evidence for identity/Admin, Neon, R2, publication, DNS/TLS, monitoring, alerts, backup, restore, and rollback readiness;
-4. issue a separate bounded production authorization only after staging evidence is current and accepted;
-5. execute production cutover with named launch, observation, rollback, communications, and incident ownership;
-6. complete external post-cutover verification and the observation window;
-7. retain immutable launch-close evidence before advancing to Phase 7.
+1. preserve 404 behavior for unauthorized readiness requests;
+2. classify only the bearer-authorized readiness failure as `runtime_configuration`, `database`, or `durable_object`;
+3. retain the bounded stage in the configured-verification diagnostic and deployment receipt;
+4. merge after normal repository validation;
+5. inspect the automatically generated fixed-review receipt for the merged main commit;
+6. repair the exact configured dependency and obtain a successful staging receipt;
+7. continue the remaining OPS-P6-001 staging evidence only after readiness succeeds.
+
+Production authorization, DNS cutover, and Phase 7 remain out of scope for this slice.
 
 ## Blocked
 
-No repository-code blocker is known.
+Configured staging authorization is blocked by the current readiness HTTP 503.
 
-Configured launch execution remains blocked until every mandatory predecessor receipt is current and accepted, a bounded authorization is issued, execution occurs, external verification passes, the observation window completes, and launch-close evidence is retained.
+The existing receipt does not distinguish runtime configuration, Neon connectivity, and Durable Object health. OPS-P6-001A adds only a fixed non-secret failure-stage enum after valid bearer authorization so the dependency can be repaired without exposing operational details.
 
 Protected operational credentials and private evidence must not be placed in the public repository or public Issue content.
 
@@ -146,6 +153,8 @@ Repository reality is determined by current `main`, merged pull requests, actual
 ## Current references
 
 - Issue #293 — OPS-P6-001 configured launch execution
+- Issue #295 — OPS-P6-001A configured staging readiness diagnosis
+- `config/staging-review/deployment-receipt.json` on the `staging-review` branch
 - `docs/P6_08_FINAL_LAUNCH_AUTHORIZATION_GO_LIVE_CLOSE_EVIDENCE.md`
 - `docs/P6_07_CONFIGURED_OPERATIONAL_MONITORING_BACKUP_RESTORE_INCIDENT_EVIDENCE.md`
 - `docs/P6_06_CONFIGURED_DOMAIN_CUTOVER_ROLLBACK_EVIDENCE.md`

--- a/functions/api/suggest/readiness.ts
+++ b/functions/api/suggest/readiness.ts
@@ -1,4 +1,5 @@
 import {
+  SuggestConfiguredReadinessError,
   suggestReadinessTokenSchema,
   type SuggestConfiguredReadinessEnvironment,
   verifySuggestConfiguredReadiness,
@@ -51,7 +52,11 @@ export async function onRequestGet(context: SuggestReadinessPagesContext): Promi
   try {
     await verifySuggestConfiguredReadiness(context.env);
     return jsonResponse(200, { ready: true });
-  } catch {
-    return jsonResponse(503, { ready: false });
+  } catch (error) {
+    const failureStage =
+      error instanceof SuggestConfiguredReadinessError
+        ? error.stage
+        : 'runtime_configuration';
+    return jsonResponse(503, { ready: false, failureStage });
   }
 }

--- a/scripts/verify-configured-suggest-review.mjs
+++ b/scripts/verify-configured-suggest-review.mjs
@@ -3,6 +3,11 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const challengeOrigin = 'https://challenges.cloudflare.com';
+const readinessFailureStages = new Set([
+  'runtime_configuration',
+  'database',
+  'durable_object',
+]);
 
 function sleep(milliseconds) {
   return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
@@ -30,11 +35,13 @@ function summarizeConfigResponse(status, parsedBody, expectedSiteKey, expectedAc
 function summarizeReadinessResponse(status, parsedBody) {
   const value = parsedBody.value;
   const objectValue = value !== null && typeof value === 'object' ? value : null;
+  const failureStage = objectValue?.failureStage;
   return {
     httpStatus: status,
     jsonParsed: parsedBody.parsed,
     ready: objectValue?.ready === true,
     errorCode: typeof objectValue?.error === 'string' ? objectValue.error.slice(0, 64) : null,
+    failureStage: readinessFailureStages.has(failureStage) ? failureStage : null,
   };
 }
 

--- a/scripts/verify-configured-suggest-review.mjs
+++ b/scripts/verify-configured-suggest-review.mjs
@@ -3,11 +3,7 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const challengeOrigin = 'https://challenges.cloudflare.com';
-const readinessFailureStages = new Set([
-  'runtime_configuration',
-  'database',
-  'durable_object',
-]);
+const readinessFailureStages = new Set(['runtime_configuration', 'database', 'durable_object']);
 
 function sleep(milliseconds) {
   return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));

--- a/src/submissions/suggest-configured-readiness.ts
+++ b/src/submissions/suggest-configured-readiness.ts
@@ -12,6 +12,16 @@ const durableObjectReadinessResponseSchema = z.object({ status: z.literal('ready
 
 export const suggestReadinessTokenSchema = z.string().min(32).max(512).regex(/^\S+$/);
 
+export const suggestConfiguredReadinessFailureStageSchema = z.enum([
+  'runtime_configuration',
+  'database',
+  'durable_object',
+]);
+
+export type SuggestConfiguredReadinessFailureStage = z.infer<
+  typeof suggestConfiguredReadinessFailureStageSchema
+>;
+
 export type SuggestConfiguredReadinessEnvironment = SuggestHttpEnvironment &
   Readonly<{
     CPM_SUGGEST_READINESS_TOKEN?: unknown;
@@ -23,7 +33,7 @@ export interface SuggestConfiguredReadinessProbes {
 }
 
 export class SuggestConfiguredReadinessError extends Error {
-  constructor() {
+  constructor(readonly stage: SuggestConfiguredReadinessFailureStage) {
     super('Suggest configured environment is unavailable.');
     this.name = 'SuggestConfiguredReadinessError';
   }
@@ -59,6 +69,9 @@ export async function verifySuggestConfiguredReadiness(
   environment: SuggestConfiguredReadinessEnvironment,
   probes: SuggestConfiguredReadinessProbes = {},
 ): Promise<void> {
+  let databaseUrl: string;
+  let rateLimitNamespace: SubmissionRateLimitDurableObjectNamespace;
+
   try {
     createSuggestHttpRuntimeFromEnvironment(environment);
     const databaseEnvironment = requiredDatabaseEnvironmentSchema.parse({
@@ -67,12 +80,21 @@ export async function verifySuggestConfiguredReadiness(
     if (!isDurableObjectNamespace(environment.SUBMISSION_RATE_LIMIT_BUCKETS)) {
       throw new Error('Durable Object namespace binding is unavailable.');
     }
-
-    await (probes.probeDatabase ?? probeDatabase)(databaseEnvironment.DATABASE_URL);
-    await (probes.probeRateLimitProvider ?? probeRateLimitProvider)(
-      environment.SUBMISSION_RATE_LIMIT_BUCKETS,
-    );
+    databaseUrl = databaseEnvironment.DATABASE_URL;
+    rateLimitNamespace = environment.SUBMISSION_RATE_LIMIT_BUCKETS;
   } catch {
-    throw new SuggestConfiguredReadinessError();
+    throw new SuggestConfiguredReadinessError('runtime_configuration');
+  }
+
+  try {
+    await (probes.probeDatabase ?? probeDatabase)(databaseUrl);
+  } catch {
+    throw new SuggestConfiguredReadinessError('database');
+  }
+
+  try {
+    await (probes.probeRateLimitProvider ?? probeRateLimitProvider)(rateLimitNamespace);
+  } catch {
+    throw new SuggestConfiguredReadinessError('durable_object');
   }
 }

--- a/tests/suggest-configured-readiness.test.ts
+++ b/tests/suggest-configured-readiness.test.ts
@@ -55,17 +55,21 @@ describe('P5-02Q configured Suggest readiness', () => {
     expect(probeDatabase).toHaveBeenCalledWith(validEnvironment.DATABASE_URL);
   });
 
-  it('fails closed when the database probe fails', async () => {
+  it('classifies a database probe failure without exposing its detail', async () => {
     await expect(
       verifySuggestConfiguredReadiness(validEnvironment, {
         probeDatabase: async () => {
           throw new Error('database detail');
         },
       }),
-    ).rejects.toThrow(SuggestConfiguredReadinessError);
+    ).rejects.toMatchObject({
+      name: 'SuggestConfiguredReadinessError',
+      message: 'Suggest configured environment is unavailable.',
+      stage: 'database',
+    });
   });
 
-  it('fails closed when the DO worker health response is malformed', async () => {
+  it('classifies a malformed DO worker health response', async () => {
     await expect(
       verifySuggestConfiguredReadiness(
         {
@@ -76,10 +80,14 @@ describe('P5-02Q configured Suggest readiness', () => {
         },
         { probeDatabase: async () => {} },
       ),
-    ).rejects.toThrow('Suggest configured environment is unavailable.');
+    ).rejects.toMatchObject({
+      name: 'SuggestConfiguredReadinessError',
+      message: 'Suggest configured environment is unavailable.',
+      stage: 'durable_object',
+    });
   });
 
-  it('fails closed when any required route configuration is missing', async () => {
+  it('classifies missing required route configuration', async () => {
     await expect(
       verifySuggestConfiguredReadiness(
         {
@@ -88,6 +96,14 @@ describe('P5-02Q configured Suggest readiness', () => {
         },
         { probeDatabase: async () => {} },
       ),
-    ).rejects.toThrow(SuggestConfiguredReadinessError);
+    ).rejects.toMatchObject({
+      name: 'SuggestConfiguredReadinessError',
+      message: 'Suggest configured environment is unavailable.',
+      stage: 'runtime_configuration',
+    });
+  });
+
+  it('keeps the exported error type available to callers', () => {
+    expect(new SuggestConfiguredReadinessError('database')).toBeInstanceOf(Error);
   });
 });

--- a/tests/suggest-readiness-route.test.ts
+++ b/tests/suggest-readiness-route.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { onRequestGet } from '../functions/api/suggest/readiness';
+import type { SuggestConfiguredReadinessEnvironment } from '../src/submissions/suggest-configured-readiness';
+
+const readinessToken = 'R'.repeat(48);
+
+function createContext(authorization: string, env: SuggestConfiguredReadinessEnvironment) {
+  return {
+    request: new Request('https://review.example.test/api/suggest/readiness', {
+      headers: { Authorization: authorization },
+    }),
+    env,
+  };
+}
+
+describe('configured Suggest readiness route', () => {
+  it('keeps unauthorized readiness diagnostics hidden behind 404', async () => {
+    const response = await onRequestGet(
+      createContext('Bearer wrong-token', {
+        CPM_SUGGEST_READINESS_TOKEN: readinessToken,
+      } as SuggestConfiguredReadinessEnvironment),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'not_found' });
+  });
+
+  it('returns only a bounded failure stage after valid bearer authorization', async () => {
+    const response = await onRequestGet(
+      createContext('Bearer ' + readinessToken, {
+        CPM_SUGGEST_READINESS_TOKEN: readinessToken,
+      } as SuggestConfiguredReadinessEnvironment),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      ready: false,
+      failureStage: 'runtime_configuration',
+    });
+  });
+});


### PR DESCRIPTION
## Operational slice

OPS-P6-001A — Diagnose configured staging readiness failure

Closes #295.

## Evidence

The fixed-review receipt for current main `dbc1620be37244657d7882ca163d25855eb338f9` shows successful credentials, configured inputs, Durable Object Worker deployment, Pages secret synchronization, and Pages deployment. Configured verification failed because the authenticated readiness endpoint returned HTTP 503 for all 18 attempts.

## Root cause addressed by this PR

The current route collapses runtime configuration, Neon connectivity, and Durable Object health failures into the same `{ ready: false }` response. The deployment receipt therefore cannot identify the failed configured dependency.

## Changes

- classify configured readiness failures as exactly one of `runtime_configuration`, `database`, or `durable_object`;
- keep the public/unauthorized readiness surface unchanged at HTTP 404;
- return the fixed failure-stage enum only after valid bearer authorization;
- retain the fixed enum in the configured verification diagnostic and deployment receipt;
- add focused core and route tests;
- update `PROJECT_STATUS.md` with the exact current main receipt and blocker while retaining historical audit markers.

## Security boundary

No exception message, stack trace, credential, database URL, provider identifier, binding content, object identity, SQL detail, or unrestricted log is returned. Only the fixed enum is exposed to a correctly authenticated readiness request.

## Validation

Normal repository CI must pass. After merge, the existing `Staging review deploy` workflow will run on the new main commit and publish a new exact-commit receipt to the `staging-review` branch.

## Next

Inspect the new receipt. Repair the exact classified dependency, obtain `status: deployed`, and only then continue configured staging authorization under Issue #293. Production authorization and DNS cutover remain out of scope.