### PR TITLE
FIX-P6-005: generate an explicit static 404 page

### DIFF
--- a/.github/workflows/ops-p6-001i-configured-staging-p6-05-public-export-release.yml
+++ b/.github/workflows/ops-p6-001i-configured-staging-p6-05-public-export-release.yml
@@ -14,6 +14,7 @@ on:
       - 'src/admin/export-release/**'
       - 'src/publication/**'
       - 'src/schemas/public-exports.ts'
+      - 'src/pages/404.astro'
   push:
     branches:
       - main
@@ -29,6 +30,7 @@ on:
       - 'src/admin/export-release/**'
       - 'src/publication/**'
       - 'src/schemas/public-exports.ts'
+      - 'src/pages/404.astro'
   workflow_dispatch:
     inputs:
       confirmation:

--- a/docs/OPS_P6_001I_CONFIGURED_STAGING_P6_05_PUBLIC_EXPORT_RELEASE.md
+++ b/docs/OPS_P6_001I_CONFIGURED_STAGING_P6_05_PUBLIC_EXPORT_RELEASE.md
@@ -38,6 +38,8 @@ The existing `review` deployment remains a preview deployment. It is not treated
 
 The executor runs the complete staging-review build twice from one exact commit. Both builds must pass the existing schema, provenance, license, privacy, accessibility, route, Media, and staging-artifact validators and must produce the same public tree digest.
 
+The static artifact must contain a top-level `404.html` generated from `src/pages/404.astro`. Without that file, Cloudflare Pages applies single-page-application fallback behavior and returns the home document with HTTP 200 for unknown navigation routes. P6-05 requires an unknown route to return HTTP 404 with an HTML error page.
+
 The baseline and candidate deployment trees contain the same validated public projection. They differ only by `/p6-05-release.json`, a bounded configured-staging release marker used to distinguish active deployment identity externally. The marker contains no credential, private payload, canonical record, contact, object key, or unrestricted provider identifier.
 
 ## Release sequence

--- a/scripts/check-ops-p6-001i-configured-staging-public-export-release.mjs
+++ b/scripts/check-ops-p6-001i-configured-staging-public-export-release.mjs
@@ -20,6 +20,7 @@ const files = {
   deployment: readFileSync('.github/workflows/staging-review-deploy.yml', 'utf8'),
   publication: readFileSync('src/admin/export-release/publication-contract.ts', 'utf8'),
   activation: readFileSync('src/admin/export-release/activation-r2.ts', 'utf8'),
+  notFoundPage: readFileSync('src/pages/404.astro', 'utf8'),
 };
 
 const expectations = [
@@ -28,10 +29,12 @@ const expectations = [
   [files.workflow, 'Enforce configured P6-05 acceptance'],
   [files.workflow, 'CLOUDFLARE_API_TOKEN'],
   [files.workflow, 'CLOUDFLARE_ACCOUNT_ID'],
+  [files.workflow, "'src/pages/404.astro'"],
   [files.procedure, 'production branch: `staging-review`'],
   [files.procedure, 'exact project platform hostname: `cryptopaymap-staging.pages.dev`'],
   [files.procedure, 'Every other hostname remains disallowed and fails closed.'],
   [files.procedure, 'Preview deployments are never rollback targets.'],
+  [files.procedure, 'top-level `404.html`'],
   [files.procedure, 'Leave the exact candidate active'],
   [files.executor, "const exactConfirmation = 'EXECUTE_CONFIGURED_STAGING_P6_05'"],
   [files.executor, "const productionBranch = 'staging-review'"],
@@ -46,8 +49,11 @@ const expectations = [
   [files.executor, 'projectDomains.filter((domain) => domain !== platformDomain)'],
   [files.executor, 'platformDomainPresent: false'],
   [files.executor, 'platformDomainMatches: false'],
+  [files.executor, "['/__p6_05_missing__', 404, 'text/html']"],
   [files.executor, 'candidateRestored: true'],
   [files.executor, "activeKind: 'candidate'"],
+  [files.notFoundPage, "import BaseLayout from '../layouts/BaseLayout.astro'"],
+  [files.notFoundPage, 'Page not found'],
   [
     files.repositoryContract,
     'P6-05 configured public export and release evidence contract passed.',

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,35 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Page not found | CryptoPayMap"
+  description="The requested CryptoPayMap page could not be found."
+>
+  <section class="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-16 sm:px-6 lg:px-8">
+    <div class="w-full rounded-[var(--radius-card)] border border-slate-200 bg-white p-6 shadow-sm sm:p-10">
+      <p class="text-sm font-semibold uppercase tracking-[0.18em] text-teal-700">404</p>
+      <h1 class="mt-3 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+        Page not found
+      </h1>
+      <p class="mt-4 max-w-2xl text-base leading-7 text-slate-600">
+        The page may have moved, or the address may be incorrect. Use one of the links below to
+        continue browsing reviewed cryptocurrency payment information.
+      </p>
+      <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+        <a
+          href="/"
+          class="inline-flex min-h-11 items-center justify-center rounded-[var(--radius-button)] bg-teal-700 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-teal-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-700"
+        >
+          Return home
+        </a>
+        <a
+          href="/places"
+          class="inline-flex min-h-11 items-center justify-center rounded-[var(--radius-button)] border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-800 transition hover:bg-slate-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-700"
+        >
+          Browse places
+        </a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
Fixes #326 within #319 and #293.

## Scope

- adds an accessible Astro `404.astro` page so the static artifact contains top-level `404.html`;
- preserves the P6-05 requirement that unknown navigation routes return HTTP 404 and HTML;
- adds the 404 page to the P6-05 workflow path filters;
- extends the configured execution contract so removal of the 404 page or weakening of the 404 probe fails CI;
- documents why Cloudflare Pages must not infer SPA fallback behavior for this static site.

## Failure boundary

The preceding configured P6-05 run passed exact-main checks, predecessor binding, deterministic generation, artifact validation, safe topology, release creation, and candidate activation. It failed closed before rollback because an unknown route returned HTTP 200 through Pages SPA fallback.

## Safety

No production CryptoPayMap domain, DNS, custom domain, canonical data, private material, release activation, or rollback is changed by this PR. After merge, exact-main configured evidence must be refreshed before P6-05 is executed again.