### PR TITLE
OPS: execute exact-main P6-07 Q2 monitoring evidence

### DIFF
--- a/.github/workflows/one-time-p6-07-q2-dispatch.yml
+++ b/.github/workflows/one-time-p6-07-q2-dispatch.yml
@@ -1,0 +1,80 @@
+name: One-time P6-07 Q2 exact-main dispatch
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/one-time-p6-07-q2-dispatch.yml'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      APPROVED_COMMIT: fccedfa7a5169abda0d0a3d8475eeb0aaa9da72d
+    steps:
+      - name: Dispatch Q2 and wait
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='ops-p6-001u-configured-staging-p6-07-monitoring-alert.yml'
+          marker="$(date -u +%s)"
+          payload="$(jq -nc \
+            --arg ref main \
+            --arg confirmation EXECUTE_CONFIGURED_STAGING_P6_07_Q2 \
+            --arg approved_commit "$APPROVED_COMMIT" \
+            --arg monitoring_owner badjoke-lab \
+            '{ref:$ref,inputs:{confirmation:$confirmation,approved_commit:$approved_commit,monitoring_owner:$monitoring_owner}}')"
+          code="$(curl --silent --show-error --output /tmp/dispatch-response --write-out '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/$REPOSITORY/actions/workflows/$workflow/dispatches" \
+            -d "$payload")"
+          if [ "$code" != '204' ]; then
+            cat /tmp/dispatch-response
+            echo "Q2 dispatch failed with HTTP $code" >&2
+            exit 1
+          fi
+
+          run_id=''
+          for _ in $(seq 1 90); do
+            sleep 5
+            runs="$(curl --fail --silent --show-error \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/$REPOSITORY/actions/workflows/$workflow/runs?event=workflow_dispatch&branch=main&per_page=20")"
+            run_id="$(jq -r --arg sha "$APPROVED_COMMIT" --argjson marker "$marker" '
+              [.workflow_runs[] | select(.head_sha == $sha and ((.created_at | fromdateiso8601) >= ($marker - 5)))]
+              | sort_by(.created_at) | last | .id // empty
+            ' <<<"$runs")"
+            [ -n "$run_id" ] && break
+          done
+          [ -n "$run_id" ] || { echo 'Could not locate Q2 run.' >&2; exit 1; }
+          echo "Tracking Q2 run $run_id"
+
+          for _ in $(seq 1 360); do
+            run="$(curl --fail --silent --show-error \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/$REPOSITORY/actions/runs/$run_id")"
+            status="$(jq -r '.status' <<<"$run")"
+            conclusion="$(jq -r '.conclusion // empty' <<<"$run")"
+            if [ "$status" = completed ]; then
+              [ "$conclusion" = success ] || { echo "Q2 run $run_id ended $conclusion" >&2; exit 1; }
+              echo "Q2 run $run_id succeeded"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Timed out waiting for Q2 run $run_id" >&2
+          exit 1


### PR DESCRIPTION
Temporary one-time dispatcher for Issue #349. It pins Q2 monitoring/alert evidence to exact main `fccedfa7a5169abda0d0a3d8475eeb0aaa9da72d`. Current Q1 is `configuration_blocked` only by the two blockers explicitly allowed by the Q2 contract: backup encryption and isolated restore database. No backup, restore, production authorization, DNS mutation, or production cutover is in scope. This PR must not be merged.