### PR TITLE
OPS: bootstrap isolated P6-07 restore target

### DIFF
--- a/.github/workflows/one-time-p6-07-restore-target-bootstrap.yml
+++ b/.github/workflows/one-time-p6-07-restore-target-bootstrap.yml
@@ -1,0 +1,68 @@
+name: One-time P6-07 isolated restore target bootstrap
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/one-time-p6-07-restore-target-bootstrap.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      TARGET_DB: cpm_p6_07_restore_20260808
+    steps:
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update >/dev/null
+          sudo apt-get install --yes postgresql-client >/dev/null
+
+      - name: Validate protected source configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$DATABASE_URL"
+          node <<'NODE'
+          const value = process.env.DATABASE_URL;
+          const url = new URL(value);
+          if (!['postgres:', 'postgresql:'].includes(url.protocol)) process.exit(1);
+          if (!url.hostname || !url.pathname.slice(1)) process.exit(1);
+          NODE
+
+      - name: Create isolated empty database if absent
+        shell: bash
+        run: |
+          set -euo pipefail
+          exists="$(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atqc "SELECT 1 FROM pg_database WHERE datname = '$TARGET_DB'" 2>/dev/null || true)"
+          if [ "$exists" != '1' ]; then
+            if ! psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE DATABASE $TARGET_DB" >/dev/null 2>/dev/null; then
+              echo 'isolated_restore_database_create_failed' >&2
+              exit 1
+            fi
+          fi
+
+      - name: Verify isolated target identity and emptiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs');
+          const url = new URL(process.env.DATABASE_URL);
+          url.pathname = `/${process.env.TARGET_DB}`;
+          const value = url.toString();
+          fs.appendFileSync(process.env.GITHUB_ENV, `RESTORE_BOOTSTRAP_URL=${value}\n`);
+          NODE
+          if ! actual="$(psql "$RESTORE_BOOTSTRAP_URL" -v ON_ERROR_STOP=1 -Atqc 'SELECT current_database()' 2>/dev/null)"; then
+            echo 'isolated_restore_database_connect_failed' >&2
+            exit 1
+          fi
+          test "$actual" = "$TARGET_DB"
+          count="$(psql "$RESTORE_BOOTSTRAP_URL" -v ON_ERROR_STOP=1 -Atqc "SELECT count(*) FROM information_schema.tables WHERE table_schema NOT IN ('pg_catalog','information_schema')" 2>/dev/null)"
+          test "$count" = '0'
+          echo 'isolated_restore_database_ready=true'
+          echo "isolated_restore_database_name=$TARGET_DB"

--- a/.github/workflows/one-time-p6-07-restore-target-bootstrap.yml
+++ b/.github/workflows/one-time-p6-07-restore-target-bootstrap.yml
@@ -50,13 +50,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node <<'NODE'
-          const fs = require('node:fs');
+          RESTORE_BOOTSTRAP_URL="$(node <<'NODE'
           const url = new URL(process.env.DATABASE_URL);
           url.pathname = `/${process.env.TARGET_DB}`;
-          const value = url.toString();
-          fs.appendFileSync(process.env.GITHUB_ENV, `RESTORE_BOOTSTRAP_URL=${value}\n`);
+          process.stdout.write(url.toString());
           NODE
+          )"
+          export RESTORE_BOOTSTRAP_URL
           if ! actual="$(psql "$RESTORE_BOOTSTRAP_URL" -v ON_ERROR_STOP=1 -Atqc 'SELECT current_database()' 2>/dev/null)"; then
             echo 'isolated_restore_database_connect_failed' >&2
             exit 1


### PR DESCRIPTION
Temporary one-time staging configuration action for Issue #349. It uses the existing protected `DATABASE_URL` only inside Actions to create or reuse the empty isolated database `cpm_p6_07_restore_20260808`, then verifies the target identity and that it contains no user tables. No database URL, password, host identifier, or credential is written to the repository or issue. No canonical source table is modified. This PR must not be merged.