### PR TITLE
OPS: execute exact-main P6-07 Q3 through Q5 on fc77

### DIFF
--- a/.github/workflows/one-time-p6-07-q3-q5-dispatch-fc77.yml
+++ b/.github/workflows/one-time-p6-07-q3-q5-dispatch-fc77.yml
@@ -1,0 +1,182 @@
+name: One-time P6-07 Q3-Q5 exact-main dispatcher fc77
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/one-time-p6-07-q3-q5-dispatch-fc77.yml'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    env:
+      APPROVED_COMMIT: fc77f588c2897d63409067e10ce3c39b6fc2c60a
+      RESTORE_TARGET_DATABASE_NAME: cpm_p6_07_restore_20260808
+    steps:
+      - name: Execute exact-main Q3 through Q5 serially
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const owner = 'badjoke-lab';
+          const repo = 'cryptopaymap';
+          const sha = process.env.APPROVED_COMMIT;
+          const restoreTarget = process.env.RESTORE_TARGET_DATABASE_NAME;
+          const token = process.env.GH_TOKEN;
+          const apiBase = 'https://api.github.com';
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+          async function api(path, options = {}) {
+            const response = await fetch(`${apiBase}${path}`, {
+              ...options,
+              headers: {
+                Accept: 'application/vnd.github+json',
+                Authorization: `Bearer ${token}`,
+                'X-GitHub-Api-Version': '2022-11-28',
+                ...(options.headers || {}),
+              },
+            });
+            if (!response.ok) {
+              const body = await response.text();
+              throw new Error(`github_api_${response.status}:${body.slice(0, 500)}`);
+            }
+            if (response.status === 204) return null;
+            return response.json();
+          }
+
+          async function readStatusJson(path) {
+            const value = await api(`/repos/${owner}/${repo}/contents/${path}?ref=staging-review`);
+            return JSON.parse(Buffer.from(value.content, 'base64').toString('utf8'));
+          }
+
+          async function dispatchAndWait(workflow, inputs, timeoutMinutes) {
+            const encoded = encodeURIComponent(workflow);
+            const before = await api(`/repos/${owner}/${repo}/actions/workflows/${encoded}/runs?event=workflow_dispatch&branch=main&per_page=30`);
+            const beforeIds = new Set(before.workflow_runs.map((run) => run.id));
+            const startedAt = Date.now();
+            await api(`/repos/${owner}/${repo}/actions/workflows/${encoded}/dispatches`, {
+              method: 'POST',
+              body: JSON.stringify({ ref: 'main', inputs }),
+              headers: { 'Content-Type': 'application/json' },
+            });
+
+            let run = null;
+            for (let attempt = 0; attempt < 60; attempt += 1) {
+              await sleep(5000);
+              const listed = await api(`/repos/${owner}/${repo}/actions/workflows/${encoded}/runs?event=workflow_dispatch&branch=main&per_page=30`);
+              run = listed.workflow_runs.find(
+                (candidate) =>
+                  !beforeIds.has(candidate.id) &&
+                  candidate.head_sha === sha &&
+                  Date.parse(candidate.created_at) >= startedAt - 10000,
+              );
+              if (run) break;
+            }
+            if (!run) throw new Error(`workflow_run_not_found:${workflow}`);
+            console.log(`${workflow}:run_id=${run.id}`);
+
+            const deadline = Date.now() + timeoutMinutes * 60 * 1000;
+            while (Date.now() < deadline) {
+              const current = await api(`/repos/${owner}/${repo}/actions/runs/${run.id}`);
+              if (current.status === 'completed') {
+                if (current.conclusion !== 'success') {
+                  throw new Error(`workflow_failed:${workflow}:run_id=${run.id}:conclusion=${current.conclusion}`);
+                }
+                console.log(`${workflow}:success:run_id=${run.id}`);
+                return run.id;
+              }
+              await sleep(10000);
+            }
+            throw new Error(`workflow_timeout:${workflow}:run_id=${run.id}`);
+          }
+
+          const main = await api(`/repos/${owner}/${repo}/commits/main`);
+          if (main.sha !== sha) throw new Error(`main_changed:${main.sha}`);
+
+          const q1 = await readStatusJson('config/staging-authorization/p6-07-prerequisite-diagnostic.json');
+          if (
+            q1.commit !== sha ||
+            q1.state !== 'diagnosed' ||
+            q1.decision !== 'ready' ||
+            q1.blockers?.length !== 0 ||
+            q1.exceptions?.length !== 0
+          ) throw new Error('q1_not_ready');
+
+          const q2 = await readStatusJson('config/staging-authorization/p6-07-monitoring-alert-receipt.json');
+          if (
+            q2.commit !== sha ||
+            q2.state !== 'accepted' ||
+            q2.checks?.alertExercise?.status !== 'passed' ||
+            q2.exceptions?.length !== 0
+          ) throw new Error('q2_not_accepted');
+          console.log(`Q2:accepted:run_id=${q2.workflowRunId}`);
+
+          await dispatchAndWait(
+            'ops-p6-001y-configured-staging-p6-07-backup-integrity.yml',
+            {
+              confirmation: 'EXECUTE_CONFIGURED_STAGING_P6_07_Q3',
+              approved_commit: sha,
+              backup_owner: 'badjoke-lab',
+            },
+            45,
+          );
+          const q3 = await readStatusJson('config/staging-authorization/p6-07-backup-integrity-receipt.json');
+          if (q3.commit !== sha || q3.state !== 'accepted' || q3.exceptions?.length !== 0) {
+            throw new Error(`q3_not_accepted:${q3.state}`);
+          }
+          console.log(`Q3:accepted:run_id=${q3.workflowRunId}`);
+
+          await dispatchAndWait(
+            'ops-p6-002a-configured-staging-p6-07-isolated-restore.yml',
+            {
+              confirmation: 'EXECUTE_CONFIGURED_STAGING_P6_07_Q4',
+              approved_commit: sha,
+              restore_owner: 'badjoke-lab',
+              restore_target_database_name: restoreTarget,
+              rpo_objective_minutes: '60',
+              rto_objective_minutes: '30',
+            },
+            60,
+          );
+          const q4 = await readStatusJson('config/staging-authorization/p6-07-isolated-restore-receipt.json');
+          if (q4.commit !== sha || q4.state !== 'accepted' || q4.exceptions?.length !== 0) {
+            throw new Error(`q4_not_accepted:${q4.state}`);
+          }
+          console.log(`Q4:accepted:run_id=${q4.workflowRunId}`);
+
+          await dispatchAndWait(
+            'ops-p6-002b-configured-staging-p6-07-incident-exercise-final-receipt.yml',
+            {
+              confirmation: 'EXECUTE_CONFIGURED_STAGING_P6_07_Q5',
+              approved_commit: sha,
+              incident_id: 'cpm-p6-07-q5-20260809-fc77f588',
+              command_owner: 'badjoke-lab:q5-command',
+              observer: 'badjoke-lab:q5-observer',
+              follow_up_owner: 'badjoke-lab:q5-follow-up',
+              incident_scenario: 'canonical_database_degradation',
+              incident_severity: 'exercise_high',
+              acknowledgement_objective_minutes: '15',
+              decision_objective_minutes: '30',
+              recovery_objective_minutes: '45',
+              status_cadence_minutes: '15',
+            },
+            45,
+          );
+          const q5 = await readStatusJson('config/staging-authorization/p6-07-operations-recovery-receipt.json');
+          if (q5.commit !== sha || q5.state !== 'accepted' || q5.exceptions?.length !== 0) {
+            throw new Error(`q5_not_accepted:${q5.state}`);
+          }
+          const inventory = await readStatusJson('config/staging-authorization/authorization-receipt.json');
+          const p607 = inventory.checks?.predecessors?.find((item) => item.evidenceId === 'P6-07');
+          if (p607?.state !== 'current' || inventory.mode !== 'inventory' || inventory.state !== 'not_authorized') {
+            throw new Error('final_inventory_invalid');
+          }
+          console.log(`Q5:accepted:run_id=${q5.workflowRunId}`);
+          console.log('P6-07:current; production authorization remains not authorized');
+          NODE


### PR DESCRIPTION
Temporary one-time dispatcher for Issue #349 after Q1 and Q2 are accepted on exact main `fc77f588c2897d63409067e10ce3c39b6fc2c60a`. It first revalidates Q1 ready and Q2 accepted, then serially executes Q3 encrypted backup integrity, Q4 isolated restore into `cpm_p6_07_restore_20260808` with explicit RPO 60m / RTO 30m, and Q5 bounded incident exercise/final receipt. Each stage must publish an accepted zero-exception receipt before the next begins. Final inventory must list P6-07 current while production remains `not_authorized`. Must not be merged.