### PR TITLE
OPS: authorize configured staging on exact main 5875b2

### DIFF
--- a/.github/workflows/one-time-configured-staging-authorize-5875b2.yml
+++ b/.github/workflows/one-time-configured-staging-authorize-5875b2.yml
@@ -1,0 +1,106 @@
+name: One-time configured staging authorization 5875b2
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/one-time-configured-staging-authorize-5875b2.yml'
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cpm-configured-staging-authorize-5875b2
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      APPROVED_COMMIT: 5875b2d8cef9f01015434888beb487cd448bc266
+    steps:
+      - name: Authorize configured staging on exact main
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          api_get() {
+            curl --fail --silent --show-error \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/$REPO/$1"
+          }
+
+          api_post() {
+            local endpoint="$1" payload="$2"
+            curl --fail --silent --show-error -X POST \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/$REPO/$endpoint" \
+              -d "$payload"
+          }
+
+          status_json() {
+            api_get "contents/$1?ref=staging-review" | jq -r '.content' | base64 -d
+          }
+
+          assert_main() {
+            test "$(api_get commits/main | jq -r .sha)" = "$APPROVED_COMMIT"
+          }
+
+          assert_main
+          before="$(api_get 'actions/workflows/ops-p6-001c-configured-staging-authorization.yml/runs?event=workflow_dispatch&branch=main&per_page=1' | jq -r '.workflow_runs[0].id // empty')"
+
+          inventory="$(status_json 'config/staging-authorization/authorization-receipt.json')"
+          test "$(jq -r .approvedCommit <<<"$inventory")" = "$APPROVED_COMMIT"
+          test "$(jq -r .mode <<<"$inventory")" = inventory
+          test "$(jq -r .state <<<"$inventory")" = not_authorized
+          test "$(jq -r .checks.predecessorBinding <<<"$inventory")" = matched
+          test "$(jq '[.checks.predecessors[] | select(.state == "current")] | length' <<<"$inventory")" = 7
+          test "$(jq '[.blockers[] | select(. == "explicit_dispatch:required")] | length' <<<"$inventory")" = 1
+
+          payload="$(jq -nc \
+            --arg ref main \
+            --arg confirmation AUTHORIZE_CONFIGURED_STAGING \
+            --arg approved_commit "$APPROVED_COMMIT" \
+            --arg launch_owner badjoke-lab \
+            --arg observer cpm-staging-independent-observer \
+            --arg rollback_owner badjoke-lab \
+            '{ref:$ref,inputs:{confirmation:$confirmation,approved_commit:$approved_commit,launch_owner:$launch_owner,observer:$observer,rollback_owner:$rollback_owner}}')"
+          api_post 'actions/workflows/ops-p6-001c-configured-staging-authorization.yml/dispatches' "$payload" >/dev/null
+
+          run_id=''
+          for _ in $(seq 1 90); do
+            sleep 5
+            run_id="$(api_get 'actions/workflows/ops-p6-001c-configured-staging-authorization.yml/runs?event=workflow_dispatch&branch=main&per_page=10' | jq -r --arg sha "$APPROVED_COMMIT" --arg before "$before" '[.workflow_runs[] | select(.head_sha == $sha and (.id|tostring) != $before)] | sort_by(.created_at) | last | .id // empty')"
+            [ -n "$run_id" ] && break
+          done
+          [ -n "$run_id" ]
+          echo "Tracking configured staging authorization run $run_id"
+
+          for _ in $(seq 1 360); do
+            run="$(api_get "actions/runs/$run_id")"
+            status="$(jq -r .status <<<"$run")"
+            conclusion="$(jq -r '.conclusion // empty' <<<"$run")"
+            if [ "$status" = completed ]; then
+              [ "$conclusion" = success ] || { echo "authorization run $run_id ended $conclusion" >&2; exit 1; }
+              break
+            fi
+            sleep 10
+          done
+
+          receipt="$(status_json 'config/staging-authorization/authorization-receipt.json')"
+          test "$(jq -r .approvedCommit <<<"$receipt")" = "$APPROVED_COMMIT"
+          test "$(jq -r .mode <<<"$receipt")" = authorization
+          test "$(jq -r .state <<<"$receipt")" = authorized
+          test "$(jq -r .checks.predecessorBinding <<<"$receipt")" = matched
+          test "$(jq '[.checks.predecessors[] | select(.state == "current")] | length' <<<"$receipt")" = 7
+          test "$(jq '.blockers | length' <<<"$receipt")" = 0
+          assert_main
+          echo "Configured staging authorized on exact main $APPROVED_COMMIT; production remains untouched."


### PR DESCRIPTION
Temporary one-time dispatcher for Issue #293. It verifies the current exact-main P6-01 through P6-07 inventory, then explicitly dispatches `AUTHORIZE_CONFIGURED_STAGING` for main `5875b2d8cef9f01015434888beb487cd448bc266` and requires an `authorized` configured-staging receipt with zero blockers. It does not authorize production, mutate production DNS, or execute production cutover. MUST NOT MERGE.