### PR TITLE
OPS-P6-024: guard protected production readiness secret scope

### DIFF
--- a/.github/workflows/ops-p6-013-configured-production-readiness-diagnostic.yml
+++ b/.github/workflows/ops-p6-013-configured-production-readiness-diagnostic.yml
@@ -23,6 +23,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: write
 
 concurrency:

--- a/.github/workflows/ops-p6-013-configured-production-readiness-diagnostic.yml
+++ b/.github/workflows/ops-p6-013-configured-production-readiness-diagnostic.yml
@@ -54,9 +54,171 @@ jobs:
       - name: Run production readiness diagnostic self-test
         run: node scripts/run-ops-p6-013-production-readiness-diagnostic.mjs --self-test
 
-  diagnose:
+  production_environment_probe:
     if: github.event_name == 'workflow_dispatch'
     needs: contract
+    runs-on: ubuntu-24.04
+    outputs:
+      production_environment_status: ${{ steps.production_environment.outputs.production_environment_status }}
+      production_environment_protection_count: ${{ steps.production_environment.outputs.production_environment_protection_count }}
+    steps:
+      - name: Inspect GitHub production environment read-only before any environment binding
+        id: production_environment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from 'node:fs';
+          const repository = process.env.GITHUB_REPOSITORY;
+          const token = process.env.GH_TOKEN;
+          const output = process.env.GITHUB_OUTPUT;
+          const response = await fetch(`https://api.github.com/repos/${repository}/environments/production`, {
+            method: 'GET',
+            headers: {
+              Accept: 'application/vnd.github+json',
+              Authorization: `Bearer ${token}`,
+              'X-GitHub-Api-Version': '2022-11-28',
+            },
+          });
+          let status = 'missing';
+          let protectionCount = 0;
+          if (response.status === 200) {
+            const payload = await response.json();
+            status = 'present';
+            protectionCount = Array.isArray(payload?.protection_rules) ? payload.protection_rules.length : 0;
+          } else if (response.status !== 404) {
+            console.error(`production_environment_probe_failed:${response.status}`);
+            process.exit(1);
+          }
+          appendFileSync(output, `production_environment_status=${status}\n`);
+          appendFileSync(output, `production_environment_protection_count=${protectionCount}\n`);
+          NODE
+
+  diagnose_blocked_environment:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      (needs.production_environment_probe.outputs.production_environment_status != 'present' ||
+      needs.production_environment_probe.outputs.production_environment_protection_count == '0')
+    needs: [contract, production_environment_probe]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      APPROVED_COMMIT: ${{ inputs.approved_commit }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      READINESS_OWNER: ${{ inputs.readiness_owner }}
+      WORKFLOW_RUN_ID: ${{ github.run_id }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Check out evaluated source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.approved_commit }}
+          path: source
+
+      - name: Check out retained status branch
+        uses: actions/checkout@v4
+        with:
+          ref: staging-review
+          path: status
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: source/package-lock.json
+
+      - name: Install locked dependencies
+        working-directory: source
+        run: npm ci
+
+      - name: Verify exact current main
+        run: |
+          set -euo pipefail
+          git -C source fetch origin main --depth=1
+          current_main_commit="$(git -C source rev-parse origin/main)"
+          test "$current_main_commit" = "$APPROVED_COMMIT"
+
+      - name: Recheck exact-source repository contract
+        id: repository_contract
+        continue-on-error: true
+        working-directory: source
+        run: |
+          npm run check
+          node scripts/check-ops-p6-013-production-readiness-diagnostic.mjs
+          node scripts/run-ops-p6-013-production-readiness-diagnostic.mjs --self-test
+
+      - name: Execute blocked read-only configured production readiness diagnostic
+        env:
+          REPOSITORY_CONTRACT_OUTCOME: ${{ steps.repository_contract.outcome }}
+          PRODUCTION_ENVIRONMENT_STATUS: ${{ needs.production_environment_probe.outputs.production_environment_status }}
+          PRODUCTION_ENVIRONMENT_PROTECTION_COUNT: ${{ needs.production_environment_probe.outputs.production_environment_protection_count }}
+        working-directory: source
+        run: |
+          node scripts/run-ops-p6-013-production-readiness-diagnostic.mjs \
+            ../status \
+            ../production-readiness-diagnostic.json
+
+      - name: Upload bounded production readiness diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ops-p6-013-configured-production-readiness-diagnostic
+          path: production-readiness-diagnostic.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish production readiness diagnostic to status branch
+        if: always()
+        run: |
+          set -euo pipefail
+          test -f production-readiness-diagnostic.json
+          mkdir -p status/config/production-authorization
+          cp production-readiness-diagnostic.json \
+            status/config/production-authorization/readiness-diagnostic.json
+          git -C status config user.name 'github-actions[bot]'
+          git -C status config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git -C status add config/production-authorization/readiness-diagnostic.json
+          if ! git -C status diff --cached --quiet; then
+            git -C status commit -m 'Record configured production readiness diagnostic'
+            git -C status push origin HEAD:staging-review
+          fi
+
+      - name: Write production readiness summary
+        if: always()
+        run: |
+          node <<'NODE'
+          const { appendFileSync, existsSync, readFileSync } = require('node:fs');
+          if (!existsSync('production-readiness-diagnostic.json')) process.exit(0);
+          const receipt = JSON.parse(readFileSync('production-readiness-diagnostic.json', 'utf8'));
+          appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            [
+              '## Configured production readiness diagnostic',
+              '',
+              `- Decision: \`${receipt.decision}\``,
+              `- Commit: \`${receipt.commit}\``,
+              `- Production mutation: \`${receipt.checks.productionMutation}\``,
+              `- Blockers: ${receipt.blockers.length === 0 ? 'none' : receipt.blockers.map((value) => `\`${value}\``).join(', ')}`,
+              '',
+            ].join('\n'),
+          );
+          NODE
+
+      - name: Enforce production readiness
+        if: always()
+        run: |
+          node -e "const r=require('./production-readiness-diagnostic.json'); if(r.decision!=='ready') process.exit(1)"
+
+  diagnose:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      needs.production_environment_probe.outputs.production_environment_status == 'present' &&
+      needs.production_environment_probe.outputs.production_environment_protection_count != '0'
+    needs: [contract, production_environment_probe]
+    environment: production
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
@@ -113,41 +275,11 @@ jobs:
           node scripts/check-ops-p6-013-production-readiness-diagnostic.mjs
           node scripts/run-ops-p6-013-production-readiness-diagnostic.mjs --self-test
 
-      - name: Inspect GitHub production environment read-only
-        id: production_environment
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          node --input-type=module <<'NODE'
-          import { appendFileSync } from 'node:fs';
-          const repository = process.env.GITHUB_REPOSITORY;
-          const token = process.env.GH_TOKEN;
-          const output = process.env.GITHUB_OUTPUT;
-          const response = await fetch(`https://api.github.com/repos/${repository}/environments/production`, {
-            method: 'GET',
-            headers: {
-              Accept: 'application/vnd.github+json',
-              Authorization: `Bearer ${token}`,
-              'X-GitHub-Api-Version': '2022-11-28',
-            },
-          });
-          let status = 'missing';
-          let protectionCount = 0;
-          if (response.status === 200) {
-            const payload = await response.json();
-            status = 'present';
-            protectionCount = Array.isArray(payload?.protection_rules) ? payload.protection_rules.length : 0;
-          }
-          appendFileSync(output, `production_environment_status=${status}\n`);
-          appendFileSync(output, `production_environment_protection_count=${protectionCount}\n`);
-          NODE
-
       - name: Execute read-only configured production readiness diagnostic
         env:
           REPOSITORY_CONTRACT_OUTCOME: ${{ steps.repository_contract.outcome }}
-          PRODUCTION_ENVIRONMENT_STATUS: ${{ steps.production_environment.outputs.production_environment_status }}
-          PRODUCTION_ENVIRONMENT_PROTECTION_COUNT: ${{ steps.production_environment.outputs.production_environment_protection_count }}
+          PRODUCTION_ENVIRONMENT_STATUS: ${{ needs.production_environment_probe.outputs.production_environment_status }}
+          PRODUCTION_ENVIRONMENT_PROTECTION_COUNT: ${{ needs.production_environment_probe.outputs.production_environment_protection_count }}
         working-directory: source
         run: |
           node scripts/run-ops-p6-013-production-readiness-diagnostic.mjs \

--- a/docs/OPS_P6_013_CONFIGURED_PRODUCTION_READINESS_DIAGNOSTIC.md
+++ b/docs/OPS_P6_013_CONFIGURED_PRODUCTION_READINESS_DIAGNOSTIC.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This slice adds the read-only production runtime readiness diagnostic required before any configured production authorization or go-live attempt under Issue #293 and the P6-08 contract.
+This slice provides the read-only production runtime readiness diagnostic required before any configured production authorization or go-live attempt under Issue #293 and the P6-08 contract.
 
 The diagnostic determines whether the production control-plane and runtime prerequisites are present for one exact current `main` commit. It does not authorize production and it does not execute production.
 
@@ -32,24 +32,34 @@ It must be distinct from the configured-staging project:
 
 Readiness cannot pass if the production project is missing or inaccessible.
 
-## GitHub production environment
+## GitHub production environment guard
 
-A GitHub `production` environment must already exist and must have at least one protection rule before readiness can pass.
+A GitHub `production` environment must already exist and must have at least one protection rule before protected readiness evaluation can run.
 
-The diagnostic deliberately does not reference `environment: production` in its workflow job because GitHub can create a missing environment implicitly. A missing production environment must remain an explicit blocker rather than being silently created by a diagnostic run.
+P6-013 uses two stages so the diagnostic never creates a missing environment merely by referring to it:
+
+1. an **unbound probe job** performs a GET-only inspection of the repository `production` environment and its protection-rule count. This job does not bind `environment: production`;
+2. only when that probe reports the environment as present with at least one protection rule does the **protected diagnostic job** run. That job binds `environment: production`, which is the only job allowed to read the production Environment secrets.
+
+If the environment is missing or unprotected, a separate blocked-environment diagnostic path records a bounded blocked readiness receipt without binding `environment: production`. It therefore cannot implicitly create the missing environment and cannot read the protected production Environment secrets.
+
+This preserves both requirements: missing/unprotected environment state remains an explicit fail-closed blocker, while correctly scoped Environment secrets become available once the guard has proven that the protected environment already exists.
 
 ## Production-specific runtime inputs
 
-The workflow checks only whether the following production-specific runtime inputs are non-empty:
+The protected diagnostic job checks whether the following production-specific runtime inputs are non-empty Environment secrets:
 
 - `P6_08_PRODUCTION_DATABASE_URL`;
 - `P6_08_PRODUCTION_REVIEW_SECRET_SEED_BASE64URL`;
 - `P6_08_PRODUCTION_TURNSTILE_SECRET_KEY`;
 - `P6_08_PRODUCTION_TURNSTILE_SITE_KEY`;
 - `P6_08_PRODUCTION_CF_ACCESS_TEAM_DOMAIN`;
-- `P6_08_PRODUCTION_CF_ACCESS_AUD`.
+- `P6_08_PRODUCTION_CF_ACCESS_AUD`;
+- `P6_08_PRODUCTION_CREDENTIAL_GENERATION_ID`.
 
-Their raw values are never written to the diagnostic receipt. Missing input names may be retained as bounded blockers.
+Their raw values are never written to the diagnostic receipt. Missing input names may be retained as bounded blockers. The production values belong in the protected GitHub `production` Environment rather than being duplicated into repository-scoped secrets merely to make the diagnostic see them.
+
+The blocked-environment path does not inspect those protected values. Because the environment gate has already failed, readiness remains blocked before any protected runtime evaluation can become authoritative.
 
 Staging/test Turnstile keys or staging-derived identities are not treated as production readiness.
 
@@ -91,7 +101,7 @@ Readiness fails closed on any of the following:
 - stale, failed, or wrong-commit P6-05 evidence;
 - missing GitHub `production` environment;
 - missing production-environment protection rule;
-- missing production-specific runtime input;
+- missing production-specific runtime input once protected evaluation is allowed;
 - production/staging Pages-project collision;
 - missing or inaccessible production Pages project;
 - missing or ambiguous Cloudflare zone;
@@ -99,11 +109,13 @@ Readiness fails closed on any of the following:
 - candidate Pages release marker missing or not matching the P6-05 candidate release;
 - production Admin `/admin/` not enforcing unauthenticated 403 with the required security headers.
 
+A blocked result is evidence of a failed readiness condition, not authorization to provision or mutate anything outside the separately authorized operational step.
+
 ## Next boundary
 
 A `ready` diagnostic is not authorization. Production still requires the separate explicit configured-production authorization gate and, after that, a separately bounded go-live execution that revalidates all evidence immediately before mutation.
 
-Parent: #293. Implementation: #415.
+Parent: #293. Original implementation: #415. Protected Environment secret-scope correction: #440.
 
 ## Production credential generation binding
 

--- a/scripts/check-ops-p6-013-production-readiness-diagnostic.mjs
+++ b/scripts/check-ops-p6-013-production-readiness-diagnostic.mjs
@@ -94,9 +94,7 @@ for (const secretName of [
   'p6_08_production_credential_generation_id',
 ]) {
   if (blockedSection.includes(`secrets.${secretName}`)) {
-    throw new Error(
-      `blocked-environment diagnostic must not read protected secret ${secretName}`,
-    );
+    throw new Error(`blocked-environment diagnostic must not read protected secret ${secretName}`);
   }
   if (!protectedSection.includes(`secrets.${secretName}`)) {
     throw new Error(`protected diagnostic missing Environment secret ${secretName}`);

--- a/scripts/check-ops-p6-013-production-readiness-diagnostic.mjs
+++ b/scripts/check-ops-p6-013-production-readiness-diagnostic.mjs
@@ -46,8 +46,11 @@ expectIncludes('runner', files.runner, [
 expectIncludes('workflow', files.workflow, [
   'workflow_dispatch',
   'diagnose_configured_production_readiness',
+  'production_environment_probe:',
+  'inspect github production environment read-only before any environment binding',
+  'diagnose_blocked_environment:',
+  'environment: production',
   'verify exact current main',
-  'inspect github production environment read-only',
   "node --input-type=module <<'node'",
   "method: 'get'",
   'production_environment_status',
@@ -58,12 +61,52 @@ expectIncludes('workflow', files.workflow, [
   'contents: write',
 ]);
 
+const probeStart = files.workflow.indexOf('\n  production_environment_probe:');
+const blockedStart = files.workflow.indexOf('\n  diagnose_blocked_environment:');
+const protectedStart = files.workflow.indexOf('\n  diagnose:\n');
+if (!(probeStart >= 0 && blockedStart > probeStart && protectedStart > blockedStart)) {
+  throw new Error('workflow job ordering does not preserve probe -> blocked/protected diagnostic boundary');
+}
+const probeSection = files.workflow.slice(probeStart, blockedStart);
+const blockedSection = files.workflow.slice(blockedStart, protectedStart);
+const protectedSection = files.workflow.slice(protectedStart);
+if (probeSection.includes('environment: production')) {
+  throw new Error('production environment probe must not bind environment: production');
+}
+if (blockedSection.includes('environment: production')) {
+  throw new Error('blocked-environment diagnostic must not bind environment: production');
+}
+if (!protectedSection.includes('environment: production')) {
+  throw new Error('protected diagnostic must bind environment: production');
+}
+for (const secretName of [
+  'p6_08_production_database_url',
+  'p6_08_production_review_secret_seed_base64url',
+  'p6_08_production_turnstile_secret_key',
+  'p6_08_production_turnstile_site_key',
+  'p6_08_production_cf_access_team_domain',
+  'p6_08_production_cf_access_aud',
+  'p6_08_production_credential_generation_id',
+]) {
+  if (blockedSection.includes(`secrets.${secretName}`)) {
+    throw new Error(`blocked-environment diagnostic must not read protected secret ${secretName}`);
+  }
+  if (!protectedSection.includes(`secrets.${secretName}`)) {
+    throw new Error(`protected diagnostic missing Environment secret ${secretName}`);
+  }
+}
+
 expectIncludes('documentation', files.doc, [
   'read-only',
   '`cryptopaymap-production`',
   '`cryptopaymap-staging`',
   'github `production` environment',
   'protection rule',
+  'unbound probe job',
+  'does not bind `environment: production`',
+  'protected diagnostic job',
+  'binds `environment: production`',
+  'environment secrets',
   'p6-05 candidate release',
   'production-specific runtime inputs',
   'cloudflare access',

--- a/scripts/check-ops-p6-013-production-readiness-diagnostic.mjs
+++ b/scripts/check-ops-p6-013-production-readiness-diagnostic.mjs
@@ -17,7 +17,9 @@ const files = {
 
 function expectIncludes(label, content, markers) {
   const missing = markers.filter((marker) => !content.includes(marker.toLowerCase()));
-  if (missing.length > 0) throw new Error(`${label} missing markers:\n- ${missing.join('\n- ')}`);
+  if (missing.length > 0) {
+    throw new Error(`${label} missing markers:\n- ${missing.join('\n- ')}`);
+  }
 }
 
 expectIncludes('runner', files.runner, [
@@ -58,6 +60,7 @@ expectIncludes('workflow', files.workflow, [
   'production-readiness-diagnostic.json',
   'config/production-authorization/readiness-diagnostic.json',
   "if(r.decision!=='ready')",
+  'actions: read',
   'contents: write',
 ]);
 
@@ -65,7 +68,9 @@ const probeStart = files.workflow.indexOf('\n  production_environment_probe:');
 const blockedStart = files.workflow.indexOf('\n  diagnose_blocked_environment:');
 const protectedStart = files.workflow.indexOf('\n  diagnose:\n');
 if (!(probeStart >= 0 && blockedStart > probeStart && protectedStart > blockedStart)) {
-  throw new Error('workflow job ordering does not preserve probe -> blocked/protected diagnostic boundary');
+  throw new Error(
+    'workflow job ordering does not preserve probe -> blocked/protected diagnostic boundary',
+  );
 }
 const probeSection = files.workflow.slice(probeStart, blockedStart);
 const blockedSection = files.workflow.slice(blockedStart, protectedStart);
@@ -89,7 +94,9 @@ for (const secretName of [
   'p6_08_production_credential_generation_id',
 ]) {
   if (blockedSection.includes(`secrets.${secretName}`)) {
-    throw new Error(`blocked-environment diagnostic must not read protected secret ${secretName}`);
+    throw new Error(
+      `blocked-environment diagnostic must not read protected secret ${secretName}`,
+    );
   }
   if (!protectedSection.includes(`secrets.${secretName}`)) {
     throw new Error(`protected diagnostic missing Environment secret ${secretName}`);


### PR DESCRIPTION
Closes #440.

Fixes the P6-013 secret-scope contradiction before configured-production provisioning continues.

Changes:
- add an unbound GET-only `production_environment_probe` job so a missing GitHub `production` Environment remains an explicit blocker and is not implicitly created by the diagnostic;
- preserve a fail-closed blocked diagnostic path when the Environment is missing or has zero protection rules, without binding that path to production or exposing production Environment secrets;
- bind the actual protected readiness job to `environment: production` only after the probe proves the Environment already exists and is protected;
- keep all seven `P6_08_PRODUCTION_*` values scoped to the protected job;
- harden the contract checker against Environment binding or secret-scope regressions;
- document the split probe/protected-evaluation contract.

Safety boundary:
- no GitHub production Environment is created by this PR;
- no production secret value is added or read by this PR;
- no Pages project, custom domain, DNS, Neon, R2, canonical data, cache, or live service is mutated;
- P6-013 remains a read-only readiness diagnostic and does not authorize P6-012 or P6-016.

After merge, exact-main configured staging evidence must be refreshed because `main` changes before production provisioning resumes.