### PR TITLE
OPS: run P6-013 read-only production readiness on 9745aad

### DIFF
--- a/.github/workflows/one-time-p6-013-readonly-9745aad.yml
+++ b/.github/workflows/one-time-p6-013-readonly-9745aad.yml
@@ -1,0 +1,64 @@
+name: One-time P6-013 readonly diagnostic 9745aad
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/one-time-p6-013-readonly-9745aad.yml'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  execute:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      APPROVED_COMMIT: 9745aada90ad3ad2c230588b1caa803146e1f109
+    steps:
+      - name: Dispatch exact-main read-only P6-013 and observe completion
+        shell: bash
+        run: |
+          set -euo pipefail
+          current="$(gh api "repos/$REPO/commits/main" --jq .sha)"
+          test "$current" = "$APPROVED_COMMIT"
+
+          wf='ops-p6-013-configured-production-readiness-diagnostic.yml'
+          before="$(gh run list --repo "$REPO" --workflow "$wf" --branch main --event workflow_dispatch --limit 20 --json databaseId,headSha,createdAt --jq "map(select(.headSha == \"$APPROVED_COMMIT\")) | sort_by(.createdAt) | last | .databaseId // empty" 2>/dev/null || true)"
+          dispatched=false
+          for attempt in $(seq 1 12); do
+            if gh workflow run "$wf" --repo "$REPO" --ref main \
+              -f confirmation=DIAGNOSE_CONFIGURED_PRODUCTION_READINESS \
+              -f approved_commit="$APPROVED_COMMIT" \
+              -f readiness_owner=badjoke-lab; then
+              dispatched=true
+              break
+            fi
+            echo "dispatch_retry:$attempt" >&2
+            sleep 5
+          done
+          test "$dispatched" = true
+
+          id=''
+          for _ in $(seq 1 120); do
+            sleep 5
+            id="$(gh run list --repo "$REPO" --workflow "$wf" --branch main --event workflow_dispatch --limit 20 --json databaseId,headSha,createdAt --jq "map(select(.headSha == \"$APPROVED_COMMIT\")) | sort_by(.createdAt) | last | .databaseId // empty" 2>/dev/null || true)"
+            [ -n "$id" ] && [ "$id" != "$before" ] && break
+          done
+          [ -n "$id" ] && [ "$id" != "$before" ]
+          echo "p6_013_run_id=$id"
+
+          for _ in $(seq 1 720); do
+            status="$(gh api "repos/$REPO/actions/runs/$id" --jq .status 2>/dev/null || true)"
+            if [ "$status" = completed ]; then
+              conclusion="$(gh api "repos/$REPO/actions/runs/$id" --jq .conclusion 2>/dev/null || true)"
+              echo "p6_013_conclusion=$conclusion"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "p6_013_timeout:$id" >&2
+          exit 1


### PR DESCRIPTION
One-time dispatcher pinned to exact main `9745aada90ad3ad2c230588b1caa803146e1f109`.

Dispatches only OPS-P6-013 configured production readiness diagnostic. It does not dispatch P6-012/P6-014/P6-016/P6-017 and does not authorize or mutate production. The P6-013 workflow first probes the GitHub `production` Environment without environment binding; if it is missing or unprotected it records the fail-closed read-only diagnostic rather than auto-creating it.

**DO NOT MERGE. Close unmerged after the diagnostic is captured.**