### PR TITLE
OPS: arm exact-main staging refresh after installation

### DIFF
--- a/.github/workflows/ops-p6-exact-main-configured-staging-refresh.yml
+++ b/.github/workflows/ops-p6-exact-main-configured-staging-refresh.yml
@@ -1,3 +1,4 @@
+# Installed on main before relying on push-triggered refreshes.
 name: OPS-P6 exact-main configured staging refresh
 
 on:


### PR DESCRIPTION
The exact-main staging orchestrator is now already present on the default branch. This one-line follow-up push arms and verifies the durable `on: push` path without changing its execution or safety boundaries.