### PR TITLE
OPS: trigger exact-main refresh now (do not merge)

### DIFF
--- a/docs/.ops-exact-main-refresh-trigger.md
+++ b/docs/.ops-exact-main-refresh-trigger.md
@@ -1,0 +1,1 @@
+Temporary same-repository pull-request trigger for the exact-main configured-staging refresh. Do not merge.


### PR DESCRIPTION
Execution-only same-repository pull-request trigger for the exact-main configured-staging refresh. This PR must not be merged; close it after the orchestrator run is observed.