### PR TITLE
OPS: fix exact-main refresh repository context

### DIFF
--- a/.github/workflows/ops-p6-001c-configured-staging-authorization.yml
+++ b/.github/workflows/ops-p6-001c-configured-staging-authorization.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Refresh P6-01 through P6-05 for exact main
         if: steps.freshness.outputs.needs_refresh == 'true'
         shell: bash
+        working-directory: source
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Fix the scheduled exact-main configured-staging refresh so GitHub CLI commands execute from the checked-out `source/` repository. The previous scheduler correctly detected stale P6-01..05 evidence but failed before dispatching P6-01 with `failed to determine base repo: fatal: not a git repository`. This is a one-line execution-context fix only; production Environment, production Pages, DNS, production DB/R2, and cutover remain untouched.