### PR TITLE
OPS: trigger exact-main refresh 66a935 (do not merge)

### DIFF
--- a/docs/.ops-exact-main-refresh-trigger.md
+++ b/docs/.ops-exact-main-refresh-trigger.md
@@ -1,0 +1,3 @@
+Execution-only trigger for exact-main configured-staging refresh on `66a93517452c1b426025d4f8a92b6b12409b2e13`.
+
+Do not merge. Close after the orchestrator starts.


### PR DESCRIPTION
Execution-only same-repository PR used to trigger the bounded exact-main configured-staging refresh for current main `66a93517452c1b426025d4f8a92b6b12409b2e13`. Do not merge. Close after the refresh orchestrator starts.