### PR TITLE
OPS: event-drive exact-main staging refresh

### DIFF
--- a/.github/workflows/ops-p6-001c-configured-staging-authorization.yml
+++ b/.github/workflows/ops-p6-001c-configured-staging-authorization.yml
@@ -60,6 +60,10 @@ jobs:
   refresh_exact_main:
     if: >-
       github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.name == 'P5-02R fixed review live audit' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main') ||
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.head_ref, 'ops/trigger-exact-main-refresh'))

--- a/.github/workflows/p5-02r-fixed-review-live-audit.yml
+++ b/.github/workflows/p5-02r-fixed-review-live-audit.yml
@@ -16,8 +16,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      contains(github.event.workflow_run.head_commit.message, '[run-p5-02r-audit]'))
+      github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-24.04
     steps:
       - name: Check out audited main commit


### PR DESCRIPTION
Replace normal schedule waiting with an event-driven configured-staging chain. Every successful main staging-review deployment now runs the bounded P5-02R fixed-review live audit. A successful P5-02R run then activates the existing exact-main refresher, which validates the current deployment/audit and runs P6-01 through P6-05 sequentially as needed. The 15-minute scheduler remains only as a self-healing fallback. No production Environment approval, production Pages, DNS, production DB/R2, or cutover is introduced.