### PR TITLE
FIX-P2-002: add Candidate acquisition and review-readiness foundation

### DIFF
--- a/src/importers/osm-overpass-candidate-acquisition.ts
+++ b/src/importers/osm-overpass-candidate-acquisition.ts
@@ -1,0 +1,257 @@
+import type {
+  NewCandidateSourceRecord,
+  NewImportBatch,
+  NewSourceCandidate,
+  NewSourceRecord,
+} from '../db/schema';
+import type { CryptoPayMapDatabase } from '../db/client';
+import {
+  createDrizzleCandidateIngestionPersistenceBackend,
+  type CandidateIngestionPersistencePlan,
+  type CandidateIngestionReceipt,
+} from './candidate-ingestion-persistence';
+
+export interface OsmOverpassElement {
+  type: 'node' | 'way' | 'relation';
+  id: number;
+  lat?: number;
+  lon?: number;
+  center?: { lat: number; lon: number };
+  tags?: Record<string, string>;
+}
+
+export interface OsmOverpassCandidateAcquisitionInput {
+  requestId: string;
+  importBatchId: string;
+  sourceId: string;
+  licenseId: string | null;
+  fetchedAt: Date;
+  importerVersion: string;
+  elements: readonly OsmOverpassElement[];
+}
+
+export interface OsmOverpassCandidateAcquisitionResult {
+  plan: CandidateIngestionPersistencePlan;
+  rejected: Array<{
+    externalId: string;
+    reason: 'missing_name' | 'missing_coordinates' | 'invalid_coordinates';
+  }>;
+}
+
+const MAX_ELEMENTS = 10_000;
+
+function normalizeName(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLocaleLowerCase('en-US')
+    .replace(/&/g, ' and ')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function elementCoordinates(element: OsmOverpassElement): { latitude: number; longitude: number } | null {
+  if (typeof element.lat === 'number' && typeof element.lon === 'number') {
+    return { latitude: element.lat, longitude: element.lon };
+  }
+  if (element.center) {
+    return { latitude: element.center.lat, longitude: element.center.lon };
+  }
+  return null;
+}
+
+function validCoordinates(coordinates: { latitude: number; longitude: number }): boolean {
+  return (
+    Number.isFinite(coordinates.latitude) &&
+    Number.isFinite(coordinates.longitude) &&
+    coordinates.latitude >= -90 &&
+    coordinates.latitude <= 90 &&
+    coordinates.longitude >= -180 &&
+    coordinates.longitude <= 180
+  );
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)]),
+    );
+  }
+  return value;
+}
+
+async function sha256(value: unknown): Promise<string> {
+  const serialized = JSON.stringify(canonicalize(value));
+  const digest = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(serialized),
+  );
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function deterministicUuid(label: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(label));
+  const bytes = new Uint8Array(digest).slice(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x80;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function candidatePriority(tags: Record<string, string>): number {
+  let priority = 100;
+  if (tags.website || tags['contact:website']) priority += 250;
+  if (Object.keys(tags).some((key) => key.startsWith('payment:'))) priority += 250;
+  if (tags.phone || tags['contact:phone']) priority += 100;
+  if (tags['addr:street'] || tags['addr:city']) priority += 100;
+  return Math.min(priority, 1_000);
+}
+
+function rejectionSummary(
+  rejected: OsmOverpassCandidateAcquisitionResult['rejected'],
+): Record<string, number> {
+  return rejected.reduce<Record<string, number>>((summary, item) => {
+    summary[item.reason] = (summary[item.reason] ?? 0) + 1;
+    return summary;
+  }, {});
+}
+
+export async function createOsmOverpassCandidateAcquisitionPlan(
+  input: OsmOverpassCandidateAcquisitionInput,
+): Promise<OsmOverpassCandidateAcquisitionResult> {
+  if (input.elements.length === 0 || input.elements.length > MAX_ELEMENTS) {
+    throw new Error(`OSM Overpass acquisition requires 1-${MAX_ELEMENTS} elements per batch.`);
+  }
+
+  const sourceRecords: NewSourceRecord[] = [];
+  const candidates: NewSourceCandidate[] = [];
+  const candidateSourceRecords: NewCandidateSourceRecord[] = [];
+  const rejected: OsmOverpassCandidateAcquisitionResult['rejected'] = [];
+
+  for (const element of input.elements) {
+    const externalId = `${element.type}:${element.id}`;
+    const name = element.tags?.name?.trim() ?? '';
+    if (!name) {
+      rejected.push({ externalId, reason: 'missing_name' });
+      continue;
+    }
+
+    const coordinates = elementCoordinates(element);
+    if (coordinates === null) {
+      rejected.push({ externalId, reason: 'missing_coordinates' });
+      continue;
+    }
+    if (!validCoordinates(coordinates)) {
+      rejected.push({ externalId, reason: 'invalid_coordinates' });
+      continue;
+    }
+
+    const tags = element.tags ?? {};
+    const contentHash = await sha256(element);
+    const sourceRecordId = await deterministicUuid(
+      `source-record:${input.sourceId}:osm:${externalId}:${contentHash}`,
+    );
+    const candidateId = await deterministicUuid(`candidate:osm:${externalId}`);
+    const sourceUrl = `https://www.openstreetmap.org/${element.type}/${element.id}`;
+
+    sourceRecords.push({
+      id: sourceRecordId,
+      sourceId: input.sourceId,
+      externalId,
+      sourceUrl,
+      rawPayload: {
+        sourceSystem: 'openstreetmap_overpass',
+        importerVersion: input.importerVersion,
+        licenseId: input.licenseId,
+        element,
+        reviewSeed: {
+          name,
+          latitude: coordinates.latitude,
+          longitude: coordinates.longitude,
+          websiteUrl: tags.website ?? tags['contact:website'] ?? null,
+          phone: tags.phone ?? tags['contact:phone'] ?? null,
+          paymentTags: Object.fromEntries(
+            Object.entries(tags).filter(([key]) => key.startsWith('payment:')),
+          ),
+        },
+      },
+      observedAt: input.fetchedAt,
+      publishedAt: null,
+      fetchedAt: input.fetchedAt,
+      contentHash,
+      archiveUrl: null,
+      licenseId: input.licenseId,
+    });
+
+    candidates.push({
+      id: candidateId,
+      candidateType: 'physical_place',
+      normalizedName: normalizeName(name),
+      candidateStatus: 'new',
+      priority: candidatePriority(tags),
+      duplicateGroupId: null,
+      firstSeenAt: input.fetchedAt,
+      lastSeenAt: input.fetchedAt,
+      importBatchId: input.importBatchId,
+      canonicalEntityId: null,
+      canonicalLocationId: null,
+    });
+
+    candidateSourceRecords.push({
+      candidateId,
+      sourceRecordId,
+      relationship: 'origin',
+    });
+  }
+
+  const inputChecksum = await sha256({
+    sourceId: input.sourceId,
+    importerVersion: input.importerVersion,
+    elements: input.elements,
+  });
+
+  const batch: NewImportBatch = {
+    id: input.importBatchId,
+    requestId: input.requestId,
+    actorId: 'osm-overpass-adapter',
+    actorType: 'system',
+    sourceId: input.sourceId,
+    importKind: 'physical_place',
+    sourceSchemaVersion: 'osm-overpass-v1',
+    importerVersion: input.importerVersion,
+    inputChecksum,
+    inputCount: input.elements.length,
+    acceptedCount: candidates.length,
+    rejectedCount: rejected.length,
+    replayedCount: 0,
+    outOfScopeCount: 0,
+    duplicateSignalCount: 0,
+    automaticConfirmedCount: 0,
+    rejectionSummary: rejectionSummary(rejected),
+    startedAt: input.fetchedAt,
+    completedAt: input.fetchedAt,
+  };
+
+  return {
+    plan: {
+      batch,
+      sourceRecords,
+      candidates,
+      candidateSourceRecords,
+      duplicateGroups: [],
+      duplicateSignals: [],
+    },
+    rejected,
+  };
+}
+
+export async function persistOsmOverpassCandidateAcquisition(
+  database: CryptoPayMapDatabase,
+  input: OsmOverpassCandidateAcquisitionInput,
+): Promise<CandidateIngestionReceipt> {
+  const { plan } = await createOsmOverpassCandidateAcquisitionPlan(input);
+  return createDrizzleCandidateIngestionPersistenceBackend(database).commit(plan);
+}

--- a/src/importers/osm-overpass-candidate-acquisition.ts
+++ b/src/importers/osm-overpass-candidate-acquisition.ts
@@ -50,7 +50,9 @@ function normalizeName(value: string): string {
     .replace(/\s+/g, ' ');
 }
 
-function elementCoordinates(element: OsmOverpassElement): { latitude: number; longitude: number } | null {
+function elementCoordinates(
+  element: OsmOverpassElement,
+): { latitude: number; longitude: number } | null {
   if (typeof element.lat === 'number' && typeof element.lon === 'number') {
     return { latitude: element.lat, longitude: element.lon };
   }

--- a/src/review/candidate-evidence-enrichment.ts
+++ b/src/review/candidate-evidence-enrichment.ts
@@ -1,0 +1,110 @@
+import {
+  evidenceClassValues,
+  evidenceKindValues,
+  evidencePolarityValues,
+  evidenceSourceTypeValues,
+} from '../db/schema/evidence';
+
+export interface CandidateEvidenceEnrichmentInput {
+  candidateId: string;
+  sourceUrl: string;
+  sourceName: string | null;
+  evidenceKind: (typeof evidenceKindValues)[number];
+  evidenceClass: (typeof evidenceClassValues)[number];
+  sourceType: (typeof evidenceSourceTypeValues)[number];
+  polarity: (typeof evidencePolarityValues)[number];
+  observedAt: Date | null;
+  paymentMethod: string | null;
+  network: string | null;
+  howToPay: string | null;
+  summary: string;
+}
+
+export interface CandidateEvidenceEnrichmentResult {
+  candidateId: string;
+  sourceUrl: string;
+  sourceName: string | null;
+  evidenceKind: CandidateEvidenceEnrichmentInput['evidenceKind'];
+  evidenceClass: CandidateEvidenceEnrichmentInput['evidenceClass'];
+  sourceType: CandidateEvidenceEnrichmentInput['sourceType'];
+  polarity: CandidateEvidenceEnrichmentInput['polarity'];
+  observedAt: Date | null;
+  paymentMethod: string | null;
+  network: string | null;
+  howToPay: string | null;
+  summary: string;
+  freshness: 'current' | 'stale' | 'unknown';
+  paymentDetailCompleteness: 'complete' | 'partial' | 'missing';
+  reviewFlags: string[];
+  eligibleForAutomaticConfirmation: false;
+}
+
+const STALE_AFTER_DAYS = 180;
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+function normalizedHttpUrl(value: string): string {
+  const url = new URL(value);
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('Evidence URLs must use HTTP or HTTPS.');
+  }
+  url.hash = '';
+  return url.toString();
+}
+
+function freshness(observedAt: Date | null, referenceTime: Date): CandidateEvidenceEnrichmentResult['freshness'] {
+  if (observedAt === null) return 'unknown';
+  if (!Number.isFinite(observedAt.getTime())) throw new Error('Evidence observedAt must be a valid date.');
+  const ageMs = referenceTime.getTime() - observedAt.getTime();
+  return ageMs > STALE_AFTER_DAYS * DAY_MS ? 'stale' : 'current';
+}
+
+function detailCompleteness(
+  input: CandidateEvidenceEnrichmentInput,
+): CandidateEvidenceEnrichmentResult['paymentDetailCompleteness'] {
+  const details = [input.paymentMethod, input.network, input.howToPay].filter(
+    (value) => value !== null && value.trim().length > 0,
+  ).length;
+  if (details === 3) return 'complete';
+  if (details === 0) return 'missing';
+  return 'partial';
+}
+
+export function enrichCandidateEvidence(
+  input: CandidateEvidenceEnrichmentInput,
+  referenceTime = new Date(),
+): CandidateEvidenceEnrichmentResult {
+  if (input.summary.trim().length === 0) throw new Error('Evidence summary is required.');
+  const sourceUrl = normalizedHttpUrl(input.sourceUrl);
+  const evidenceFreshness = freshness(input.observedAt, referenceTime);
+  const paymentDetailCompleteness = detailCompleteness(input);
+  const reviewFlags: string[] = [];
+
+  if (input.evidenceClass === 'c') reviewFlags.push('weak_evidence_only');
+  if (input.sourceType === 'directory' || input.sourceType === 'openstreetmap') {
+    reviewFlags.push('external_seed_requires_independent_evidence');
+  }
+  if (input.sourceType === 'search') reviewFlags.push('search_result_not_confirmation_evidence');
+  if (evidenceFreshness === 'stale') reviewFlags.push('stale_evidence');
+  if (evidenceFreshness === 'unknown') reviewFlags.push('unknown_observation_date');
+  if (input.polarity === 'contradicting') reviewFlags.push('conflicting_evidence');
+  if (paymentDetailCompleteness !== 'complete') reviewFlags.push('payment_details_incomplete');
+
+  return {
+    candidateId: input.candidateId,
+    sourceUrl,
+    sourceName: input.sourceName,
+    evidenceKind: input.evidenceKind,
+    evidenceClass: input.evidenceClass,
+    sourceType: input.sourceType,
+    polarity: input.polarity,
+    observedAt: input.observedAt,
+    paymentMethod: input.paymentMethod,
+    network: input.network,
+    howToPay: input.howToPay,
+    summary: input.summary.trim(),
+    freshness: evidenceFreshness,
+    paymentDetailCompleteness,
+    reviewFlags,
+    eligibleForAutomaticConfirmation: false,
+  };
+}

--- a/src/review/candidate-evidence-enrichment.ts
+++ b/src/review/candidate-evidence-enrichment.ts
@@ -51,9 +51,13 @@ function normalizedHttpUrl(value: string): string {
   return url.toString();
 }
 
-function freshness(observedAt: Date | null, referenceTime: Date): CandidateEvidenceEnrichmentResult['freshness'] {
+function freshness(
+  observedAt: Date | null,
+  referenceTime: Date,
+): CandidateEvidenceEnrichmentResult['freshness'] {
   if (observedAt === null) return 'unknown';
-  if (!Number.isFinite(observedAt.getTime())) throw new Error('Evidence observedAt must be a valid date.');
+  if (!Number.isFinite(observedAt.getTime()))
+    throw new Error('Evidence observedAt must be a valid date.');
   const ageMs = referenceTime.getTime() - observedAt.getTime();
   return ageMs > STALE_AFTER_DAYS * DAY_MS ? 'stale' : 'current';
 }

--- a/src/review/candidate-review-readiness.ts
+++ b/src/review/candidate-review-readiness.ts
@@ -1,0 +1,129 @@
+export interface CandidateEvidenceSignal {
+  evidenceClass: 'a' | 'b' | 'c';
+  sourceType:
+    | 'official_page'
+    | 'official_social'
+    | 'processor'
+    | 'openstreetmap'
+    | 'directory'
+    | 'article'
+    | 'search'
+    | 'user_submission'
+    | 'business_representative'
+    | 'live_observation'
+    | 'payment_proof'
+    | 'other';
+  polarity: 'supporting' | 'contradicting' | 'neutral';
+  observedAt: Date | null;
+}
+
+export interface CandidateReviewReadinessInput {
+  hasLocationMatch: boolean;
+  duplicateRisk: 'none' | 'review' | 'strong';
+  evidence: readonly CandidateEvidenceSignal[];
+  hasAsset: boolean;
+  hasNetwork: boolean;
+  hasRouteType: boolean;
+  hasPaymentMethod: boolean;
+  hasHowToPay: boolean;
+}
+
+export interface CandidateReviewReadinessResult {
+  score: number;
+  tier: 'ready' | 'promising' | 'needs_enrichment' | 'blocked';
+  reasons: string[];
+  blockers: string[];
+  automaticConfirmedCount: 0;
+}
+
+export function scoreCandidateReviewReadiness(
+  input: CandidateReviewReadinessInput,
+): CandidateReviewReadinessResult {
+  let score = 0;
+  const reasons: string[] = [];
+  const blockers: string[] = [];
+
+  const supporting = input.evidence.filter((item) => item.polarity === 'supporting');
+  const contradicting = input.evidence.filter((item) => item.polarity === 'contradicting');
+  const hasStrongOfficialEvidence = supporting.some(
+    (item) => item.evidenceClass === 'a' && item.sourceType === 'official_page',
+  );
+  const hasStrongEvidence = supporting.some((item) => item.evidenceClass === 'a');
+  const supportingBCount = supporting.filter((item) => item.evidenceClass === 'b').length;
+
+  if (hasStrongOfficialEvidence) {
+    score += 35;
+    reasons.push('strong official evidence');
+  } else if (hasStrongEvidence) {
+    score += 30;
+    reasons.push('strong evidence');
+  } else if (supportingBCount >= 2) {
+    score += 20;
+    reasons.push('multiple medium-strength evidence signals');
+  } else if (supporting.length > 0) {
+    score += 8;
+    reasons.push('supporting evidence exists');
+  } else {
+    blockers.push('no supporting evidence');
+  }
+
+  if (input.hasLocationMatch) {
+    score += 15;
+    reasons.push('location matched');
+  } else {
+    blockers.push('location not matched');
+  }
+
+  if (input.duplicateRisk === 'none') {
+    score += 10;
+    reasons.push('low duplicate risk');
+  } else if (input.duplicateRisk === 'review') {
+    score += 3;
+    reasons.push('duplicate review required');
+  } else {
+    blockers.push('strong duplicate signal');
+  }
+
+  const paymentCompleteness = [
+    input.hasAsset,
+    input.hasNetwork,
+    input.hasRouteType,
+    input.hasPaymentMethod,
+    input.hasHowToPay,
+  ].filter(Boolean).length;
+  score += paymentCompleteness * 8;
+
+  if (input.hasAsset) reasons.push('asset identified');
+  else blockers.push('asset missing');
+  if (input.hasNetwork) reasons.push('network identified');
+  else blockers.push('network missing');
+  if (input.hasRouteType) reasons.push('route type identified');
+  else blockers.push('route type missing');
+  if (input.hasPaymentMethod) reasons.push('payment method identified');
+  else blockers.push('payment method missing');
+  if (input.hasHowToPay) reasons.push('How to pay available');
+  else blockers.push('How to pay missing');
+
+  if (contradicting.length > 0) {
+    score = Math.max(0, score - 20);
+    blockers.push('conflicting evidence requires review');
+  }
+
+  const boundedScore = Math.min(100, score);
+  const tier =
+    input.duplicateRisk === 'strong' || contradicting.length > 0
+      ? 'blocked'
+      : boundedScore >= 80 && blockers.length === 0
+        ? 'ready'
+        : boundedScore >= 55
+          ? 'promising'
+          : 'needs_enrichment';
+
+  return {
+    score: boundedScore,
+    tier,
+    reasons,
+    blockers,
+    automaticConfirmedCount: 0,
+  };
+}

--- a/tests/candidate-evidence-enrichment.test.ts
+++ b/tests/candidate-evidence-enrichment.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { enrichCandidateEvidence } from '../src/review/candidate-evidence-enrichment';
+
+const referenceTime = new Date('2026-08-28T00:00:00.000Z');
+
+describe('Candidate evidence enrichment', () => {
+  it('marks official current evidence with complete payment details as review-ready input only', () => {
+    const result = enrichCandidateEvidence(
+      {
+        candidateId: '00000000-0000-4000-8000-000000000201',
+        sourceUrl: 'https://merchant.example/payments#crypto',
+        sourceName: 'Merchant payments',
+        evidenceKind: 'official_payment_page',
+        evidenceClass: 'a',
+        sourceType: 'official_page',
+        polarity: 'supporting',
+        observedAt: new Date('2026-08-27T00:00:00.000Z'),
+        paymentMethod: 'wallet_qr',
+        network: 'bitcoin',
+        howToPay: 'Ask staff for the payment QR and scan it with a Bitcoin wallet.',
+        summary: 'Official payment page describes direct Bitcoin payment.',
+      },
+      referenceTime,
+    );
+
+    expect(result.sourceUrl).toBe('https://merchant.example/payments');
+    expect(result.freshness).toBe('current');
+    expect(result.paymentDetailCompleteness).toBe('complete');
+    expect(result.reviewFlags).toEqual([]);
+    expect(result.eligibleForAutomaticConfirmation).toBe(false);
+  });
+
+  it('flags OSM and directory evidence as seed material requiring independent evidence', () => {
+    const result = enrichCandidateEvidence(
+      {
+        candidateId: '00000000-0000-4000-8000-000000000202',
+        sourceUrl: 'https://www.openstreetmap.org/node/1',
+        sourceName: 'OpenStreetMap',
+        evidenceKind: 'undated_osm_tag',
+        evidenceClass: 'c',
+        sourceType: 'openstreetmap',
+        polarity: 'supporting',
+        observedAt: null,
+        paymentMethod: null,
+        network: null,
+        howToPay: null,
+        summary: 'OSM payment tag indicates possible crypto acceptance.',
+      },
+      referenceTime,
+    );
+
+    expect(result.freshness).toBe('unknown');
+    expect(result.paymentDetailCompleteness).toBe('missing');
+    expect(result.reviewFlags).toContain('weak_evidence_only');
+    expect(result.reviewFlags).toContain('external_seed_requires_independent_evidence');
+    expect(result.reviewFlags).toContain('payment_details_incomplete');
+    expect(result.eligibleForAutomaticConfirmation).toBe(false);
+  });
+
+  it('surfaces stale contradictory evidence as a blocking review signal', () => {
+    const result = enrichCandidateEvidence(
+      {
+        candidateId: '00000000-0000-4000-8000-000000000203',
+        sourceUrl: 'https://merchant.example/help',
+        sourceName: 'Merchant help',
+        evidenceKind: 'official_payment_page',
+        evidenceClass: 'a',
+        sourceType: 'official_page',
+        polarity: 'contradicting',
+        observedAt: new Date('2025-01-01T00:00:00.000Z'),
+        paymentMethod: null,
+        network: null,
+        howToPay: null,
+        summary: 'Official page says crypto payments are no longer available.',
+      },
+      referenceTime,
+    );
+
+    expect(result.freshness).toBe('stale');
+    expect(result.reviewFlags).toContain('stale_evidence');
+    expect(result.reviewFlags).toContain('conflicting_evidence');
+    expect(result.eligibleForAutomaticConfirmation).toBe(false);
+  });
+});

--- a/tests/candidate-review-readiness.test.ts
+++ b/tests/candidate-review-readiness.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { scoreCandidateReviewReadiness } from '../src/review/candidate-review-readiness';
+
+describe('Candidate review-readiness scoring', () => {
+  it('prioritizes complete evidence-rich Candidates without auto-confirming them', () => {
+    const result = scoreCandidateReviewReadiness({
+      hasLocationMatch: true,
+      duplicateRisk: 'none',
+      evidence: [
+        {
+          evidenceClass: 'a',
+          sourceType: 'official_page',
+          polarity: 'supporting',
+          observedAt: new Date('2026-08-28T00:00:00.000Z'),
+        },
+      ],
+      hasAsset: true,
+      hasNetwork: true,
+      hasRouteType: true,
+      hasPaymentMethod: true,
+      hasHowToPay: true,
+    });
+
+    expect(result.tier).toBe('ready');
+    expect(result.score).toBe(100);
+    expect(result.blockers).toEqual([]);
+    expect(result.automaticConfirmedCount).toBe(0);
+  });
+
+  it('keeps directory-only incomplete Candidates in enrichment', () => {
+    const result = scoreCandidateReviewReadiness({
+      hasLocationMatch: true,
+      duplicateRisk: 'review',
+      evidence: [
+        {
+          evidenceClass: 'c',
+          sourceType: 'directory',
+          polarity: 'supporting',
+          observedAt: null,
+        },
+      ],
+      hasAsset: true,
+      hasNetwork: false,
+      hasRouteType: false,
+      hasPaymentMethod: false,
+      hasHowToPay: false,
+    });
+
+    expect(result.tier).toBe('needs_enrichment');
+    expect(result.blockers).toContain('network missing');
+    expect(result.blockers).toContain('How to pay missing');
+    expect(result.automaticConfirmedCount).toBe(0);
+  });
+
+  it('blocks high-scoring Candidates when conflicting evidence exists', () => {
+    const result = scoreCandidateReviewReadiness({
+      hasLocationMatch: true,
+      duplicateRisk: 'none',
+      evidence: [
+        {
+          evidenceClass: 'a',
+          sourceType: 'official_page',
+          polarity: 'supporting',
+          observedAt: new Date('2026-08-28T00:00:00.000Z'),
+        },
+        {
+          evidenceClass: 'a',
+          sourceType: 'official_page',
+          polarity: 'contradicting',
+          observedAt: new Date('2026-08-28T00:30:00.000Z'),
+        },
+      ],
+      hasAsset: true,
+      hasNetwork: true,
+      hasRouteType: true,
+      hasPaymentMethod: true,
+      hasHowToPay: true,
+    });
+
+    expect(result.tier).toBe('blocked');
+    expect(result.blockers).toContain('conflicting evidence requires review');
+    expect(result.automaticConfirmedCount).toBe(0);
+  });
+});

--- a/tests/osm-overpass-candidate-acquisition.test.ts
+++ b/tests/osm-overpass-candidate-acquisition.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { createOsmOverpassCandidateAcquisitionPlan } from '../src/importers/osm-overpass-candidate-acquisition';
+
+const IDS = {
+  requestId: '00000000-0000-4000-8000-000000000101',
+  importBatchId: '00000000-0000-4000-8000-000000000102',
+  sourceId: '00000000-0000-4000-8000-000000000103',
+  licenseId: '00000000-0000-4000-8000-000000000104',
+};
+
+const fetchedAt = new Date('2026-08-28T01:00:00.000Z');
+
+describe('OSM Overpass Candidate acquisition', () => {
+  it('creates Candidate-only persistence rows with provenance and no automatic confirmation', async () => {
+    const result = await createOsmOverpassCandidateAcquisitionPlan({
+      ...IDS,
+      fetchedAt,
+      importerVersion: '1.0.0',
+      elements: [
+        {
+          type: 'node',
+          id: 123,
+          lat: 35.6812,
+          lon: 139.7671,
+          tags: {
+            name: 'Example Cafe',
+            website: 'https://example.test/',
+            'payment:bitcoin': 'yes',
+          },
+        },
+      ],
+    });
+
+    expect(result.rejected).toEqual([]);
+    expect(result.plan.batch.acceptedCount).toBe(1);
+    expect(result.plan.batch.automaticConfirmedCount).toBe(0);
+    expect(result.plan.candidates[0]?.candidateStatus).toBe('new');
+    expect(result.plan.candidates[0]?.canonicalEntityId).toBeNull();
+    expect(result.plan.candidates[0]?.canonicalLocationId).toBeNull();
+    expect(result.plan.sourceRecords[0]?.sourceUrl).toBe(
+      'https://www.openstreetmap.org/node/123',
+    );
+    expect(result.plan.sourceRecords[0]?.licenseId).toBe(IDS.licenseId);
+    expect(result.plan.candidateSourceRecords).toHaveLength(1);
+  });
+
+  it('rejects thin or invalid rows instead of inventing publishable data', async () => {
+    const result = await createOsmOverpassCandidateAcquisitionPlan({
+      ...IDS,
+      fetchedAt,
+      importerVersion: '1.0.0',
+      elements: [
+        { type: 'node', id: 1, lat: 35, lon: 139, tags: {} },
+        { type: 'way', id: 2, tags: { name: 'No coordinates' } },
+        { type: 'node', id: 3, lat: 200, lon: 139, tags: { name: 'Bad coordinates' } },
+      ],
+    });
+
+    expect(result.plan.batch.acceptedCount).toBe(0);
+    expect(result.plan.batch.rejectedCount).toBe(3);
+    expect(result.plan.batch.automaticConfirmedCount).toBe(0);
+    expect(result.rejected.map((item) => item.reason)).toEqual([
+      'missing_name',
+      'missing_coordinates',
+      'invalid_coordinates',
+    ]);
+  });
+});

--- a/tests/osm-overpass-candidate-acquisition.test.ts
+++ b/tests/osm-overpass-candidate-acquisition.test.ts
@@ -37,9 +37,7 @@ describe('OSM Overpass Candidate acquisition', () => {
     expect(result.plan.candidates[0]?.candidateStatus).toBe('new');
     expect(result.plan.candidates[0]?.canonicalEntityId).toBeNull();
     expect(result.plan.candidates[0]?.canonicalLocationId).toBeNull();
-    expect(result.plan.sourceRecords[0]?.sourceUrl).toBe(
-      'https://www.openstreetmap.org/node/123',
-    );
+    expect(result.plan.sourceRecords[0]?.sourceUrl).toBe('https://www.openstreetmap.org/node/123');
     expect(result.plan.sourceRecords[0]?.licenseId).toBe(IDS.licenseId);
     expect(result.plan.candidateSourceRecords).toHaveLength(1);
   });


### PR DESCRIPTION
## FIX-P2-002

Builds the next bounded real-data readiness layer on top of #464 without changing the Confirmed publication boundary.

### Scope
- adds an OSM/Overpass payload adapter for batches up to 10,000 elements
- converts accepted rows into `new` physical-place Candidates only
- preserves source URL, raw source payload, content hash, source/license/import metadata, and Candidate/source provenance
- persists through the FIX-P2-001 Candidate-ingestion backend
- rejects missing-name, missing-coordinate, and invalid-coordinate rows instead of inventing publishable data
- adds Candidate evidence enrichment for evidence class/source/polarity, freshness, payment-detail completeness, stale/unknown/conflict flags
- adds review-readiness scoring using Evidence, location match, duplicate risk, asset/network/route/payment method, and How to pay completeness
- keeps automatic confirmation explicitly disabled (`automaticConfirmedCount = 0` / `eligibleForAutomaticConfirmation = false`)
- adds unit tests for acquisition, evidence enrichment, and review prioritization safety boundaries

### Explicitly not included
- no automatic Confirmed promotion
- no production DB mutation, deployment, DNS, or Phase 6 execution
- no runtime bulk dataset committed to the repository
- no scheduler or unbounded external crawl
- no claim/canonical writes from OSM, directories, search results, or scoring alone
- no assertion that OSM or directory evidence is sufficient for Confirmed

### Follow-on work
- durable evidence-enrichment persistence and queue integration
- cross-batch duplicate grouping/signals against existing Candidates
- bounded external-fetch orchestration and source-specific adapters
- review queue projection/sorting for large Candidate sets

Public and private boundaries remain unchanged: external directories seed research Candidates; human/rule review remains required before canonical/Confirmed publication.