### PR TITLE
FIX-P2-003: reconcile repeat-source Candidate acquisition

### DIFF
--- a/src/importers/candidate-acquisition-reconciliation.ts
+++ b/src/importers/candidate-acquisition-reconciliation.ts
@@ -104,7 +104,9 @@ export function reconcileCandidateAcquisition(
   incoming: readonly AcquisitionSeedSnapshot[],
   existing: readonly ExistingCandidateSnapshot[],
 ): AcquisitionReconciliationPlan {
-  const existingBySourceIdentity = new Map(existing.map((item) => [sourceIdentity(item), item]));
+  const existingBySourceIdentity = new Map(
+    existing.map((item) => [sourceIdentity(item), item]),
+  );
   const newSeeds: AcquisitionSeedSnapshot[] = [];
   const unchangedSeeds: AcquisitionReconciliationPlan['unchangedSeeds'] = [];
   const changedSeeds: AcquisitionReconciliationPlan['changedSeeds'] = [];

--- a/src/importers/candidate-acquisition-reconciliation.ts
+++ b/src/importers/candidate-acquisition-reconciliation.ts
@@ -44,10 +44,7 @@ function orderedPair(left: string, right: string): [string, string] {
   return left < right ? [left, right] : [right, left];
 }
 
-function sameCoordinates(
-  left: AcquisitionSeedSnapshot,
-  right: AcquisitionSeedSnapshot,
-): boolean {
+function sameCoordinates(left: AcquisitionSeedSnapshot, right: AcquisitionSeedSnapshot): boolean {
   return (
     left.latitude !== null &&
     left.longitude !== null &&

--- a/src/importers/candidate-acquisition-reconciliation.ts
+++ b/src/importers/candidate-acquisition-reconciliation.ts
@@ -1,0 +1,149 @@
+export interface AcquisitionSeedSnapshot {
+  candidateId: string;
+  sourceId: string;
+  externalId: string;
+  contentHash: string;
+  normalizedName: string;
+  latitude: number | null;
+  longitude: number | null;
+  officialDomain: string | null;
+}
+
+export interface ExistingCandidateSnapshot extends AcquisitionSeedSnapshot {
+  candidateStatus: string;
+}
+
+export interface AcquisitionReconciliationPlan {
+  newSeeds: AcquisitionSeedSnapshot[];
+  unchangedSeeds: Array<{
+    incoming: AcquisitionSeedSnapshot;
+    existing: ExistingCandidateSnapshot;
+  }>;
+  changedSeeds: Array<{
+    incoming: AcquisitionSeedSnapshot;
+    existing: ExistingCandidateSnapshot;
+  }>;
+  duplicateSignals: Array<{
+    leftCandidateId: string;
+    rightCandidateId: string;
+    reason:
+      | 'shared_osm_identity'
+      | 'same_name_and_coordinates'
+      | 'shared_official_domain'
+      | 'same_normalized_name';
+    strength: 'strong' | 'review';
+  }>;
+  automaticConfirmedCount: 0;
+}
+
+function sourceIdentity(seed: AcquisitionSeedSnapshot): string {
+  return `${seed.sourceId}\u0000${seed.externalId}`;
+}
+
+function orderedPair(left: string, right: string): [string, string] {
+  return left < right ? [left, right] : [right, left];
+}
+
+function sameCoordinates(
+  left: AcquisitionSeedSnapshot,
+  right: AcquisitionSeedSnapshot,
+): boolean {
+  return (
+    left.latitude !== null &&
+    left.longitude !== null &&
+    right.latitude !== null &&
+    right.longitude !== null &&
+    Math.abs(left.latitude - right.latitude) <= 0.0001 &&
+    Math.abs(left.longitude - right.longitude) <= 0.0001
+  );
+}
+
+function duplicateSignal(
+  left: AcquisitionSeedSnapshot,
+  right: AcquisitionSeedSnapshot,
+): AcquisitionReconciliationPlan['duplicateSignals'][number] | null {
+  const [leftCandidateId, rightCandidateId] = orderedPair(left.candidateId, right.candidateId);
+
+  if (sourceIdentity(left) === sourceIdentity(right)) {
+    return {
+      leftCandidateId,
+      rightCandidateId,
+      reason: 'shared_osm_identity',
+      strength: 'strong',
+    };
+  }
+  if (left.normalizedName === right.normalizedName && sameCoordinates(left, right)) {
+    return {
+      leftCandidateId,
+      rightCandidateId,
+      reason: 'same_name_and_coordinates',
+      strength: 'strong',
+    };
+  }
+  if (
+    left.officialDomain !== null &&
+    right.officialDomain !== null &&
+    left.officialDomain === right.officialDomain
+  ) {
+    return {
+      leftCandidateId,
+      rightCandidateId,
+      reason: 'shared_official_domain',
+      strength: 'review',
+    };
+  }
+  if (left.normalizedName === right.normalizedName) {
+    return {
+      leftCandidateId,
+      rightCandidateId,
+      reason: 'same_normalized_name',
+      strength: 'review',
+    };
+  }
+  return null;
+}
+
+export function reconcileCandidateAcquisition(
+  incoming: readonly AcquisitionSeedSnapshot[],
+  existing: readonly ExistingCandidateSnapshot[],
+): AcquisitionReconciliationPlan {
+  const existingBySourceIdentity = new Map(existing.map((item) => [sourceIdentity(item), item]));
+  const newSeeds: AcquisitionSeedSnapshot[] = [];
+  const unchangedSeeds: AcquisitionReconciliationPlan['unchangedSeeds'] = [];
+  const changedSeeds: AcquisitionReconciliationPlan['changedSeeds'] = [];
+
+  for (const seed of incoming) {
+    const matched = existingBySourceIdentity.get(sourceIdentity(seed));
+    if (matched === undefined) {
+      newSeeds.push(seed);
+    } else if (matched.contentHash === seed.contentHash) {
+      unchangedSeeds.push({ incoming: seed, existing: matched });
+    } else {
+      changedSeeds.push({ incoming: seed, existing: matched });
+    }
+  }
+
+  const duplicateSignals: AcquisitionReconciliationPlan['duplicateSignals'] = [];
+  const seenSignals = new Set<string>();
+  const comparisonPool: AcquisitionSeedSnapshot[] = [...existing, ...newSeeds];
+
+  for (const seed of newSeeds) {
+    for (const other of comparisonPool) {
+      if (seed.candidateId === other.candidateId) continue;
+      const signal = duplicateSignal(seed, other);
+      if (signal === null) continue;
+      const key = `${signal.leftCandidateId}:${signal.rightCandidateId}:${signal.reason}`;
+      if (seenSignals.has(key)) continue;
+      seenSignals.add(key);
+      duplicateSignals.push(signal);
+    }
+  }
+
+  return {
+    newSeeds,
+    unchangedSeeds,
+    changedSeeds,
+    duplicateSignals,
+    automaticConfirmedCount: 0,
+  };
+}

--- a/tests/candidate-acquisition-reconciliation.test.ts
+++ b/tests/candidate-acquisition-reconciliation.test.ts
@@ -1,27 +1,28 @@
 import { describe, expect, it } from 'vitest';
-import { reconcileCandidateAcquisition } from '../src/importers/candidate-acquisition-reconciliation';
+import {
+  reconcileCandidateAcquisition,
+  type ExistingCandidateSnapshot,
+} from '../src/importers/candidate-acquisition-reconciliation';
 
-const existing = [
-  {
-    candidateId: '00000000-0000-4000-8000-000000000301',
-    sourceId: '00000000-0000-4000-8000-000000000311',
-    externalId: 'node:100',
-    contentHash: 'hash-old',
-    normalizedName: 'example cafe',
-    latitude: 35.6812,
-    longitude: 139.7671,
-    officialDomain: 'example.test',
-    candidateStatus: 'new',
-  },
-];
+const existingCandidate: ExistingCandidateSnapshot = {
+  candidateId: '00000000-0000-4000-8000-000000000301',
+  sourceId: '00000000-0000-4000-8000-000000000311',
+  externalId: 'node:100',
+  contentHash: 'hash-old',
+  normalizedName: 'example cafe',
+  latitude: 35.6812,
+  longitude: 139.7671,
+  officialDomain: 'example.test',
+  candidateStatus: 'new',
+};
+const existing: ExistingCandidateSnapshot[] = [existingCandidate];
 
 describe('Candidate acquisition reconciliation', () => {
   it('classifies exact repeated source data as unchanged instead of a new Candidate', () => {
     const result = reconcileCandidateAcquisition(
       [
         {
-          ...existing[0],
-          candidateId: existing[0].candidateId,
+          ...existingCandidate,
           contentHash: 'hash-old',
         },
       ],
@@ -38,8 +39,7 @@ describe('Candidate acquisition reconciliation', () => {
     const result = reconcileCandidateAcquisition(
       [
         {
-          ...existing[0],
-          candidateId: existing[0].candidateId,
+          ...existingCandidate,
           contentHash: 'hash-new',
         },
       ],

--- a/tests/candidate-acquisition-reconciliation.test.ts
+++ b/tests/candidate-acquisition-reconciliation.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { reconcileCandidateAcquisition } from '../src/importers/candidate-acquisition-reconciliation';
+
+const existing = [
+  {
+    candidateId: '00000000-0000-4000-8000-000000000301',
+    sourceId: '00000000-0000-4000-8000-000000000311',
+    externalId: 'node:100',
+    contentHash: 'hash-old',
+    normalizedName: 'example cafe',
+    latitude: 35.6812,
+    longitude: 139.7671,
+    officialDomain: 'example.test',
+    candidateStatus: 'new',
+  },
+];
+
+describe('Candidate acquisition reconciliation', () => {
+  it('classifies exact repeated source data as unchanged instead of a new Candidate', () => {
+    const result = reconcileCandidateAcquisition(
+      [
+        {
+          ...existing[0],
+          candidateId: existing[0].candidateId,
+          contentHash: 'hash-old',
+        },
+      ],
+      existing,
+    );
+
+    expect(result.newSeeds).toHaveLength(0);
+    expect(result.unchangedSeeds).toHaveLength(1);
+    expect(result.changedSeeds).toHaveLength(0);
+    expect(result.automaticConfirmedCount).toBe(0);
+  });
+
+  it('classifies changed content for the same external source identity as refresh work', () => {
+    const result = reconcileCandidateAcquisition(
+      [
+        {
+          ...existing[0],
+          candidateId: existing[0].candidateId,
+          contentHash: 'hash-new',
+        },
+      ],
+      existing,
+    );
+
+    expect(result.newSeeds).toHaveLength(0);
+    expect(result.unchangedSeeds).toHaveLength(0);
+    expect(result.changedSeeds).toHaveLength(1);
+    expect(result.changedSeeds[0]?.existing.contentHash).toBe('hash-old');
+    expect(result.changedSeeds[0]?.incoming.contentHash).toBe('hash-new');
+    expect(result.automaticConfirmedCount).toBe(0);
+  });
+
+  it('emits a strong duplicate signal for a new cross-source Candidate at the same named location', () => {
+    const result = reconcileCandidateAcquisition(
+      [
+        {
+          candidateId: '00000000-0000-4000-8000-000000000302',
+          sourceId: '00000000-0000-4000-8000-000000000312',
+          externalId: 'merchant:42',
+          contentHash: 'hash-directory',
+          normalizedName: 'example cafe',
+          latitude: 35.68121,
+          longitude: 139.76709,
+          officialDomain: 'example.test',
+        },
+      ],
+      existing,
+    );
+
+    expect(result.newSeeds).toHaveLength(1);
+    expect(result.duplicateSignals).toEqual([
+      {
+        leftCandidateId: '00000000-0000-4000-8000-000000000301',
+        rightCandidateId: '00000000-0000-4000-8000-000000000302',
+        reason: 'same_name_and_coordinates',
+        strength: 'strong',
+      },
+    ]);
+    expect(result.automaticConfirmedCount).toBe(0);
+  });
+
+  it('uses official-domain and normalized-name matches only as review signals', () => {
+    const domainResult = reconcileCandidateAcquisition(
+      [
+        {
+          candidateId: '00000000-0000-4000-8000-000000000303',
+          sourceId: '00000000-0000-4000-8000-000000000313',
+          externalId: 'merchant:43',
+          contentHash: 'hash-domain',
+          normalizedName: 'example cafe east',
+          latitude: 36,
+          longitude: 140,
+          officialDomain: 'example.test',
+        },
+      ],
+      existing,
+    );
+    expect(domainResult.duplicateSignals[0]?.reason).toBe('shared_official_domain');
+    expect(domainResult.duplicateSignals[0]?.strength).toBe('review');
+
+    const nameResult = reconcileCandidateAcquisition(
+      [
+        {
+          candidateId: '00000000-0000-4000-8000-000000000304',
+          sourceId: '00000000-0000-4000-8000-000000000314',
+          externalId: 'merchant:44',
+          contentHash: 'hash-name',
+          normalizedName: 'example cafe',
+          latitude: 34,
+          longitude: 135,
+          officialDomain: null,
+        },
+      ],
+      existing,
+    );
+    expect(nameResult.duplicateSignals[0]?.reason).toBe('same_normalized_name');
+    expect(nameResult.duplicateSignals[0]?.strength).toBe('review');
+  });
+});


### PR DESCRIPTION
## Summary

- classify repeat acquisition as unchanged, changed, or new before Candidate creation
- emit strong duplicate signals for shared source identity and same-name/same-coordinate matches
- emit review-only signals for shared official domains and normalized-name matches
- keep automatic Confirmed promotion at zero
- add focused reconciliation tests

## Boundary

This is a pure reconciliation-planning slice. It does not mutate production, promote Candidates to canonical/Confirmed, or perform production deployment/DNS changes. DB-backed reconciliation/persistence is the follow-up slice.

## Validation

GitHub Actions is the source of truth for format, lint, typecheck, tests, build, migrations, and retained audit checks.